### PR TITLE
Add administrator tag to guest user fixture to fix flaky spec.

### DIFF
--- a/test/list_users_command_test.exs
+++ b/test/list_users_command_test.exs
@@ -33,7 +33,7 @@ defmodule ListUsersCommandTest do
     end)
 
     std_result = [
-      [{:user,@guest},{:tags,[]}],
+      [{:user,@guest},{:tags,[:administrator]}],
       [{:user,@user},{:tags,[]}]
     ]
 


### PR DESCRIPTION
Fixes https://github.com/rabbitmq/rabbitmq-cli/issues/21.
