### PR TITLE
Re-parse the command on bad option in standard messages

### DIFF
--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -87,14 +87,18 @@ defmodule RabbitMQCtl do
     result
   end
 
-  defp print_standard_messages({:too_many_args, _} = result, [cmd | _] = unparsed_command) do
+  defp print_standard_messages({:too_many_args, _} = result, unparsed_command) do
+    {[cmd | _], _} = parse(unparsed_command)
+
     IO.puts "Error: too many arguments."
     IO.puts "Given:\n\t#{unparsed_command |> Enum.join(" ")}"
     IO.puts "Usage:\n#{cmd |> command_usage |> format_usage}"
     result
   end
 
-  defp print_standard_messages({:not_enough_args, _} = result, [cmd | _] = unparsed_command) do
+  defp print_standard_messages({:not_enough_args, _} = result, unparsed_command) do
+    {[cmd | _], _} = parse(unparsed_command)
+
     IO.puts "Error: not enough arguments."
     IO.puts "Given:\n\t#{unparsed_command |> Enum.join(" ")}"
     IO.puts "Usage:\n#{cmd |> command_usage |> format_usage}"

--- a/test/rabbitmqctl_test.exs
+++ b/test/rabbitmqctl_test.exs
@@ -110,6 +110,23 @@ defmodule RabbitMQCtlTest do
     capture_io(fn -> error_check(command, exit_software) end)
   end
 
+  test "A malformed command with an option as the first command-line arg fails gracefully" do
+    command1 = ["--invalid=true", "list_permissions", "-p", "/"]
+    assert capture_io(fn ->
+      error_check(command1, exit_usage)
+    end) =~ ~r/Error: invalid options for this command/
+
+    command2 = ["--node", "rabbit", "status", "quack"]
+    assert capture_io(fn ->
+      error_check(command2, exit_usage)
+    end) =~ ~r/Error: too many arguments./
+
+    command3 = ["--node", "rabbit", "add_user", "quack"]
+    assert capture_io(fn ->
+      error_check(command3, exit_usage)
+    end) =~ ~r/Error: not enough arguments./
+  end
+
 ## ------------------------- Default Flags ------------------------------------
 
   test "an empty node option is filled with the default rabbit node" do
@@ -143,11 +160,6 @@ defmodule RabbitMQCtlTest do
     command2 = ["list_permissions", "-o", "/"]
     assert capture_io(fn ->
       error_check(command2, exit_usage)
-    end) =~ ~r/Error: invalid options for this command/
-
-    command3 = ["--invalid=true", "list_permissions", "-p", "/"]
-    assert capture_io(fn ->
-      error_check(command3, exit_usage)
     end) =~ ~r/Error: invalid options for this command/
   end
 end


### PR DESCRIPTION
Addresses [issue #25](https://github.com/rabbitmq/rabbitmq-cli/issues/25)
