### PR TITLE
Initial implementations of cluster_status and report command

### DIFF
--- a/lib/cluster_status_command.ex
+++ b/lib/cluster_status_command.ex
@@ -1,0 +1,48 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule ClusterStatusCommand do
+  @behaviour CommandBehaviour
+  @flags []
+
+  def run([_|_] = args, _) when length(args) != 0, do: {:too_many_args, args}
+  def run([], %{node: node_name} = opts) do
+    info(opts)
+    target_node =
+      node_name
+      |> Helpers.parse_node
+    status = :rabbit_misc.rpc_call(target_node, :rabbit_mnesia, :status, [])
+    case :rabbit_misc.rpc_call(target_node, :rabbit_mnesia, :cluster_nodes, [:running]) do
+      {:badrpc, _} = err ->
+        err
+      nodes ->
+        alarms_by_node = Enum.map(nodes, &alarms_by_node/1)
+        status ++ [{:alarms, alarms_by_node}]
+    end
+  end
+
+  def usage, do: "cluster_status"
+
+  def flags, do: @flags
+
+  defp alarms_by_node(node) do
+    status = :rabbit_misc.rpc_call(node, :rabbit, :status, [])
+    {node, List.keyfind(status, :alarms, 1, [])}
+  end
+
+  defp info(%{quiet: true}), do: nil
+  defp info(%{node: node_name}), do: IO.puts "Cluster status of node #{node_name} ..."
+end

--- a/lib/report_command.ex
+++ b/lib/report_command.ex
@@ -1,0 +1,57 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule ReportCommand do
+  @behaviour CommandBehaviour
+  @flags []
+
+  def run([_|_] = args, _) when length(args) != 0, do: {:too_many_args, args}
+  def run([], %{node: node_name} = opts) do
+    info(opts)
+    node_name =
+      node_name
+      |> Helpers.parse_node
+    case :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :list, []) do
+      {:badrpc, _} = err ->
+        err
+      vhosts ->
+        data =
+          [ StatusCommand.run([], opts),
+            ClusterStatusCommand.run([], opts),
+            EnvironmentCommand.run([], opts),
+            ListConnectionsCommand.run([], opts),
+            ListChannelsCommand.run([], opts) ]
+
+        vhost_data =
+            vhosts
+            |> Enum.flat_map(fn v ->
+              opts = Map.put(opts, :vhost, v)
+              [ ListQueuesCommand.run([], opts),
+                ListExchangesCommand.run([], opts),
+                ListBindingsCommand.run([], opts),
+                ListPermissionsCommand.run([], opts) ]
+            end)
+        data ++ vhost_data
+    end
+  end
+
+  def usage, do: "report"
+
+  def flags, do: @flags
+
+  defp info(%{quiet: true}), do: nil
+  defp info(%{node: node_name}), do: IO.puts "Reporting server status of node #{node_name} ..."
+end

--- a/test/cluster_status_command_test.exs
+++ b/test/cluster_status_command_test.exs
@@ -1,0 +1,74 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule ClusterStatusCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+  import ExUnit.CaptureIO
+
+  setup_all do
+    :net_kernel.start([:rabbitmqctl, :shortnames])
+    :net_kernel.connect_node(get_rabbit_hostname)
+
+    on_exit([], fn ->
+      :erlang.disconnect_node(get_rabbit_hostname)
+      :net_kernel.stop()
+    end)
+
+    :ok
+  end
+
+  setup do
+    {:ok, opts: %{node: get_rabbit_hostname}}
+  end
+
+  test "with extra arguments, status returns an arg count error", context do
+    capture_io(fn ->
+      assert ClusterStatusCommand.run(["extra"], context[:opts]) ==
+      {:too_many_args, ["extra"]}
+    end)
+  end
+
+  test "status request on a named, active RMQ node is successful", context do
+    capture_io(fn ->
+      assert ClusterStatusCommand.run([], context[:opts])[:nodes] != nil
+    end)
+  end
+
+  test "status request on nonexistent RabbitMQ node returns nodedown" do
+    target = :jake@thedog
+    :net_kernel.connect_node(target)
+    opts = %{node: target}
+
+    capture_io(fn ->
+      assert ClusterStatusCommand.run([], opts) != nil
+    end)
+  end
+
+  test "by default, status request prints an info message", context do
+    assert capture_io(fn ->
+      ClusterStatusCommand.run([], context[:opts])
+    end) =~ ~r/Cluster status of node #{get_rabbit_hostname}/
+  end
+
+  test "the quiet flag suppresses the info message", context do
+    opts = Map.merge(context[:opts], %{quiet: true})
+
+    refute capture_io(fn ->
+      ClusterStatusCommand.run([], opts)
+    end) =~ ~r/Cluster status of node #{get_rabbit_hostname}/
+  end
+end

--- a/test/report_test.exs
+++ b/test/report_test.exs
@@ -1,0 +1,66 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule ReportTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+  import ExUnit.CaptureIO
+
+  setup_all do
+    :net_kernel.start([:rabbitmqctl, :shortnames])
+    :net_kernel.connect_node(get_rabbit_hostname)
+
+    on_exit([], fn ->
+      :erlang.disconnect_node(get_rabbit_hostname)
+      :net_kernel.stop()
+    end)
+
+    :ok
+  end
+
+  setup do
+    {:ok, opts: %{node: get_rabbit_hostname, timeout: :infinity}}
+  end
+
+  test "with extra arguments, status returns an arg count error", context do
+    assert ReportCommand.run(["extra"], context[:opts]) ==
+    {:too_many_args, ["extra"]}
+  end
+
+  test "report request on a named, active RMQ node is successful", context do
+    assert match?([_|_], ReportCommand.run([], context[:opts]))
+  end
+
+  test "report request on nonexistent RabbitMQ node returns nodedown" do
+    target = :jake@thedog
+    :net_kernel.connect_node(target)
+    opts = %{node: target}
+    assert match?({:badrpc, _}, ReportCommand.run([], opts))
+  end
+
+  test "by default, report request prints an info message", context do
+    assert capture_io(fn ->
+      ReportCommand.run([], context[:opts])
+    end) =~ ~r/Reporting server status of node #{get_rabbit_hostname}/
+  end
+
+  test "the quiet flag suppresses the info message", context do
+    opts = Map.merge(context[:opts], %{quiet: true})
+    refute capture_io(fn ->
+      ReportCommand.run([], opts)
+    end) =~ ~r/Status of node #{get_rabbit_hostname}/
+  end
+end


### PR DESCRIPTION
Fixes #36.

The output of the run command is just a list of all the various sub commands included in the report. Because of the mix of IO and expressions in the run command, info gets printed first then all the data. This should be addressed by the upcoming command behaviour refactoring. 
