### PR TITLE
CSV formatter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
 PROJECT = rabbitmq_cli
 VERSION ?= 0.0.1
 
-BUILD_DEPS = rabbit_common amqp_client amqp json
+BUILD_DEPS = rabbit_common amqp_client amqp json csv
 
 dep_amqp = git https://github.com/pma/amqp.git master
 dep_json = hex 1.0.0
+dep_csv = hex 1.4.4
 
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 

--- a/lib/rabbitmq/cli/formatters/csv.ex
+++ b/lib/rabbitmq/cli/formatters/csv.ex
@@ -92,19 +92,33 @@ end
 
 defimpl CSV.Encode, for: PID do
   def encode(pid, env \\ []) do
-    :rabbit_misc.pid_to_string(pid) |> CSV.Encode.encode(env)
+    FormatterHelpers.format_info_item(pid)
+    |> to_string
+    |> CSV.Encode.encode(env)
   end
 end
 
 defimpl CSV.Encode, for: List do
-  def encode(list, env \\ [])
-  def encode([{key, type, _table_entry_value} | _] = value, env)
-  when is_binary(key) and is_atom(type) do
-    :io_lib.format("~1000000000000tp",
-                   [FormatterHelpers.prettify_amqp_table(value, true)])
+  def encode(list, env \\ []) do
+    FormatterHelpers.format_info_item(list)
+    |> to_string
     |> CSV.Encode.encode(env)
   end
-  def encode(list, env) do
-    to_string(list) |> CSV.Encode.encode(env)
+end
+
+defimpl CSV.Encode, for: Tuple do
+  def encode(tuple, env \\ []) do
+    FormatterHelpers.format_info_item(tuple)
+    |> to_string
+    |> CSV.Encode.encode(env)
   end
 end
+
+defimpl CSV.Encode, for: Map do
+  def encode(map, env \\ []) do
+    FormatterHelpers.format_info_item(map)
+    |> to_string
+    |> CSV.Encode.encode(env)
+  end
+end
+

--- a/lib/rabbitmq/cli/formatters/csv.ex
+++ b/lib/rabbitmq/cli/formatters/csv.ex
@@ -1,0 +1,110 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+
+alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
+
+defmodule RabbitMQ.CLI.Formatters.Csv do
+
+  @behaviour RabbitMQ.CLI.FormatterBehaviour
+
+  def format_stream(stream, _) do
+    ## Flatten list_consumers
+    Stream.flat_map(stream,
+                    fn({:error, msg}) ->
+                        [{:error, msg}];
+                      ([first | _] = element) ->
+                        case Keyword.keyword?(first) or is_map(first) do
+                          true  -> element;
+                          false -> [element]
+                        end
+                      (other) ->
+                        other
+                    end)
+    ## Add info_items names
+    |> Stream.transform(:init,
+                        fn
+                          ({:error, msg}, _) ->
+                            {:error, msg};
+                          (element, :init) ->
+                            {
+                              case keys(element) do
+                                nil -> [values(element)];
+                                ks  -> [ks, values(element)]
+                              end,
+                              :next
+                             };
+                          (element, :next) ->
+                            {[values(element)], :next}
+                          end)
+    |> CSV.encode([delimiter: ""])
+  end
+
+  def format_output(output, _) do
+    case keys(output) do
+      nil -> [values(output)];
+      ks  -> [ks, values(output)]
+    end
+    |> CSV.encode
+  end
+
+  def keys(map) when is_map(map) do
+    Map.keys(map)
+  end
+  def keys(list) when is_list(list) do
+    case Keyword.keyword?(list) do
+      true  -> Keyword.keys(list);
+      false -> nil
+    end
+  end
+  def keys(_other) do
+    nil
+  end
+
+  def values(map) when is_map(map) do
+    Map.values(map)
+  end
+  def values([]) do
+    []
+  end
+  def values(list) when is_list(list) do
+    case Keyword.keyword?(list) do
+      true  -> Keyword.values(list);
+      false -> list
+    end
+  end
+  def values(other) do
+    other
+  end
+
+end
+
+defimpl CSV.Encode, for: PID do
+  def encode(pid, env \\ []) do
+    :rabbit_misc.pid_to_string(pid) |> CSV.Encode.encode(env)
+  end
+end
+
+defimpl CSV.Encode, for: List do
+  def encode(list, env \\ [])
+  def encode([{key, type, _table_entry_value} | _] = value, env)
+  when is_binary(key) and is_atom(type) do
+    :io_lib.format("~1000000000000tp",
+                   [FormatterHelpers.prettify_amqp_table(value, true)])
+    |> CSV.Encode.encode(env)
+  end
+  def encode(list, env) do
+    to_string(list) |> CSV.Encode.encode(env)
+  end
+end

--- a/lib/rabbitmq/cli/formatters/formatter_helpers.ex
+++ b/lib/rabbitmq/cli/formatters/formatter_helpers.ex
@@ -1,0 +1,65 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Formatters.FormatterHelpers do
+  use Bitwise
+
+  def prettify_amqp_table(table, escaped) do
+    for {k, t, v} <- table do
+      {escape(k, escaped), prettify_typed_amqp_value(t, v, escaped)}
+    end
+  end
+
+  defp prettify_typed_amqp_value(:longstr, value, escaped) do
+    escape(value, escaped)
+  end
+  defp prettify_typed_amqp_value(:table, value, escaped) do
+    prettify_amqp_table(value, escaped)
+  end
+  defp prettify_typed_amqp_value(:array, value, escaped) do
+    for {t, v} <- value, do: prettify_typed_amqp_value(t, v, escaped)
+  end
+  defp prettify_typed_amqp_value(_type, value, _escaped) do
+    value
+  end
+
+
+  def escape(atom, escaped) when is_atom(atom) do
+    escape(to_charlist(atom), escaped)
+  end
+  def escape(bin, escaped)  when is_binary(bin) do
+    escape(to_charlist(bin), escaped)
+  end
+  def escape(l, false) when is_list(l) do
+    escape_char(:lists.reverse(l), [])
+  end
+  def escape(l, true) when is_list(l) do
+    l
+  end
+
+  defp escape_char([?\\ | t], acc) do
+    escape_char(t, [?\\, ?\\ | acc])
+  end
+  defp escape_char([x | t], acc) when x >= 32 and x != 127 do
+    escape_char(t, [x | acc])
+  end
+  defp escape_char([x | t], acc) do
+    escape_char(t, [?\\, ?0 + (x >>> 6), ?0 + (x &&& 0o070 >>> 3),
+                    ?0 + (x &&& 7) | acc])
+  end
+  defp escape_char([], acc) do
+    acc
+  end
+end

--- a/lib/rabbitmq/cli/formatters/formatter_helpers.ex
+++ b/lib/rabbitmq/cli/formatters/formatter_helpers.ex
@@ -14,9 +14,78 @@
 ## Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Formatters.FormatterHelpers do
+  import RabbitCommon.Records
   use Bitwise
 
-  def prettify_amqp_table(table, escaped) do
+  defmacro is_u8(x) do
+    quote do
+      (unquote(x) >= 0 and unquote(x) <= 255)
+    end
+  end
+
+  defmacro is_u16(x) do
+    quote do
+      (unquote(x) >= 0 and unquote(x) <= 65_535)
+    end
+  end
+
+  def format_info_item(item, escaped \\ true)
+  def format_info_item(map, escaped) when is_map(map) do
+    ["\#\{",
+     Enum.map(map,
+              fn({k, v}) ->
+                ["#{escape(k, escaped)} => ", format_info_item(v, escaped)]
+              end)
+     |> Enum.join(", "),
+     "}"]
+  end
+  def format_info_item(resource(name: name), escaped) do # when Record.is_record(res, :resource) do
+    #resource(name: name) = res
+    escape(name, escaped)
+  end
+  def format_info_item({n1, n2, n3, n4} = value, _escaped) when
+      is_u8(n1) and is_u8(n2) and is_u8(n3) and is_u8(n4) do
+    :rabbit_misc.ntoa(value)
+  end
+  def format_info_item({k1, k2, k3, k4, k5, k6, k7, k8} = value, _escaped) when
+      is_u16(k1) and is_u16(k2) and is_u16(k3) and is_u16(k4) and
+      is_u16(k5) and is_u16(k6) and is_u16(k7) and is_u16(k8) do
+    :rabbit_misc.ntoa(value)
+  end
+  def format_info_item(value, _escaped) when is_pid(value) do
+    :rabbit_misc.pid_to_string(value)
+  end
+  def format_info_item(value, escaped) when is_binary(value) do
+    escape(value, escaped)
+  end
+  def format_info_item(value, escaped) when is_atom(value) do
+    escape(to_charlist(value), escaped)
+  end
+  def format_info_item([{key, type, _table_entry_value} | _] =
+                          value, escaped) when is_binary(key) and
+                                               is_atom(type) do
+    :io_lib.format("~1000000000000tp",
+                   [prettify_amqp_table(value, escaped)])
+  end
+  def format_info_item([t | _] = value, escaped)
+  when is_tuple(t) or is_pid(t) or is_binary(t) or is_atom(t) or is_list(t) do
+    ["[",
+       Enum.map(value,
+                fn(el) ->
+                  format_info_item(el, escaped)
+                end)
+       |> Enum.join(", "),
+       "]"]
+  end
+  def format_info_item({key, value}, escaped) do
+    ["{" , :io_lib.format("~p", [key]), ", ",
+     format_info_item(value, escaped), "}"]
+  end
+  def format_info_item(value, _escaped) do
+    :io_lib.format("~1000000000000tp", [value])
+  end
+
+  defp prettify_amqp_table(table, escaped) do
     for {k, t, v} <- table do
       {escape(k, escaped), prettify_typed_amqp_value(t, v, escaped)}
     end
@@ -36,16 +105,16 @@ defmodule RabbitMQ.CLI.Formatters.FormatterHelpers do
   end
 
 
-  def escape(atom, escaped) when is_atom(atom) do
+  defp escape(atom, escaped) when is_atom(atom) do
     escape(to_charlist(atom), escaped)
   end
-  def escape(bin, escaped)  when is_binary(bin) do
+  defp escape(bin, escaped)  when is_binary(bin) do
     escape(to_charlist(bin), escaped)
   end
-  def escape(l, false) when is_list(l) do
+  defp escape(l, false) when is_list(l) do
     escape_char(:lists.reverse(l), [])
   end
-  def escape(l, true) when is_list(l) do
+  defp escape(l, true) when is_list(l) do
     l
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -119,6 +119,10 @@ defmodule RabbitMQCtl.MixfileBase do
       {
         :json, "~> 1.0.0",
         path: Path.join(deps_dir, "json")
+      },
+      {
+        :csv, "~> 1.4.2",
+        path: Path.join(deps_dir, "csv")
       }
     ]
   end

--- a/test/set_user_tags_command_test.exs
+++ b/test/set_user_tags_command_test.exs
@@ -53,10 +53,10 @@ defmodule SetUserTagsCommandTest do
     :net_kernel.connect_node(target)
     opts = %{node: target}
 
-    assert @command.run([@user, "imperator"], opts) == {:badrpc, :nodedown}
+    assert @command.run([@user, :imperator], opts) == {:badrpc, :nodedown}
   end
 
-  @tag user: @user, tags: ["imperator"]
+  @tag user: @user, tags: [:imperator]
   test "run: on a single optional argument, add a flag to the user", context  do
     @command.run(
       [context[:user] | context[:tags]],
@@ -71,7 +71,7 @@ defmodule SetUserTagsCommandTest do
     assert result[:tags] == context[:tags]
   end
 
-  @tag user: "interloper", tags: ["imperator"]
+  @tag user: "interloper", tags: [:imperator]
   test "run: on an invalid user, get a no such user error", context do
     assert @command.run(
       [context[:user] | context[:tags]],
@@ -79,7 +79,7 @@ defmodule SetUserTagsCommandTest do
     ) == {:error, {:no_such_user, context[:user]}}
   end
 
-  @tag user: @user, tags: ["imperator", "generalissimo"]
+  @tag user: @user, tags: [:imperator, :generalissimo]
   test "run: on multiple optional arguments, add all flags to the user", context  do
     @command.run(
       [context[:user] | context[:tags]],
@@ -94,7 +94,7 @@ defmodule SetUserTagsCommandTest do
     assert result[:tags] == context[:tags]
   end
 
-  @tag user: @user, tags: ["imperator"]
+  @tag user: @user, tags: [:imperator]
   test "run: with no optional arguments, clear user tags", context  do
 
     set_user_tags(context[:user], context[:tags])
@@ -109,7 +109,7 @@ defmodule SetUserTagsCommandTest do
     assert result[:tags] == []
   end
 
-  @tag user: @user, tags: ["imperator"]
+  @tag user: @user, tags: [:imperator]
   test "run: identical calls are idempotent", context  do
 
     set_user_tags(context[:user], context[:tags])
@@ -127,7 +127,7 @@ defmodule SetUserTagsCommandTest do
     assert result[:tags] == context[:tags]
   end
 
-  @tag user: @user, old_tags: ["imperator"], new_tags: ["generalissimo"]
+  @tag user: @user, old_tags: [:imperator], new_tags: [:generalissimo]
   test "run: if different tags exist, overwrite them", context  do
 
     set_user_tags(context[:user], context[:old_tags])


### PR DESCRIPTION
Fixes #115
Flattens `list_consumers`, outputs map keys as a first row. Info items are formatted the same way as with table formatter.