### PR TITLE
Copy CTL modules to /ebin to be included in ERL_LIBS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /deps
 /escript
 /.erlang.mk/
+/ebin
 erl_crash.dump
 mix.lock
 *.ez

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,12 @@ app:: $(ESCRIPTS)
 rabbitmqctl_srcs := mix.exs \
 		    $(shell find config lib -name "*.ex" -o -name "*.exs")
 
-escript/rabbitmqctl: $(rabbitmqctl_srcs)
+ebin: $(rabbitmqctl_srcs)
+	mix compile
+	mkdir -p ebin
+	cp -r _build/dev/lib/rabbitmqctl/ebin/* ebin
+
+escript/rabbitmqctl: ebin
 	mix escript.build
 
 escript/rabbitmq-plugins escript/rabbitmq-diagnostics: escript/rabbitmqctl
@@ -53,6 +58,7 @@ test:: all
 clean::
 	rm -f $(ESCRIPTS)
 	- mix local.hex --force
+	rm -rf ebin
 	mix clean
 
 repl:


### PR DESCRIPTION
When adding a command to a rabbitmq plugin, the build process requires `Elixir.RabbitMQ.CLI.CommandBehaviour` module to be available in `ERL_LIBS`.

To be included in `ERL_LIBS`, rabbitmqctl bytecode files should be located in `ebin` directory.