### PR TITLE
Make switches as aliases callbacks optional.

### DIFF
--- a/lib/rabbitmq/cli/auto_complete.ex
+++ b/lib/rabbitmq/cli/auto_complete.ex
@@ -24,7 +24,7 @@ defmodule Rabbitmq.CLI.AutoComplete do
     case List.last(tokens) do
       nil        -> [];
       last_token ->
-        {args, opts, _} = Parser.parse(tokens)
+        {args, opts, _} = Parser.parse_global(tokens)
         CommandModules.load(opts)
         variants = case args do
           []      -> complete_default_opts(last_token);

--- a/lib/rabbitmq/cli/command_behaviour.ex
+++ b/lib/rabbitmq/cli/command_behaviour.ex
@@ -20,8 +20,6 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
   @callback merge_defaults(List.t, Map.t) :: {List.t, Map.t}
   @callback banner(List.t, Map.t) :: String.t
   @callback run(List.t, Map.t) :: any
-  @callback switches() :: Keyword.t
-  @callback aliases() :: Keyword.t
   # Coerces run/2 return value into the standard command output form
   # that is then formatted, printed and returned as an exit code.
   # There is a default implementation for this callback in DefaultOutput module
@@ -29,7 +27,13 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
                                   {:error, ExitCodes.exit_code, [String.t]}
   @optional_callbacks formatter: 0,
                       scopes: 0,
-                      usage_additional: 0
+                      usage_additional: 0,
+                      switches: 0,
+                      aliases: 0
+
+  @callback switches() :: Keyword.t
+  @callback aliases() :: Keyword.t
+
   @callback formatter() :: Atom.t
   @callback scopes() :: [Atom.t]
   @callback usage_additional() :: String.t | [String.t]

--- a/lib/rabbitmq/cli/core/command_modules.ex
+++ b/lib/rabbitmq/cli/core/command_modules.ex
@@ -24,7 +24,6 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
     Application.get_env(:rabbitmqctl, :commands) || load(%{})
   end
 
-  def is_command?([head | _]), do: is_command?(head)
   def is_command?(str), do: module_map[str] != nil
 
   def load(opts) do

--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -19,14 +19,14 @@ defmodule RabbitMQ.CLI.Core.Parser do
   # Input: A list of strings
   # Output: A 2-tuple of lists: one containing the command,
   #         one containing flagged options.
-  def parse(command) do
-    switches = build_switches(default_switches())
+  def parse(input, switches, aliases) do
+    # switches = build_switches(default_switches(), extra_switches)
+    # aliases  = build_aliases(default_aliases(), extra_aliases)
+
     {options, cmd, invalid} = OptionParser.parse(
-      command,
+      input,
       strict: switches,
-      aliases: build_aliases([p: :vhost, n: :node, q: :quiet,
-                              t: :timeout, l: :longnames])
-    )
+      aliases: aliases)
     norm_options = normalize_options(options, switches)
     {clear_on_empty_command(cmd), Map.new(norm_options), invalid}
   end
@@ -49,42 +49,63 @@ defmodule RabbitMQ.CLI.Core.Parser do
     ]
   end
 
-  defp build_switches(default) do
-    Enum.reduce(RabbitMQ.CLI.Core.CommandModules.module_map,
-                default,
-                fn({_, _}, {:error, _} = err) -> err;
-                  ({_, command}, switches) ->
-                    command_switches = command.switches()
-                    case Enum.filter(command_switches,
-                                     fn({key, val}) ->
-                                       existing_val = switches[key]
-                                       existing_val != nil and existing_val != val
-                                     end) do
-                      [] -> switches ++ command_switches;
-                      _  -> exit({:command_invalid,
-                                  {command, {:invalid_switches,
-                                             command_switches}}})
-                    end
-                end)
+  def default_aliases() do
+    [p: :vhost,
+     n: :node,
+     q: :quiet,
+     t: :timeout,
+     l: :longnames
+    ]
   end
 
-  defp build_aliases(default) do
-    Enum.reduce(RabbitMQ.CLI.Core.CommandModules.module_map,
-                default,
-                fn({_, _}, {:error, _} = err) -> err;
-                  ({_, command}, aliases) ->
-                    command_aliases = command.aliases()
-                    case Enum.filter(command_aliases,
-                                     fn({key, val}) ->
-                                       existing_val = aliases[key]
-                                       existing_val != nil and existing_val != val
-                                     end) do
-                      [] -> aliases ++ command_aliases;
-                      _  -> exit({:command_invalid,
-                                  {command, {:invalid_switches,
-                                             command_aliases}}})
-                    end
-                end)
+  def parse_global(input) do
+    parse(input, default_switches(), default_aliases())
+  end
+
+  def parse_command_specific(command, input) do
+    switches = build_switches(default_switches(), command)
+    aliases  = build_aliases(default_aliases(), command)
+    parse(input, switches, aliases)
+  end
+
+  defp build_switches(default, command) do
+    command_switches = maybe_apply(command, :switches, [], [])
+    merge_if_different(default, command_switches,
+                       {:command_invalid,
+                        {command, {:invalid_switches,
+                                   command_switches}}})
+  end
+
+  defp build_aliases(default, command) do
+    command_aliases = maybe_apply(command, :aliases, [], [])
+    merge_if_different(default, command_aliases,
+                       {:command_invalid,
+                        {command, {:invalid_aliases,
+                                   command_aliases}}})
+  end
+
+  defp maybe_apply(mod, fun, args, default) do
+    case function_exported?(mod, fun, length(args)) do
+      true  -> apply(mod, fun, args);
+      false -> default
+    end
+  end
+
+  defp merge_if_different(default, specific, error) do
+    case keyword_intersect(default, specific) do
+      [] -> Keyword.merge(default, specific);
+      _  -> exit(error)
+    end
+  end
+
+  defp keyword_intersect(one, two) do
+    one_keys = MapSet.new(Keyword.keys(one))
+    two_keys = MapSet.new(Keyword.keys(two))
+
+    case MapSet.intersection(one_keys, two_keys) do
+      %MapSet{} -> [];
+      set       -> MapSet.to_list(set)
+    end
   end
 
   defp normalize_options(options, switches) do

--- a/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -23,8 +23,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
 
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def validate(args, _) when length(args) < 2 do
     {:validation_failure, :not_enough_args}

--- a/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -25,8 +25,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
 
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
   def run([vhost], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost])
   end

--- a/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
@@ -22,8 +22,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AuthenticateUserCommand do
   def validate(args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
   def validate([_,_], _), do: :ok
   def merge_defaults(args, opts), do: {args, opts}
-  def switches(), do: []
-  def aliases(), do: []
 
   def run([user, password], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/cancel_sync_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/cancel_sync_queue_command.ex
@@ -21,10 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CancelSyncQueueCommand do
     {args, Map.merge(default_opts, opts)}
   end
 
-
-  def switches, do: []
-  def aliases, do: []
-
   def usage, do: "cancel_sync_queue [-p <vhost>] queue"
 
   def validate([], _),  do: {:validation_failure, :not_enough_args}

--- a/lib/rabbitmq/cli/ctl/commands/change_cluster_node_type_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/change_cluster_node_type_command.ex
@@ -17,8 +17,6 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.ChangeClusterNodeTypeCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def merge_defaults(args, opts) do
     {args, opts}

--- a/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
@@ -21,8 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ChangePasswordCommand do
 
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def validate(args, _) when length(args) < 2, do: {:validation_failure, :not_enough_args}
   def validate([_|_] = args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}

--- a/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
@@ -19,8 +19,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearOperatorPolicyCommand do
   use RabbitMQ.CLI.DefaultOutput
   @flags [:vhost]
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/clear_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_parameter_command.ex
@@ -19,8 +19,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearParameterCommand do
   use RabbitMQ.CLI.DefaultOutput
   @flags [:vhost]
 
-  def switches(), do: []
-  def aliases(), do: []
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}
   end

--- a/lib/rabbitmq/cli/ctl/commands/clear_password_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_password_command.ex
@@ -23,8 +23,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearPasswordCommand do
   def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
   def validate([_], _), do: :ok
   def merge_defaults(args, opts), do: {args, opts}
-  def switches(), do: []
-  def aliases(), do: []
 
   def run([_user] = args, %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_auth_backend_internal, :clear_password, args)

--- a/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
@@ -31,8 +31,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearPermissionsCommand do
   end
   def validate([_], _), do: :ok
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def run([username], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/clear_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_policy_command.ex
@@ -19,8 +19,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearPolicyCommand do
   use RabbitMQ.CLI.DefaultOutput
   @flags [:vhost]
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/clear_vhost_limits_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_vhost_limits_command.ex
@@ -18,8 +18,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearVhostLimitsCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/close_connection_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/close_connection_command.ex
@@ -23,8 +23,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseConnectionCommand do
   def validate(args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
   def validate(args, _) when length(args) < 2, do: {:validation_failure, :not_enough_args}
   def validate([_,_], _), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 
 
   def run([pid, explanation], %{node: node_name}) do

--- a/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
@@ -20,8 +20,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
   @flags []
 
   def merge_defaults(args, opts), do: {args, opts}
-  def switches(), do: []
-  def aliases(), do: []
   def validate(args, _) when length(args) != 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang

--- a/lib/rabbitmq/cli/ctl/commands/delete_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/delete_user_command.ex
@@ -23,8 +23,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteUserCommand do
   def validate([_], _), do: :ok
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
   def run([username], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_auth_backend_internal,

--- a/lib/rabbitmq/cli/ctl/commands/delete_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/delete_vhost_command.ex
@@ -23,8 +23,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteVhostCommand do
   def validate([_], _), do: :ok
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
   def run([arg], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :delete, [arg])
   end

--- a/lib/rabbitmq/cli/ctl/commands/environment_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/environment_command.ex
@@ -23,8 +23,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EnvironmentCommand do
   def merge_defaults(args, opts), do: {args, opts}
 
   def scopes(), do: [:ctl, :diagnostics]
-  def switches(), do: []
-  def aliases(), do: []
   def run([], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit, :environment, [])
   end

--- a/lib/rabbitmq/cli/ctl/commands/eval_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/eval_command.ex
@@ -20,8 +20,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
 
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 

--- a/lib/rabbitmq/cli/ctl/commands/exec_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/exec_command.ex
@@ -20,8 +20,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExecCommand do
 
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Inspect
 

--- a/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
@@ -21,8 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceBootCommand do
 
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def validate(args, _) when length(args) > 0 do
     {:validation_failure, :too_many_args}

--- a/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
@@ -21,8 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceResetCommand do
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 
 
   def run([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
@@ -23,7 +23,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def switches(), do: [offline: :boolean]
-  def aliases(), do: []
+
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{offline: false}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -25,8 +25,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
   def validate(_, _), do: :ok
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def scopes(), do: [:ctl, :diagnostics, :plugins]
 

--- a/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
@@ -30,7 +30,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
     ]
   end
 
-    def aliases(), do: []
+
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{disc: true, ram: false}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/list_bindings_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_bindings_command.ex
@@ -42,8 +42,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListBindingsCommand do
   def merge_defaults(args, opts) do
     {args, Map.merge(default_opts, opts)}
   end
-  def switches(), do: []
-  def aliases(), do: []
 
 
   def usage() do

--- a/lib/rabbitmq/cli/ctl/commands/list_channels_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_channels_command.ex
@@ -43,8 +43,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListChannelsCommand do
   end
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def usage() do
       "list_channels [<channelinfoitem> ...]"

--- a/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
@@ -44,8 +44,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConnectionsCommand do
   end
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def usage() do
       "list_connections [<connectioninfoitem> ...]"

--- a/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
@@ -40,8 +40,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
   end
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
 
 
   def usage() do

--- a/lib/rabbitmq/cli/ctl/commands/list_exchanges_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_exchanges_command.ex
@@ -42,8 +42,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListExchangesCommand do
     {args, Map.merge(%{vhost: "/"}, opts)}
   end
 
-  def switches(), do: []
-  def aliases(), do: []
 
 
   def usage() do

--- a/lib/rabbitmq/cli/ctl/commands/list_operator_policies_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_operator_policies_command.ex
@@ -21,8 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListOperatorPoliciesCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
   @flags [:vhost]
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def scopes(), do: [:ctl, :diagnostics]
 

--- a/lib/rabbitmq/cli/ctl/commands/list_parameters_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_parameters_command.ex
@@ -26,8 +26,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListParametersCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def validate([_|_], _) do
     {:validation_failure, :too_many_args}

--- a/lib/rabbitmq/cli/ctl/commands/list_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_permissions_command.ex
@@ -27,8 +27,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListPermissionsCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def validate([_|_], _) do
     {:validation_failure, :too_many_args}

--- a/lib/rabbitmq/cli/ctl/commands/list_policies_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_policies_command.ex
@@ -21,8 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListPoliciesCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
   @flags [:vhost]
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def scopes(), do: [:ctl, :diagnostics]
 

--- a/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
@@ -53,7 +53,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
 
   def switches(), do: [offline: :boolean, online: :boolean, local: :boolean]
 
-  def aliases(), do: []
+
 
   def usage() do
       "list_queues [-p <vhost>] [--online] [--offline] [<queueinfoitem> ...]"

--- a/lib/rabbitmq/cli/ctl/commands/list_user_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_user_permissions_command.ex
@@ -27,8 +27,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserPermissionsCommand do
   def scopes(), do: [:ctl, :diagnostics]
 
   def merge_defaults(args, opts), do: {args, opts}
-  def switches(), do: []
-  def aliases(), do: []
 
   def run([username], %{node: node_name, timeout: time_out}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
@@ -24,8 +24,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUsersCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def switches(), do: []
-  def aliases(), do: []
   def validate([_|_], _) do
     {:validation_failure, :too_many_args}
   end

--- a/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
@@ -26,8 +26,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostsCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def switches(), do: []
-  def aliases(), do: []
   def validate(args, _) do
     case InfoKeys.validate_info_keys(args, @info_keys) do
       {:ok, _} -> :ok

--- a/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
@@ -34,7 +34,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand do
 
   def switches(), do: [timeout: :integer]
 
-  def aliases(), do: []
+
 
   def usage, do: "node_health_check"
 

--- a/lib/rabbitmq/cli/ctl/commands/purge_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/purge_queue_command.ex
@@ -18,9 +18,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.PurgeQueueCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   @flags []
-
-  def switches, do: []
-  def aliases, do: []
   def usage, do: "purge_queue <queue>"
 
   def run([queue], %{node: node_name, vhost: vhost, timeout: timeout}) do

--- a/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
@@ -24,7 +24,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RenameClusterNodeCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def switches(), do: [mnesia_dir: :string, rabbitmq_home: :string]
-  def aliases(), do: []
+
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/ctl/commands/report_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/report_command.ex
@@ -31,8 +31,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def switches(), do: []
-  def aliases(), do: []
   def merge_defaults(args, opts), do: {args, opts}
 
   def validate([_|_] = args, _) when length(args) != 0, do: {:validation_failure, :too_many_args}

--- a/lib/rabbitmq/cli/ctl/commands/reset_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/reset_command.ex
@@ -21,8 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ResetCommand do
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 
 
   def run([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/ctl/commands/rotate_logs_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/rotate_logs_command.ex
@@ -22,8 +22,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RotateLogsCommand do
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 
 
   def run([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/ctl/commands/set_cluster_name_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_cluster_name_command.ex
@@ -19,8 +19,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetClusterNameCommand do
   use RabbitMQ.CLI.DefaultOutput
   @flags []
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/ctl/commands/set_disk_free_limit_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_disk_free_limit_command.ex
@@ -21,8 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetDiskFreeLimitCommand do
   use RabbitMQ.CLI.DefaultOutput
   @flags []
   def merge_defaults(args, opts), do: {args, opts}
-  def switches(), do: []
-  def aliases(), do: []
 
   def validate([], _) do
     {:validation_failure, :not_enough_args}

--- a/lib/rabbitmq/cli/ctl/commands/set_operator_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_operator_policy_command.ex
@@ -19,7 +19,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetOperatorPolicyCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def switches(), do: [priority: :integer, apply_to: :string]
-  def aliases(), do: []
+
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/", priority: 0, apply_to: "all"}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
@@ -19,8 +19,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetParameterCommand do
   use RabbitMQ.CLI.DefaultOutput
   @flags [:vhost]
 
-  def switches(), do: []
-  def aliases(), do: []
   def merge_defaults(args, opts) do
     {args, Map.merge(opts, %{vhost: "/"})}
   end

--- a/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
@@ -23,8 +23,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPermissionsCommand do
     {args, Map.merge(%{vhost: "/"}, opts)}
   end
 
-  def switches(), do: []
-  def aliases(), do: []
   def validate([], _) do
     {:validation_failure, :not_enough_args}
   end

--- a/lib/rabbitmq/cli/ctl/commands/set_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_policy_command.ex
@@ -19,7 +19,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPolicyCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def switches(), do: [priority: :integer, apply_to: :string]
-  def aliases(), do: []
+
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/", priority: 0, apply_to: "all"}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
@@ -20,8 +20,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetUserTagsCommand do
   @flags []
   def merge_defaults(args, opts), do: {args, opts}
 
-  def switches(), do: []
-  def aliases(), do: []
   def validate([], _), do: {:validation_failure, :not_enough_args}
   def validate(_, _), do: :ok
   def run([user | tags], %{node: node_name}) do

--- a/lib/rabbitmq/cli/ctl/commands/set_vhost_limits_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_vhost_limits_command.ex
@@ -18,8 +18,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetVhostLimitsCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/set_vm_memory_high_watermark_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_vm_memory_high_watermark_command.ex
@@ -21,8 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetVmMemoryHighWatermarkCommand do
   use RabbitMQ.CLI.DefaultOutput
   @flags []
   def merge_defaults(args, opts), do: {args, opts}
-  def switches(), do: []
-  def aliases(), do: []
 
   def validate([], _) do
     {:validation_failure, :not_enough_args}

--- a/lib/rabbitmq/cli/ctl/commands/start_app_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/start_app_command.ex
@@ -22,8 +22,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StartAppCommand do
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 
 
   def run([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/ctl/commands/status_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/status_command.ex
@@ -22,8 +22,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 
   def scopes(), do: [:ctl, :diagnostics]
 

--- a/lib/rabbitmq/cli/ctl/commands/stop_app_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/stop_app_command.ex
@@ -22,8 +22,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StopAppCommand do
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 
 
   def run([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/ctl/commands/stop_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/stop_command.ex
@@ -22,8 +22,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StopCommand do
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 
 
   def run([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/ctl/commands/sync_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/sync_queue_command.ex
@@ -21,10 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SyncQueueCommand do
     {args, Map.merge(default_opts, opts)}
   end
 
-
-  def switches, do: []
-  def aliases, do: []
-
   def usage, do: "sync_queue [-p <vhost>] queue"
 
   def validate([], _),  do: {:validation_failure, :not_enough_args}

--- a/lib/rabbitmq/cli/ctl/commands/trace_off_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/trace_off_command.ex
@@ -21,8 +21,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.TraceOffCommand do
 
   def validate([_|_], _), do: {:validation_failure, :too_many_args}
   def validate(_, _), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
   def merge_defaults(_, opts) do
     {[], Map.merge(%{vhost: "/"}, opts)}
   end

--- a/lib/rabbitmq/cli/ctl/commands/trace_on_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/trace_on_command.ex
@@ -24,8 +24,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.TraceOnCommand do
   def merge_defaults(_, opts) do
     {[], Map.merge(%{vhost: "/"}, opts)}
   end
-  def switches(), do: []
-  def aliases(), do: []
 
   def run([], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_trace, :start, [vhost])

--- a/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
@@ -19,8 +19,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.UpdateClusterNodesCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def merge_defaults(args, opts) do
     {args, opts}

--- a/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -26,8 +26,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def switches(), do: []
-  def aliases(), do: []
 
   def run([pid_file], %{node: node_name}) do
     wait_for_application(node_name, pid_file, :rabbit_and_plugins);

--- a/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -28,7 +28,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
 
   def switches(), do: [online: :boolean,
                        offline: :boolean]
-  def aliases(), do: []
+
 
   def validate([], _) do
     {:validation_failure, :not_enough_arguments}

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -28,7 +28,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
 
   def switches(), do: [online: :boolean,
                        offline: :boolean]
-  def aliases(), do: []
+
 
   def validate([], _) do
     {:validation_failure, :not_enough_arguments}

--- a/lib/rabbitmq/cli/plugins/commands/set_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/set_command.ex
@@ -28,7 +28,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.SetCommand do
 
   def switches(), do: [online: :boolean,
                        offline: :boolean]
-  def aliases(), do: []
+
 
   def validate(_, %{online: true, offline: true}) do
     {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}

--- a/test/command_modules_test.exs
+++ b/test/command_modules_test.exs
@@ -131,25 +131,6 @@ defmodule CommandModulesTest do
     assert @subject.is_command?(nil) == false
   end
 
-  test "an empty array returns false" do
-    set_scope(:ctl)
-    @subject.load(%{})
-    assert @subject.is_command?([]) == false
-  end
-
-  test "an non-empty array tests the first element" do
-    set_scope(:ctl)
-    @subject.load(%{})
-    assert @subject.is_command?(["status", "quack"]) == true
-    assert @subject.is_command?(["quack", "status"]) == false
-  end
-
-  test "a non-string list returns false" do
-    set_scope(:ctl)
-    @subject.load(%{})
-    assert @subject.is_command?([{"status", "quack"}, {4, "Fantastic"}]) == false
-  end
-
   ## ------------------- commands/0 tests --------------------
 
   test "command_modules has existing commands" do

--- a/test/command_modules_test.exs
+++ b/test/command_modules_test.exs
@@ -164,8 +164,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DuckCommand do
   def merge_defaults(_,_), do: {[], %{}}
   def banner(_,_), do: ""
   def run(_,_), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 end
 
 defmodule RabbitMQ.CLI.Ctl.Commands.GrayGooseCommand do
@@ -176,8 +174,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.GrayGooseCommand do
   def merge_defaults(_,_), do: {[], %{}}
   def banner(_,_), do: ""
   def run(_,_), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 end
 
 defmodule RabbitMQ.CLI.Ctl.Commands.UglyDucklingCommand do
@@ -194,8 +190,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.StorkCommand do
   def merge_defaults(_,_), do: {[], %{}}
   def banner(_,_), do: ""
   def run(_,_), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 end
 
 defmodule RabbitMQ.CLI.Plugins.Commands.HeronCommand do
@@ -206,8 +200,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.HeronCommand do
   def merge_defaults(_,_), do: {[], %{}}
   def banner(_,_), do: ""
   def run(_,_), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 end
 
 # Mock command modules for Custom
@@ -220,8 +212,6 @@ defmodule RabbitMQ.CLI.Custom.Commands.CrowCommand do
   def merge_defaults(_,_), do: {[], %{}}
   def banner(_,_), do: ""
   def run(_,_), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
   def scopes(), do: [:custom, ]
 end
 
@@ -233,8 +223,6 @@ defmodule RabbitMQ.CLI.Custom.Commands.RavenCommand do
   def merge_defaults(_,_), do: {[], %{}}
   def banner(_,_), do: ""
   def run(_,_), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
 end
 
 defmodule RabbitMQ.CLI.Seagull.Commands.SeagullCommand do
@@ -245,8 +233,6 @@ defmodule RabbitMQ.CLI.Seagull.Commands.SeagullCommand do
   def merge_defaults(_,_), do: {[], %{}}
   def banner(_,_), do: ""
   def run(_,_), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
   def scopes(), do: [:plugins, :custom]
 end
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -20,80 +20,80 @@ defmodule ParserTest do
   @subject RabbitMQ.CLI.Core.Parser
 
   test "one arity 0 command, no options" do
-    assert @subject.parse(["sandwich"]) == {["sandwich"], %{}, []}
+    assert @subject.parse_global(["sandwich"]) == {["sandwich"], %{}, []}
   end
 
   test "one arity 1 command, no options" do
-    assert @subject.parse(["sandwich", "pastrami"]) == {["sandwich", "pastrami"], %{}, []}
+    assert @subject.parse_global(["sandwich", "pastrami"]) == {["sandwich", "pastrami"], %{}, []}
   end
 
   test "no commands, no options (empty string)" do
-    assert @subject.parse([""]) == {[], %{}, []}
+    assert @subject.parse_global([""]) == {[], %{}, []}
   end
 
   test "no commands, no options (empty array)" do
-    assert @subject.parse([]) == {[],%{}, []}
+    assert @subject.parse_global([]) == {[],%{}, []}
   end
 
   test "one arity 1 command, one double-dash quiet flag" do
-    assert @subject.parse(["sandwich", "pastrami", "--quiet"]) ==
+    assert @subject.parse_global(["sandwich", "pastrami", "--quiet"]) ==
       {["sandwich", "pastrami"], %{quiet: true}, []}
   end
 
   test "one arity 1 command, one single-dash quiet flag" do
-    assert @subject.parse(["sandwich", "pastrami", "-q"]) ==
+    assert @subject.parse_global(["sandwich", "pastrami", "-q"]) ==
       {["sandwich", "pastrami"], %{quiet: true}, []}
   end
 
   test "one arity 0 command, one single-dash node option" do
-    assert @subject.parse(["sandwich", "-n", "rabbitmq@localhost"]) ==
+    assert @subject.parse_global(["sandwich", "-n", "rabbitmq@localhost"]) ==
       {["sandwich"], %{node: :"rabbitmq@localhost"}, []}
   end
 
   test "one arity 1 command, one single-dash node option" do
-    assert @subject.parse(["sandwich", "pastrami", "-n", "rabbitmq@localhost"]) ==
+    assert @subject.parse_global(["sandwich", "pastrami", "-n", "rabbitmq@localhost"]) ==
       {["sandwich", "pastrami"], %{node: :"rabbitmq@localhost"}, []}
   end
 
   test "one arity 1 command, one single-dash node option and one quiet flag" do
-    assert @subject.parse(["sandwich", "pastrami", "-n", "rabbitmq@localhost", "--quiet"]) ==
+    assert @subject.parse_global(["sandwich", "pastrami", "-n", "rabbitmq@localhost", "--quiet"]) ==
       {["sandwich", "pastrami"], %{node: :"rabbitmq@localhost", quiet: true}, []}
   end
 
   test "single-dash node option before command" do
-    assert @subject.parse(["-n", "rabbitmq@localhost", "sandwich", "pastrami"]) ==
+    assert @subject.parse_global(["-n", "rabbitmq@localhost", "sandwich", "pastrami"]) ==
       {["sandwich", "pastrami"], %{node: :"rabbitmq@localhost"}, []}
   end
 
   test "no commands, one double-dash node option" do
-    assert @subject.parse(["--node=rabbitmq@localhost"]) == {[], %{node: :"rabbitmq@localhost"}, []}
+    assert @subject.parse_global(["--node=rabbitmq@localhost"]) == {[], %{node: :"rabbitmq@localhost"}, []}
   end
 
   test "no commands, one integer --timeout value" do
-    assert @subject.parse(["--timeout=600"]) == {[], %{timeout: 600}, []}
+    assert @subject.parse_global(["--timeout=600"]) == {[], %{timeout: 600}, []}
   end
 
   test "no commands, one string --timeout value is invalid" do
-    assert @subject.parse(["--timeout=sandwich"]) == {[], %{}, [{"--timeout", "sandwich"}]}
+    assert @subject.parse_global(["--timeout=sandwich"]) == {[], %{}, [{"--timeout", "sandwich"}]}
   end
 
   test "no commands, one float --timeout value is invalid" do
-    assert @subject.parse(["--timeout=60.5"]) == {[], %{}, [{"--timeout", "60.5"}]}
+    assert @subject.parse_global(["--timeout=60.5"]) == {[], %{}, [{"--timeout", "60.5"}]}
   end
 
   test "no commands, one integer -t value" do
-    assert @subject.parse(["-t", "600"]) == {[], %{timeout: 600}, []}
+    assert @subject.parse_global(["-t", "600"]) == {[], %{timeout: 600}, []}
   end
 
   test "no commands, one string -t value is invalid" do
-    assert @subject.parse(["-t", "sandwich"]) == {[], %{}, [{"-t", "sandwich"}]}
+    assert @subject.parse_global(["-t", "sandwich"]) == {[], %{}, [{"-t", "sandwich"}]}
   end
 
   test "no commands, one float -t value is invalid" do
-    assert @subject.parse(["-t", "60.5"]) == {[], %{}, [{"-t", "60.5"}]}
+    assert @subject.parse_global(["-t", "60.5"]) == {[], %{}, [{"-t", "60.5"}]}
   end
 
   test "no commands, one single-dash -p option" do
-    assert @subject.parse(["-p", "sandwich"]) == {[], %{vhost: "sandwich"}, []}
+    assert @subject.parse_global(["-p", "sandwich"]) == {[], %{vhost: "sandwich"}, []}
   end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -120,14 +120,14 @@ defmodule ParserTest do
     assert @subject.parse_global(["-p", "sandwich"]) == {[], %{vhost: "sandwich"}, []}
   end
 
-  test "global parse returns command specific arguments as invlid" do
+  test "global parse returns command-specific arguments as nil" do
     command_line = ["seagull", "--herring=atlantic", "-g", "-p", "my_vhost"]
     command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
     {:module, command} = Code.ensure_loaded(command)
     assert @subject.parse_global(command_line) == {["seagull"], %{vhost: "my_vhost"}, [{"--herring", nil}, {"-g", nil}]}
   end
 
-  test "command specific parse can parse command switches" do
+  test "command-specific parse can parse command switches" do
     command_line = ["seagull", "--herring=atlantic", "-g", "-p", "my_vhost"]
     command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
     {:module, command} = Code.ensure_loaded(command)
@@ -135,7 +135,7 @@ defmodule ParserTest do
       {["seagull"], %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
   end
 
-  test "command specific switches and aliases are optional" do
+  test "command-specific switches and aliases are optional" do
     command_line = ["seagull", "-p", "my_vhost"]
     command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
     {:module, command} = Code.ensure_loaded(command)

--- a/test/purge_queue_command_test.exs
+++ b/test/purge_queue_command_test.exs
@@ -76,10 +76,6 @@ defmodule PurgeQueueCommandTest do
     assert @command.run(["foo"], context[:opts]) == {:badrpc, :timeout}
   end
 
-  test "has no switches" do
-    assert @command.switches == []
-  end
-
   test "shows up in help" do
     s = @command.usage()
     assert s =~ ~r/purge_queue/

--- a/test/set_cluster_name_command_test.exs
+++ b/test/set_cluster_name_command_test.exs
@@ -45,10 +45,6 @@ defmodule SetClusterNameCommandTest do
     assert @command.merge_defaults(["foo"], %{bar: "baz"}) == {["foo"], %{bar: "baz"}}
   end
 
-  test "has no switches" do
-    assert @command.switches == []
-  end
-
   test "validate: with insufficient number of arguments, return arg count error" do
     assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
   end


### PR DESCRIPTION
Fixes #120 

Refactored parser to parse command specific and global flags separately, so there is no need to load commands before parsing.
Should also make the CTL faster