### PR TITLE
Load command specific options from a single command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ test:: all
 
 clean::
 	rm -f $(ESCRIPTS)
-	- mix local.hex --force
+	[[ -d $(HOME)/.mix/archives ]] || mix local.hex --force
 	rm -rf ebin
 	mix clean
 

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -66,10 +66,6 @@ defmodule RabbitMQ.CLI.Core.Helpers do
 
   def power_as_int(num, x, y), do: round(num * (:math.pow(x, y)))
 
-  def global_flags() do
-    RabbitMQ.CLI.Core.Parser.default_switches |> Keyword.keys
-  end
-
   def nodes_in_cluster(node, timeout \\ :infinity) do
     case :rpc.call(node, :rabbit_mnesia, :cluster_nodes, [:running], timeout) do
       {:badrpc, _} = err -> throw(err);

--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -28,12 +28,7 @@ defmodule RabbitMQ.CLI.Core.Parser do
     {parsed_args, options, invalid} = parse_global(input)
     CommandModules.load(options)
 
-    {command_name, command_module, arguments} = case parsed_args do
-      [cmd_name | arguments] ->
-        {cmd_name, CommandModules.module_map[cmd_name], arguments}
-      [] ->
-        {"", nil, []}
-    end
+    {command_name, command_module, arguments} = look_up_command(parsed_args)
 
     case command_module do
       nil ->
@@ -42,6 +37,15 @@ defmodule RabbitMQ.CLI.Core.Parser do
         {[^command_name | cmd_arguments], cmd_options, cmd_invalid} =
           parse_command_specific(input, command_module)
         {command_module, command_name, cmd_arguments, cmd_options, cmd_invalid}
+    end
+  end
+
+  defp look_up_command(parsed_args) do
+    case parsed_args do
+      [cmd_name | arguments] ->
+        {cmd_name, CommandModules.module_map[cmd_name], arguments}
+      [] ->
+        {"", nil, []}
     end
   end
 

--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -13,23 +13,58 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
 
+alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
 
 defmodule RabbitMQ.CLI.Core.Parser do
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
-  # Input: A list of strings
-  # Output: A 2-tuple of lists: one containing the command,
-  #         one containing flagged options.
-  def parse(command) do
-    switches = build_switches(default_switches())
-    {options, cmd, invalid} = OptionParser.parse(
-      command,
+  @spec parse(String.t) :: {command :: :no_command | atom(),
+                            command_name :: String.t,
+                            arguments :: [String.t],
+                            options :: Map.t,
+                            invalid :: [{String.t, String.t | nil}]}
+
+  def parse(input) do
+    {parsed_args, options, invalid} = parse_global(input)
+    CommandModules.load(options)
+
+    {command_name, command_module, arguments} = case parsed_args do
+      [cmd_name | arguments] ->
+        {cmd_name, CommandModules.module_map[cmd_name], arguments}
+      [] ->
+        {"", nil, []}
+    end
+
+    case command_module do
+      nil ->
+        {:no_command, command_name, arguments, options, invalid};
+      command_module when is_atom(command_module) ->
+        {[^command_name | cmd_arguments], cmd_options, cmd_invalid} =
+          parse_command_specific(input, command_module)
+        {command_module, command_name, cmd_arguments, cmd_options, cmd_invalid}
+    end
+  end
+
+  def parse_command_specific(input, command) do
+    switches = build_switches(default_switches(), command)
+    aliases = build_aliases(default_aliases(), command)
+    parse_generic(input, switches, aliases)
+  end
+
+  def parse_global(input) do
+    switches = default_switches()
+    aliases = default_aliases()
+    parse_generic(input, switches, aliases)
+  end
+
+  defp parse_generic(input, switches, aliases) do
+    {options, args, invalid} = OptionParser.parse(
+      input,
       strict: switches,
-      aliases: build_aliases([p: :vhost, n: :node, q: :quiet,
-                              t: :timeout, l: :longnames])
+      aliases: aliases
     )
-    norm_options = normalize_options(options, switches)
-    {clear_on_empty_command(cmd), Map.new(norm_options), invalid}
+    norm_options = normalize_options(options, switches) |> Map.new
+    {args, norm_options, invalid}
   end
 
   def default_switches() do
@@ -50,42 +85,51 @@ defmodule RabbitMQ.CLI.Core.Parser do
     ]
   end
 
-  defp build_switches(default) do
-    Enum.reduce(RabbitMQ.CLI.Core.CommandModules.module_map,
-                default,
-                fn({_, _}, {:error, _} = err) -> err;
-                  ({_, command}, switches) ->
-                    command_switches = Helpers.apply_if_exported(command, :switches, [], [])
-                    case Enum.filter(command_switches,
-                                     fn({key, val}) ->
-                                       existing_val = switches[key]
-                                       existing_val != nil and existing_val != val
-                                     end) do
-                      [] -> switches ++ command_switches;
-                      _  -> exit({:command_invalid,
-                                  {command, {:invalid_switches,
-                                             command_switches}}})
-                    end
-                end)
+  def default_aliases() do
+    [p: :vhost,
+     n: :node,
+     q: :quiet,
+     t: :timeout,
+     l: :longnames]
   end
 
-  defp build_aliases(default) do
-    Enum.reduce(RabbitMQ.CLI.Core.CommandModules.module_map,
-                default,
-                fn({_, _}, {:error, _} = err) -> err;
-                  ({_, command}, aliases) ->
-                    command_aliases = Helpers.apply_if_exported(command, :aliases, [], [])
-                    case Enum.filter(command_aliases,
-                                     fn({key, val}) ->
-                                       existing_val = aliases[key]
-                                       existing_val != nil and existing_val != val
-                                     end) do
-                      [] -> aliases ++ command_aliases;
-                      _  -> exit({:command_invalid,
-                                  {command, {:invalid_switches,
-                                             command_aliases}}})
-                    end
-                end)
+  defp build_switches(default, command) do
+    command_switches = apply_if_exported(command, :switches, [], [])
+    merge_if_different(default, command_switches,
+                       {:command_invalid,
+                        {command, {:invalid_switches,
+                                   command_switches}}})
+  end
+
+  defp build_aliases(default, command) do
+    command_aliases = apply_if_exported(command, :aliases, [], [])
+    merge_if_different(default, command_aliases,
+                       {:command_invalid,
+                        {command, {:invalid_aliases,
+                                   command_aliases}}})
+  end
+
+  defp apply_if_exported(mod, fun, args, default) do
+    case function_exported?(mod, fun, length(args)) do
+      true  -> apply(mod, fun, args);
+      false -> default
+    end
+  end
+
+  defp merge_if_different(default, specific, error) do
+    case keyword_intersect(default, specific) do
+      [] -> Keyword.merge(default, specific);
+      _  -> exit(error)
+    end
+  end
+
+  defp keyword_intersect(one, two) do
+    one_keys = MapSet.new(Keyword.keys(one))
+    two_keys = MapSet.new(Keyword.keys(two))
+    case MapSet.intersection(one_keys, two_keys) do
+      %MapSet{} -> [];
+      set       -> MapSet.to_list(set)
+    end
   end
 
   defp normalize_options(options, switches) do
@@ -102,12 +146,4 @@ defmodule RabbitMQ.CLI.Core.Parser do
     value
   end
 
-  # Discards entire command if first command term is empty.
-  defp clear_on_empty_command(command_args) do
-    case command_args do
-      [] -> []
-      [""|_] -> []
-      [_head|_] -> command_args
-    end
-  end
 end

--- a/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -31,7 +31,7 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
         :rabbit_plugins.read_enabled(to_char_list(enabled));
       # Existence of enabled_plugins_file should be validated separately
       {:error, :no_plugins_file} ->
-        IO.puts(:stderr, "ENABLED_PLUGINS_FILE not defined")
+        # IO.puts(:stderr, "ENABLED_PLUGINS_FILE not defined")
         []
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,9 @@ defmodule RabbitMQCtl.MixfileBase do
                     RabbitMQ.CLI.Plugins.Commands.HeronCommand,
                     RabbitMQ.CLI.Custom.Commands.CrowCommand,
                     RabbitMQ.CLI.Custom.Commands.RavenCommand,
-                    RabbitMQ.CLI.Seagull.Commands.SeagullCommand]
+                    RabbitMQ.CLI.Seagull.Commands.SeagullCommand,
+                    RabbitMQ.CLI.Seagull.Commands.PacificGullCommand,
+                    RabbitMQ.CLI.Seagull.Commands.HerringGullCommand]
     [{:modules, mods ++ test_modules |> Enum.sort} | app]
   end
   defp add_modules(app, _) do

--- a/test/command_modules_test.exs
+++ b/test/command_modules_test.exs
@@ -13,10 +13,9 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.Config, as: Config
-
 defmodule CommandModulesTest do
   use ExUnit.Case, async: false
+  import TestHelper
 
   @subject RabbitMQ.CLI.Core.CommandModules
 
@@ -163,13 +162,6 @@ defmodule CommandModulesTest do
     set_scope(:ctl)
     @subject.load(%{})
     assert @subject.module_map[:p_equals_np_proof] == nil
-  end
-
-
-  def set_scope(scope) do
-    script_name = Config.get_option(:script_name, %{})
-    scopes = Keyword.put(Application.get_env(:rabbitmqctl, :scopes), script_name, scope)
-    Application.put_env(:rabbitmqctl, :scopes, scopes)
   end
 end
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -13,87 +13,194 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2016 Pivotal Software, Inc.  All rights reserved.
 
+## Mock command for command specific parser
+defmodule RabbitMQ.CLI.Seagull.Commands.HerringGullCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+  use RabbitMQ.CLI.DefaultOutput
+  def usage(), do: ["herring_gull"]
+  def validate(_,_), do: :ok
+  def merge_defaults(_,_), do: {[], %{}}
+  def banner(_,_), do: ""
+  def run(_,_), do: :ok
+  def switches(), do: [herring: :string, garbage: :boolean]
+  def aliases(), do: [h: :herring, g: :garbage]
+end
+
+defmodule RabbitMQ.CLI.Seagull.Commands.PacificGullCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+  use RabbitMQ.CLI.DefaultOutput
+  def usage(), do: ["pacific_gull"]
+  def validate(_,_), do: :ok
+  def merge_defaults(_,_), do: {[], %{}}
+  def banner(_,_), do: ""
+  def run(_,_), do: :ok
+  def switches(), do: []
+  def aliases(), do: []
+end
 
 defmodule ParserTest do
   use ExUnit.Case, async: true
+  import TestHelper
 
   @subject RabbitMQ.CLI.Core.Parser
 
+  setup_all do
+    Code.ensure_loaded(RabbitMQ.CLI.Seagull.Commands.HerringGullCommand)
+    Code.ensure_loaded(RabbitMQ.CLI.Seagull.Commands.PacificGullCommand)
+    set_scope(:seagull)
+    on_exit(fn ->
+      set_scope(:none)
+    end)
+    :ok
+  end
+
   test "one arity 0 command, no options" do
-    assert @subject.parse(["sandwich"]) == {["sandwich"], %{}, []}
+    assert @subject.parse_global(["sandwich"]) == {["sandwich"], %{}, []}
   end
 
   test "one arity 1 command, no options" do
-    assert @subject.parse(["sandwich", "pastrami"]) == {["sandwich", "pastrami"], %{}, []}
+    assert @subject.parse_global(["sandwich", "pastrami"]) == {["sandwich", "pastrami"], %{}, []}
   end
 
   test "no commands, no options (empty string)" do
-    assert @subject.parse([""]) == {[], %{}, []}
+    assert @subject.parse_global([""]) == {[""], %{}, []}
   end
 
   test "no commands, no options (empty array)" do
-    assert @subject.parse([]) == {[],%{}, []}
+    assert @subject.parse_global([]) == {[],%{}, []}
   end
 
   test "one arity 1 command, one double-dash quiet flag" do
-    assert @subject.parse(["sandwich", "pastrami", "--quiet"]) ==
+    assert @subject.parse_global(["sandwich", "pastrami", "--quiet"]) ==
       {["sandwich", "pastrami"], %{quiet: true}, []}
   end
 
   test "one arity 1 command, one single-dash quiet flag" do
-    assert @subject.parse(["sandwich", "pastrami", "-q"]) ==
+    assert @subject.parse_global(["sandwich", "pastrami", "-q"]) ==
       {["sandwich", "pastrami"], %{quiet: true}, []}
   end
 
   test "one arity 0 command, one single-dash node option" do
-    assert @subject.parse(["sandwich", "-n", "rabbitmq@localhost"]) ==
+    assert @subject.parse_global(["sandwich", "-n", "rabbitmq@localhost"]) ==
       {["sandwich"], %{node: :"rabbitmq@localhost"}, []}
   end
 
   test "one arity 1 command, one single-dash node option" do
-    assert @subject.parse(["sandwich", "pastrami", "-n", "rabbitmq@localhost"]) ==
+    assert @subject.parse_global(["sandwich", "pastrami", "-n", "rabbitmq@localhost"]) ==
       {["sandwich", "pastrami"], %{node: :"rabbitmq@localhost"}, []}
   end
 
   test "one arity 1 command, one single-dash node option and one quiet flag" do
-    assert @subject.parse(["sandwich", "pastrami", "-n", "rabbitmq@localhost", "--quiet"]) ==
+    assert @subject.parse_global(["sandwich", "pastrami", "-n", "rabbitmq@localhost", "--quiet"]) ==
       {["sandwich", "pastrami"], %{node: :"rabbitmq@localhost", quiet: true}, []}
   end
 
   test "single-dash node option before command" do
-    assert @subject.parse(["-n", "rabbitmq@localhost", "sandwich", "pastrami"]) ==
+    assert @subject.parse_global(["-n", "rabbitmq@localhost", "sandwich", "pastrami"]) ==
       {["sandwich", "pastrami"], %{node: :"rabbitmq@localhost"}, []}
   end
 
   test "no commands, one double-dash node option" do
-    assert @subject.parse(["--node=rabbitmq@localhost"]) == {[], %{node: :"rabbitmq@localhost"}, []}
+    assert @subject.parse_global(["--node=rabbitmq@localhost"]) == {[], %{node: :"rabbitmq@localhost"}, []}
   end
 
   test "no commands, one integer --timeout value" do
-    assert @subject.parse(["--timeout=600"]) == {[], %{timeout: 600}, []}
+    assert @subject.parse_global(["--timeout=600"]) == {[], %{timeout: 600}, []}
   end
 
   test "no commands, one string --timeout value is invalid" do
-    assert @subject.parse(["--timeout=sandwich"]) == {[], %{}, [{"--timeout", "sandwich"}]}
+    assert @subject.parse_global(["--timeout=sandwich"]) == {[], %{}, [{"--timeout", "sandwich"}]}
   end
 
   test "no commands, one float --timeout value is invalid" do
-    assert @subject.parse(["--timeout=60.5"]) == {[], %{}, [{"--timeout", "60.5"}]}
+    assert @subject.parse_global(["--timeout=60.5"]) == {[], %{}, [{"--timeout", "60.5"}]}
   end
 
   test "no commands, one integer -t value" do
-    assert @subject.parse(["-t", "600"]) == {[], %{timeout: 600}, []}
+    assert @subject.parse_global(["-t", "600"]) == {[], %{timeout: 600}, []}
   end
 
   test "no commands, one string -t value is invalid" do
-    assert @subject.parse(["-t", "sandwich"]) == {[], %{}, [{"-t", "sandwich"}]}
+    assert @subject.parse_global(["-t", "sandwich"]) == {[], %{}, [{"-t", "sandwich"}]}
   end
 
   test "no commands, one float -t value is invalid" do
-    assert @subject.parse(["-t", "60.5"]) == {[], %{}, [{"-t", "60.5"}]}
+    assert @subject.parse_global(["-t", "60.5"]) == {[], %{}, [{"-t", "60.5"}]}
   end
 
   test "no commands, one single-dash -p option" do
-    assert @subject.parse(["-p", "sandwich"]) == {[], %{vhost: "sandwich"}, []}
+    assert @subject.parse_global(["-p", "sandwich"]) == {[], %{vhost: "sandwich"}, []}
   end
+
+  test "global parse returns command-specific arguments as invalid" do
+    command_line = ["seagull", "--herring=atlantic", "-g", "-p", "my_vhost"]
+    command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+    {args, options, invalid} = @subject.parse_global(command_line)
+    assert {args, options, invalid} ==
+      {["seagull"], %{vhost: "my_vhost"}, [{"--herring", nil}, {"-g", nil}]}
+  end
+
+  test "command-specific parse can parse command switches" do
+    command_line = ["seagull", "--herring=atlantic", "-g", "-p", "my_vhost"]
+    command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+    assert @subject.parse_command_specific(command_line, command) ==
+      {["seagull"], %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
+  end
+
+  test "command-specific switches and aliases are optional" do
+    command_line = ["seagull", "-p", "my_vhost"]
+    command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+    assert @subject.parse_command_specific(command_line, command) ==
+      {["seagull"], %{vhost: "my_vhost"}, []}
+  end
+
+  test "parse/1 locates command" do
+    command_line = ["pacific_gull", "fly", "-p", "my_vhost"]
+    command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+    assert @subject.parse(command_line) ==
+      {command, "pacific_gull", ["fly"], %{vhost: "my_vhost"}, []}
+  end
+
+  test "parse/1 returns :no_command for empty arguments" do
+    command_line = ["-p", "my_vhost"]
+    command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+    assert @subject.parse(command_line) ==
+      {:no_command, "", [], %{vhost: "my_vhost"}, []}
+  end
+
+  test "parse/1 returns :no_command and command name if command not found" do
+    command_line = ["atlantic_gull", "-p", "my_vhost"]
+    command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+    assert @subject.parse(command_line) ==
+      {:no_command, "atlantic_gull", [], %{vhost: "my_vhost"}, []}
+  end
+
+  test "parse/1 returns :no command if command specific options come before the command" do
+    command_line = ["--herring", "atlantic", "herring_gull", "-p", "my_vhost"]
+    command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+    assert @subject.parse(command_line) ==
+      {:no_command, "atlantic", ["herring_gull"],
+       %{vhost: "my_vhost"}, [{"--herring", nil}]}
+  end
+
+  test "parse/1 returns command with command specific options" do
+    command_line = ["herring_gull", "--herring", "atlantic",
+                    "-g", "fly", "-p", "my_vhost"]
+    command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+    assert @subject.parse(command_line) ==
+      {command, "herring_gull", ["fly"],
+       %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
+  end
+
+  test "parse/1 returns invalid options for command as invalid" do
+    command_line = ["pacific_gull", "fly",
+                    "--herring", "atlantic",
+                    "-p", "my_vhost"]
+    pacific_gull = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+    assert @subject.parse(command_line) ==
+      {pacific_gull, "pacific_gull", ["fly", "atlantic"],
+       %{vhost: "my_vhost"},
+       [{"--herring", nil}]}
+  end
+
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -176,6 +176,20 @@ defmodule ParserTest do
       {command, "pacific_gull", ["fly"], %{vhost: "my_vhost"}, []}
   end
 
+  test "parse/1 returns command name when a global flag comes before the command" do
+    command_line = ["-p", "my_vhost", "pacific_gull", "fly"]
+    command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+    assert @subject.parse(command_line) ==
+      {command, "pacific_gull", ["fly"], %{vhost: "my_vhost"}, []}
+  end
+
+  test "parse/1 returns command name when a global flag separated by an equals sign comes before the command" do
+    command_line = ["-p=my_vhost", "pacific_gull", "fly"]
+    command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
+    assert @subject.parse(command_line) ==
+      {command, "pacific_gull", ["fly"], %{vhost: "my_vhost"}, []}
+  end
+
   test "parse/1 returns :no_command when given an empty argument list" do
     command_line = ["-p", "my_vhost"]
     command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand
@@ -214,7 +228,16 @@ defmodule ParserTest do
        %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
   end
 
-  test "parse/1 returns invalid options for command as invalid" do
+  test "parse/1 returns command with command specific options that are separated by an equals sign" do
+    command_line = ["herring_gull", "--herring=atlantic",
+                    "-g", "fly", "-p=my_vhost"]
+    command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+    assert @subject.parse(command_line) ==
+      {command, "herring_gull", ["fly"],
+       %{vhost: "my_vhost", herring: "atlantic", garbage: true}, []}
+  end
+
+  test "parse/1 returns invalid/extra options for command" do
     command_line = ["pacific_gull", "fly",
                     "--herring", "atlantic",
                     "-p", "my_vhost"]

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -212,11 +212,25 @@ defmodule ParserTest do
        %{vhost: "my_vhost"}, [{"--herring", nil}]}
   end
 
-  test "parse/1 returns command name if global options come before the command" do
+  test "parse/1 returns command name if a global option comes before the command" do
     command_line = ["-p", "my_vhost", "herring_gull"]
     command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
     assert @subject.parse(command_line) ==
       {command, "herring_gull", [], %{vhost: "my_vhost"}, []}
+  end
+
+  test "parse/1 returns command name if multiple global options come before the command" do
+    command_line = ["-p", "my_vhost", "-q", "-n", "rabbit@test", "herring_gull"]
+    command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+    assert @subject.parse(command_line) ==
+      {command, "herring_gull", [], %{vhost: "my_vhost", node: :rabbit@test, quiet: true}, []}
+  end
+
+  test "parse/1 returns command name if multiple global options separated by an equals sign come before the command" do
+    command_line = ["-p=my_vhost", "-q", "--node=rabbit@test", "herring_gull"]
+    command = RabbitMQ.CLI.Seagull.Commands.HerringGullCommand
+    assert @subject.parse(command_line) ==
+      {command, "herring_gull", [], %{vhost: "my_vhost", node: :rabbit@test, quiet: true}, []}
   end
 
   test "parse/1 returns command with command specific options" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -19,6 +19,8 @@ ExUnit.start()
 defmodule TestHelper do
   import ExUnit.Assertions
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
+  alias RabbitMQ.CLI.Core.Config, as: Config
+  alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
 
   def get_rabbit_hostname() do
     RabbitMQ.CLI.Core.Helpers.get_rabbit_hostname
@@ -342,5 +344,12 @@ defmodule TestHelper do
 
   def clear_vhost_limits(vhost) do
     :rpc.call(get_rabbit_hostname, :rabbit_vhost_limit, :clear, [vhost])
+  end
+
+  def set_scope(scope) do
+    script_name = Config.get_option(:script_name, %{})
+    scopes = Keyword.put(Application.get_env(:rabbitmqctl, :scopes), script_name, scope)
+    Application.put_env(:rabbitmqctl, :scopes, scopes)
+    CommandModules.load(%{})
   end
 end


### PR DESCRIPTION
Fixes #129 
Change the command parsing behaviour to return a command if it was found, or `:no_command` if it wasn't.
Move responsibility for command discovery from `rabbitmqctl` to `parser`