### PR TITLE
Suggest similar commands

### DIFF
--- a/lib/rabbitmq/cli/core/distribution.ex
+++ b/lib/rabbitmq/cli/core/distribution.ex
@@ -26,6 +26,7 @@ defmodule RabbitMQ.CLI.Core.Distribution do
 
   def start(options) do
     node_name_type = Config.get_option(:longnames, options)
+    :rabbit_nodes.ensure_epmd()
     start(node_name_type, 10, :undefined)
   end
 

--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -16,7 +16,8 @@
 alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
 
 defmodule RabbitMQ.CLI.Core.Parser do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+
+  @levenshtein_distance_limit 5
 
   @spec parse(String.t) :: {command :: :no_command | atom(),
                             command_name :: String.t,
@@ -33,6 +34,8 @@ defmodule RabbitMQ.CLI.Core.Parser do
     case command_module do
       nil ->
         {:no_command, command_name, arguments, options, invalid};
+      {:suggest, _} = suggest ->
+        {suggest, command_name, arguments, options, invalid};
       command_module when is_atom(command_module) ->
         {[^command_name | cmd_arguments], cmd_options, cmd_invalid} =
           parse_command_specific(input, command_module)
@@ -43,9 +46,32 @@ defmodule RabbitMQ.CLI.Core.Parser do
   defp look_up_command(parsed_args) do
     case parsed_args do
       [cmd_name | arguments] ->
-        {cmd_name, CommandModules.module_map[cmd_name], arguments}
+        module_map = CommandModules.module_map
+        command = case module_map[cmd_name] do
+          nil     -> closest_similar_command(cmd_name, module_map)
+          command -> command
+        end
+        {cmd_name, command, arguments}
       [] ->
         {"", nil, []}
+    end
+  end
+
+  defp closest_similar_command(_cmd_name, empty) when empty == %{} do
+    nil
+  end
+  defp closest_similar_command(cmd_name, module_map) do
+    suggestion = module_map
+                 |> Map.keys
+                 |> Enum.map(fn(cmd) ->
+                      {cmd, Simetric.Levenshtein.compare(cmd, cmd_name)}
+                    end)
+                 |> Enum.min_by(fn({_,distance}) -> distance end)
+    case suggestion do
+      {cmd, distance} when distance < @levenshtein_distance_limit ->
+        {:suggest, cmd};
+      _ ->
+        nil
     end
   end
 

--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -17,7 +17,8 @@ alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
 
 defmodule RabbitMQ.CLI.Core.Parser do
 
-  ## Avg letter count in english language is 5
+  # This assumes the average word letter count in
+  # the English language is 5.
   @levenshtein_distance_limit 5
 
   @spec parse(String.t) :: {command :: :no_command | atom(),

--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -17,6 +17,7 @@ alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
 
 defmodule RabbitMQ.CLI.Core.Parser do
 
+  ## Avg letter count in english language is 5
   @levenshtein_distance_limit 5
 
   @spec parse(String.t) :: {command :: :no_command | atom(),
@@ -68,7 +69,7 @@ defmodule RabbitMQ.CLI.Core.Parser do
                     end)
                  |> Enum.min_by(fn({_,distance}) -> distance end)
     case suggestion do
-      {cmd, distance} when distance < @levenshtein_distance_limit ->
+      {cmd, distance} when distance <= @levenshtein_distance_limit ->
         {:suggest, cmd};
       _ ->
         nil

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -38,11 +38,12 @@ defmodule RabbitMQCtl do
     {command, command_name, arguments, parsed_options, invalid} = parse(unparsed_command)
     case {command, invalid} do
       {:no_command, _} ->
-        usage_string = HelpCommand.all_usage()
+        usage_string = "\nCommand '#{command_name}' not found. \n"<>
+                       HelpCommand.all_usage()
         {:error, ExitCodes.exit_usage, usage_string};
       {{:suggest, suggested}, _} ->
-        suggest_message = "Command '#{command_name}' not found."<>
-                          " Did you mean '#{suggested}'?"
+        suggest_message = "\nCommand '#{command_name}' not found. \n"<>
+                          "Did you mean '#{suggested}'? \n"
         {:error, ExitCodes.exit_usage, suggest_message};
       {_, [_|_]} ->
         validation_error({:bad_option, invalid}, command_name, unparsed_command);

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -36,11 +36,14 @@ defmodule RabbitMQCtl do
   end
   def main(unparsed_command) do
     {command, command_name, arguments, parsed_options, invalid} = parse(unparsed_command)
-
     case {command, invalid} do
       {:no_command, _} ->
         usage_string = HelpCommand.all_usage()
         {:error, ExitCodes.exit_usage, usage_string};
+      {{:suggest, suggested}, _} ->
+        suggest_message = "Command '#{command_name}' not found."<>
+                          " Did you mean '#{suggested}'?"
+        {:error, ExitCodes.exit_usage, suggest_message};
       {_, [_|_]} ->
         validation_error({:bad_option, invalid}, command_name, unparsed_command);
       _ ->
@@ -224,10 +227,6 @@ defmodule RabbitMQCtl do
     Enum.join([header | for {key, val} <- opts do "#{key} : #{val}" end], "\n")
   end
   defp format_validation_error(err, _), do: inspect err
-
-  defp command_flags(command) do
-    apply_if_exported(command, :switches, [], []) |> Keyword.keys
-  end
 
   defp exit_program(code) do
     :net_kernel.stop

--- a/mix.exs
+++ b/mix.exs
@@ -64,7 +64,8 @@ defmodule RabbitMQCtl.MixfileBase do
                     RabbitMQ.CLI.Custom.Commands.RavenCommand,
                     RabbitMQ.CLI.Seagull.Commands.SeagullCommand,
                     RabbitMQ.CLI.Seagull.Commands.PacificGullCommand,
-                    RabbitMQ.CLI.Seagull.Commands.HerringGullCommand]
+                    RabbitMQ.CLI.Seagull.Commands.HerringGullCommand,
+                    RabbitMQ.CLI.Seagull.Commands.HermannGullCommand]
     [{:modules, mods ++ test_modules |> Enum.sort} | app]
   end
   defp add_modules(app, _) do

--- a/mix.exs
+++ b/mix.exs
@@ -110,16 +110,10 @@ defmodule RabbitMQCtl.MixfileBase do
         compile: make,
         override: true
       },
-      {
-        :amqp, "~> 0.1.5",
-        only: :test
-      },
-      {
-        :json, "~> 1.0.0"
-      },
-      {
-        :csv, "~> 1.4.2"
-      }
+      {:amqp, "~> 0.1.5", only: :test},
+      {:json, "~> 1.0.0"},
+      {:csv, "~> 1.4.2"},
+      {:simetric, "~> 0.1.0"}
     ]
   end
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -271,31 +271,31 @@ defmodule ParserTest do
   end
 
   test "parse/1 suggests similar command" do
-    ## One letter differ
+    # One letter difference
     assert @subject.parse(["pacific_gulf"]) ==
       {{:suggest, "pacific_gull"}, "pacific_gulf", [], %{}, []}
 
-    ## One letter missing
+    # One letter missing
     assert @subject.parse(["pacific_gul"]) ==
       {{:suggest, "pacific_gull"}, "pacific_gul", [], %{}, []}
 
-    ## One letter added
+    # One letter extra
     assert @subject.parse(["pacific_gulll"]) ==
       {{:suggest, "pacific_gull"}, "pacific_gulll", [], %{}, []}
 
-    ## Five letters differ
+    # Five letter difference
     assert @subject.parse(["pacifistcatl"]) ==
       {{:suggest, "pacific_gull"}, "pacifistcatl", [], %{}, []}
 
-    ## Five letters missing
+    # Five letters missing
     assert @subject.parse(["pacific"]) ==
       {{:suggest, "pacific_gull"}, "pacific", [], %{}, []}
 
-    ## Closest from similar
+    # Closest to similar
     assert @subject.parse(["herrdog_gull"]) ==
       {{:suggest, "herring_gull"}, "herrdog_gull", [], %{}, []}
 
-    ## Closest from similar
+    # Closest to similar
     assert @subject.parse(["hermaug_gull"]) ==
       {{:suggest, "hermann_gull"}, "hermaug_gull", [], %{}, []}
   end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -34,8 +34,16 @@ defmodule RabbitMQ.CLI.Seagull.Commands.PacificGullCommand do
   def merge_defaults(_,_), do: {[], %{}}
   def banner(_,_), do: ""
   def run(_,_), do: :ok
-  def switches(), do: []
-  def aliases(), do: []
+end
+
+defmodule RabbitMQ.CLI.Seagull.Commands.HermannGullCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+  use RabbitMQ.CLI.DefaultOutput
+  def usage(), do: ["hermann_gull"]
+  def validate(_,_), do: :ok
+  def merge_defaults(_,_), do: {[], %{}}
+  def banner(_,_), do: ""
+  def run(_,_), do: :ok
 end
 
 defmodule ParserTest do
@@ -260,6 +268,36 @@ defmodule ParserTest do
       {pacific_gull, "pacific_gull", ["fly", "atlantic"],
        %{vhost: "my_vhost"},
        [{"--herring", nil}]}
+  end
+
+  test "parse/1 suggests similar command" do
+    ## One letter differ
+    assert @subject.parse(["pacific_gulf"]) ==
+      {{:suggest, "pacific_gull"}, "pacific_gulf", [], %{}, []}
+
+    ## One letter missing
+    assert @subject.parse(["pacific_gul"]) ==
+      {{:suggest, "pacific_gull"}, "pacific_gul", [], %{}, []}
+
+    ## One letter added
+    assert @subject.parse(["pacific_gulll"]) ==
+      {{:suggest, "pacific_gull"}, "pacific_gulll", [], %{}, []}
+
+    ## Five letters differ
+    assert @subject.parse(["pacifistcatl"]) ==
+      {{:suggest, "pacific_gull"}, "pacifistcatl", [], %{}, []}
+
+    ## Five letters missing
+    assert @subject.parse(["pacific"]) ==
+      {{:suggest, "pacific_gull"}, "pacific", [], %{}, []}
+
+    ## Closest from similar
+    assert @subject.parse(["herrdog_gull"]) ==
+      {{:suggest, "herring_gull"}, "herrdog_gull", [], %{}, []}
+
+    ## Closest from similar
+    assert @subject.parse(["hermaug_gull"]) ==
+      {{:suggest, "hermann_gull"}, "hermaug_gull", [], %{}, []}
   end
 
 end


### PR DESCRIPTION
Fixes #135 

If command name is not found, finds a command with Levenshtein distance less or equal to 5 and show a suggestion message.