### PR TITLE
rabbitmq-plugins: Support enable/disable --all

### DIFF
--- a/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -24,14 +24,19 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Plugins
 
   def merge_defaults(args, opts) do
-    {args, Map.merge(%{online: false, offline: false}, opts)}
+    {args, Map.merge(%{online: false, offline: false, all: false}, opts)}
   end
 
   def switches(), do: [online: :boolean,
-                       offline: :boolean]
+                       offline: :boolean,
+                       all: :boolean]
 
-  def validate([], _) do
+  def validate([], %{all: false}) do
     {:validation_failure, :not_enough_arguments}
+  end
+  def validate([_ | _], %{all: true}) do
+    {:validation_failure,
+      {:bad_argument, "Cannot set both --all and a list of plugins"}}
   end
   def validate(_, %{online: true, offline: true}) do
     {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}
@@ -54,15 +59,21 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
     {:validation_failure, err}
   end
 
-  def usage, do: "disable [<plugin>] [--offline] [--online]"
+  def usage, do: "disable <plugin>|--all [--offline] [--online]"
 
+  def banner([], %{all: true, node: node_name}) do
+    "Disabling ALL plugins on node #{node_name}"
+  end
   def banner(plugins, %{node: node_name}) do
     ["Disabling plugins on node #{node_name}:" | plugins]
   end
 
 
-  def run(plugin_names, %{node: node_name} = opts) do
-    plugins = for s <- plugin_names, do: String.to_atom(s)
+  def run(plugin_names, %{all: all_flag, node: node_name} = opts) do
+    plugins = case all_flag do
+      false -> for s <- plugin_names, do: String.to_atom(s);
+      true  -> PluginHelpers.plugin_names(PluginHelpers.list(opts))
+    end
     %{online: online, offline: offline} = opts
 
     enabled = PluginHelpers.read_enabled(opts)

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -24,14 +24,19 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Plugins
 
   def merge_defaults(args, opts) do
-    {args, Map.merge(%{online: false, offline: false}, opts)}
+    {args, Map.merge(%{online: false, offline: false, all: false}, opts)}
   end
 
   def switches(), do: [online: :boolean,
-                       offline: :boolean]
+                       offline: :boolean,
+                       all: :boolean]
 
-  def validate([], _) do
+  def validate([], %{all: false}) do
     {:validation_failure, :not_enough_arguments}
+  end
+  def validate([_ | _], %{all: true}) do
+    {:validation_failure,
+      {:bad_argument, "Cannot set both --all and a list of plugins"}}
   end
   def validate(_, %{online: true, offline: true}) do
     {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}
@@ -54,15 +59,21 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
     {:validation_failure, err}
   end
 
-  def usage, do: "enable [<plugin>] [--offline] [--online]"
+  def usage, do: "enable <plugin>|--all [--offline] [--online]"
 
+  def banner([], %{all: true, node: node_name}) do
+    "Enabling ALL plugins on node #{node_name}"
+  end
   def banner(plugins, %{node: node_name}) do
     ["Enabling plugins on node #{node_name}:" | plugins]
   end
 
 
-  def run(plugin_names, %{node: node_name} = opts) do
-    plugins = for s <- plugin_names, do: String.to_atom(s)
+  def run(plugin_names, %{all: all_flag, node: node_name} = opts) do
+    plugins = case all_flag do
+      false -> for s <- plugin_names, do: String.to_atom(s);
+      true  -> PluginHelpers.plugin_names(PluginHelpers.list(opts))
+    end
     %{online: online, offline: offline} = opts
 
     enabled = PluginHelpers.read_enabled(opts)

--- a/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -76,7 +76,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
     all     = PluginHelpers.list(opts)
     enabled = PluginHelpers.read_enabled(opts)
 
-    case MapSet.difference(MapSet.new(enabled), MapSet.new(plugin_names(all))) do
+    case MapSet.difference(MapSet.new(enabled), MapSet.new(PluginHelpers.plugin_names(all))) do
         %MapSet{} -> :ok;
         missing   -> IO.puts("WARNING - plugins currently enabled but missing: #{missing}~n~n")
     end
@@ -153,10 +153,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
     normal = format_plugin(plugin, :normal, enabled, enabled_implicitly, running)
     plugin(dependencies: dependencies, description: description) = plugin
     Map.merge(normal, %{dependencies: dependencies, description: description})
-  end
-
-  defp plugin_names(plugins) do
-    for plugin <- plugins, do: PluginHelpers.plugin_name(plugin)
   end
 
   defp default_opts() do

--- a/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -75,6 +75,10 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     name
   end
 
+  def plugin_names(plugins) do
+    for plugin <- plugins, do: plugin_name(plugin)
+  end
+
   defp to_list(str) when is_binary(str) do
     :erlang.binary_to_list(str)
   end


### PR DESCRIPTION
As the new flag suggests, it allows to enable or disable all plugins at once.

This is at least useful to simplify `mk/rabbitmq-run.mk` in rabbitmq-common.

[#136769947]