### PR TITLE
Makefile, mix.exs: Reduce build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ $(HOME)/.mix/archives/hex-*:
 hex: $(HOME)/.mix/archives/hex-*
 
 deps:: hex
-	$(verbose) mix make_deps
 
 app:: $(ESCRIPTS)
 	@:
@@ -40,6 +39,10 @@ app:: $(ESCRIPTS)
 rabbitmqctl_srcs := mix.exs \
 		    $(shell find config lib -name "*.ex" -o -name "*.exs")
 
+# Elixir dependencies are fetched and compiled as part of the alias
+# `mix make_all`. We do not fetch and build them in `make deps` because
+# mix(1) startup time is quite high. Thus we prefer to run it once, even
+# though it kind of breaks the Erlang.mk model.
 escript/rabbitmqctl: $(rabbitmqctl_srcs) deps
 	$(gen_verbose) mix make_all
 

--- a/mix.exs
+++ b/mix.exs
@@ -85,29 +85,20 @@ defmodule RabbitMQCtl.MixfileBase do
   #
   # Type "mix help deps" for more examples and options
   defp deps(deps_dir) do
-    # RabbitMQ components (rabbit_common and amqp_client) require GNU
-    # Make. This ensures that GNU Make is available before we attempt
-    # to use it.
-    make = find_gnu_make()
-
     [
-      # {
-      #   :rabbit,
-      #   path: Path.join(deps_dir, "rabbit"),
-      #   compile: make,
-      #   override: true
-      # },
+      # We use `true` as the command to "build" rabbit_common and
+      # amqp_client because Erlang.mk already built them.
       {
         :rabbit_common,
         path: Path.join(deps_dir, "rabbit_common"),
-        compile: make,
+        compile: "true",
         override: true
       },
       {
         :amqp_client,
         only: :test,
         path: Path.join(deps_dir, "amqp_client"),
-        compile: make,
+        compile: "true",
         override: true
       },
       {:amqp, "~> 0.1.5", only: :test},
@@ -123,34 +114,16 @@ defmodule RabbitMQCtl.MixfileBase do
         "deps.get",
         "deps.compile",
       ],
-      make_all: [
+      make_app: [
         "compile",
         "escript.build",
-      ]
+      ],
+      make_all: [
+        "deps.get",
+        "deps.compile",
+        "compile",
+        "escript.build",
+      ],
     ]
   end
-
-  defp find_gnu_make do
-    possible_makes = [
-      System.get_env("MAKE"),
-      "gmake",
-      "make",
-    ]
-    test_gnu_make(possible_makes)
-  end
-
-  defp test_gnu_make([nil | rest]) do
-    test_gnu_make(rest)
-  end
-  defp test_gnu_make([make | rest]) do
-    {output, _} = System.cmd(make, ["--version"], stderr_to_stdout: true)
-    case String.contains?(output, "GNU Make") do
-      true  -> make
-      false -> test_gnu_make(rest)
-    end
-  end
-  defp test_gnu_make([]) do
-    nil
-  end
-
 end


### PR DESCRIPTION
First, run mix(1) once from the Makefile. We use an mix alias to call all actual mix commands in a single run. Now `make app` takes care of calling the equivalent of `deps.get`, `deps.compile`, `compile` and
`escript.build`. It doesn't match the expected Erlang.mk behavior but it saves us from starting mix(1) multiple times.

Second, only build Erlang dependencies (rabbit_common and amqp_client) once from the Makefile (through Erlang.mk dependency mechanism). In `mix.exs`, their compile command is set to `true` because they are already up-to-date. This saves two no-op builds of those dependencies.

On my laptop, this reduces the no-op build from 10 seconds to 5 seconds.