### PR TITLE
Support command aliases

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -73,14 +73,14 @@ CLI core consists of several modules implementing command execution process:
 
  Arguments are then validated using the `validate/2` callback
 
-##### Command aliases
+##### Command Aliases
 
-  You can define aliases for commands using an aliases file. The file name can be
-  specified using `RABBITMQCTL_ALIASES` environment variable or `--aliases-file`
-  argument.
+ It is possible to define aliases for commands using an aliases file. The file name can be
+ specified using `RABBITMQ_CLI_ALIASES_FILE` environment variable or the `--aliases-file`
+ command lineargument.
 
-  Aliases can be specified using `alias = command [options]` format.
-  For example:
+ Aliases can be specified using `alias = command [options]` format.
+ For example:
 
 ```
 lq = list_queues
@@ -439,5 +439,5 @@ By default it will be loaded from environment variables, same as used in rabbitm
 | enabled_plugins_file | RABBITMQ_ENABLED_PLUGINS_FILE |
 | longnames            | RABBITMQ_USE_LONGNAME         |
 | node                 | RABBITMQ_NODENAME             |
-| aliases-file         | RABBITMQCTL_ALIASES           |
+| aliases_file         | RABBITMQ_CLI_ALIASES_FILE     |
 

--- a/lib/rabbitmq/cli/core/config.ex
+++ b/lib/rabbitmq/cli/core/config.ex
@@ -44,7 +44,7 @@ defmodule RabbitMQ.CLI.Core.Config do
       :plugins_dir          -> "RABBITMQ_PLUGINS_DIR";
       :enabled_plugins_file -> "RABBITMQ_ENABLED_PLUGINS_FILE";
       :node                 -> "RABBITMQ_NODENAME";
-      :aliases_file         -> "RABBITMQCTL_ALIASES"
+      :aliases_file         -> "RABBITMQ_CLI_ALIASES_FILE"
       _ -> ""
     end
     System.get_env(system_env_option)

--- a/lib/rabbitmq/cli/core/config.ex
+++ b/lib/rabbitmq/cli/core/config.ex
@@ -44,6 +44,7 @@ defmodule RabbitMQ.CLI.Core.Config do
       :plugins_dir          -> "RABBITMQ_PLUGINS_DIR";
       :enabled_plugins_file -> "RABBITMQ_ENABLED_PLUGINS_FILE";
       :node                 -> "RABBITMQ_NODENAME";
+      :aliases_file         -> "RABBITMQCTL_ALIASES"
       _ -> ""
     end
     System.get_env(system_env_option)

--- a/test/eval_command_test.exs
+++ b/test/eval_command_test.exs
@@ -80,13 +80,13 @@ defmodule EvalCommandTest do
     end) == "output"
   end
 
-  test "run: passes parameters to the expression as numbered variables", context do
+  test "run: passes parameters to the expression as positional/numerical variables", context do
     assert @command.run(["binary_to_atom(_1, utf8).", "foo"], context[:opts]) == {:ok, :foo}
     assert @command.run(["{_1, _2}.", "foo", "bar"], context[:opts]) == {:ok, {"foo", "bar"}}
   end
 
-  test "run: passes global options as named variables", context do
-    assert @command.run(["{_vhost, _node}."], Map.put(context[:opts], :vhost, "foo")) ==
-      {:ok, {"foo", context[:opts][:node]}}
+  test "run: passes globally recognised options as named variables", context do
+    assert @command.run(["{_vhost, _node}."], Map.put(context[:opts], :vhost, "a-node")) ==
+      {:ok, {"a-node", context[:opts][:node]}}
   end
 end


### PR DESCRIPTION
Fixes #10 
Aliases will be loaded from the alias file.
Alias file format
```
alias = command [options]
```
See DESIGN.md for more information.

Extended `eval` command to accept positional arguments. They will be bound to: `_1`, `_2` ...
Named options like vhost will be bound to named variables `_vhost`, `_node` ...
