### PR TITLE
Make it possible to specify erlang cookie from command line

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -231,13 +231,14 @@ be shown in usage and available for execution.
 
 #### Environment Arguments
 
- * script_name: atom, configurable tool name (`rabbitmq-plugins`, `rabbitmqctl`) to select command scope (see [Command scopes](#command-scopes))
- * rabbitmq_home: string, broker install directory
- * mnesia_dir: string, broker mnesia data directory
- * plugins_dir: string, broker plugins directory
- * enabled_plugins_file: string, broker enabled plugins file
+ * script-name: atom, configurable tool name (`rabbitmq-plugins`, `rabbitmqctl`) to select command scope (see [Command scopes](#command-scopes))
+ * rabbitmq-home: string, broker install directory
+ * mnesia-dir: string, broker mnesia data directory
+ * plugins-dir: string, broker plugins directory
+ * enabled-plugins-file: string, broker enabled plugins file
  * longnames (l): boolean, use longnames to communicate with broker erlang node. Should be set to `true` only if broker is started with longnames.
  * aliases-file: string, a file name to load aliases from
+ * erlang-cookie: atom, an [erlang distribution cookie](http://erlang.org/doc/reference_manual/distributed.html)
 
 Environment argument defaults are loaded from rabbitmq environment variables (see [Environment configuration](#environment-configuration)).
 
@@ -469,11 +470,12 @@ By default it will be loaded from environment variables, same as used in rabbitm
 
 | Argument name        | Environment variable          |
 |----------------------|-------------------------------|
-| rabbitmq_home        | RABBITMQ_HOME                 |
-| mnesia_dir           | RABBITMQ_MNESIA_DIR           |
-| plugins_dir          | RABBITMQ_PLUGINS_DIR          |
-| enabled_plugins_file | RABBITMQ_ENABLED_PLUGINS_FILE |
+| rabbitmq-home        | RABBITMQ_HOME                 |
+| mnesia-dir           | RABBITMQ_MNESIA_DIR           |
+| plugins-dir          | RABBITMQ_PLUGINS_DIR          |
+| enabled-plugins-file | RABBITMQ_ENABLED_PLUGINS_FILE |
 | longnames            | RABBITMQ_USE_LONGNAME         |
 | node                 | RABBITMQ_NODENAME             |
-| aliases_file         | RABBITMQ_CLI_ALIASES_FILE     |
+| aliases-file         | RABBITMQ_CLI_ALIASES_FILE     |
+| erlang-cookie        | RABBITMQ_ERLANG_COOKIE        |
 

--- a/lib/rabbitmq/cli/core/config.ex
+++ b/lib/rabbitmq/cli/core/config.ex
@@ -22,8 +22,13 @@ defmodule RabbitMQ.CLI.Core.Config do
     normalize(name, raw_option)
   end
 
+  def normalize(:node, nil), do: nil
   def normalize(:node, node) when not is_atom(node) do
     Rabbitmq.Atom.Coerce.to_atom(node)
+  end
+  def normalize(:erlang_cookie, nil), do: nil
+  def normalize(:erlang_cookie, c) when not is_atom(c) do
+    Rabbitmq.Atom.Coerce.to_atom(c)
   end
   def normalize(:longnames, true),   do: :longnames
   def normalize(:longnames, "true"), do: :longnames
@@ -44,7 +49,8 @@ defmodule RabbitMQ.CLI.Core.Config do
       :plugins_dir          -> "RABBITMQ_PLUGINS_DIR";
       :enabled_plugins_file -> "RABBITMQ_ENABLED_PLUGINS_FILE";
       :node                 -> "RABBITMQ_NODENAME";
-      :aliases_file         -> "RABBITMQ_CLI_ALIASES_FILE"
+      :aliases_file         -> "RABBITMQ_CLI_ALIASES_FILE";
+      :erlang_cookie        -> "RABBITMQ_ERLANG_COOKIE";
       _ -> ""
     end
     System.get_env(system_env_option)

--- a/lib/rabbitmq/cli/core/distribution.ex
+++ b/lib/rabbitmq/cli/core/distribution.ex
@@ -27,13 +27,24 @@ defmodule RabbitMQ.CLI.Core.Distribution do
   def start(options) do
     node_name_type = Config.get_option(:longnames, options)
     :rabbit_nodes.ensure_epmd()
-    start(node_name_type, 10, :undefined)
+    distribution = start(node_name_type, 10, :undefined)
+    ensure_cookie(options)
+    distribution
   end
 
-  def start_as(node_name, opts) do
+  def start_as(node_name, options) do
     :rabbit_nodes.ensure_epmd()
-    node_name_type = Config.get_option(:longnames, opts)
-    :net_kernel.start([node_name, node_name_type])
+    node_name_type = Config.get_option(:longnames, options)
+    distribution = :net_kernel.start([node_name, node_name_type])
+    ensure_cookie(options)
+    distribution
+  end
+
+  def ensure_cookie(options) do
+    case Config.get_option(:erlang_cookie, options) do
+      nil    -> :ok;
+      cookie -> Node.set_cookie(cookie)
+    end
   end
 
   #

--- a/lib/rabbitmq/cli/core/distribution.ex
+++ b/lib/rabbitmq/cli/core/distribution.ex
@@ -27,23 +27,24 @@ defmodule RabbitMQ.CLI.Core.Distribution do
   def start(options) do
     node_name_type = Config.get_option(:longnames, options)
     :rabbit_nodes.ensure_epmd()
-    distribution = start(node_name_type, 10, :undefined)
+    result = start(node_name_type, 10, :undefined)
     ensure_cookie(options)
-    distribution
+    result
   end
 
   def start_as(node_name, options) do
     :rabbit_nodes.ensure_epmd()
     node_name_type = Config.get_option(:longnames, options)
-    distribution = :net_kernel.start([node_name, node_name_type])
+    result = :net_kernel.start([node_name, node_name_type])
     ensure_cookie(options)
-    distribution
+    result
   end
 
   def ensure_cookie(options) do
     case Config.get_option(:erlang_cookie, options) do
       nil    -> :ok;
       cookie -> Node.set_cookie(cookie)
+                :ok
     end
   end
 

--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -170,7 +170,8 @@ defmodule RabbitMQ.CLI.Core.Parser do
      mnesia_dir: :string,
      plugins_dir: :string,
      enabled_plugins_file: :string,
-     aliases_file: :string
+     aliases_file: :string,
+     erlang_cookie: :atom
     ]
   end
 

--- a/test/distribution_test.exs
+++ b/test/distribution_test.exs
@@ -1,0 +1,48 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+
+alias RabbitMQ.CLI.Core.Distribution, as: Distribution
+
+defmodule DostributionTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  setup_all do
+    :net_kernel.stop()
+    :ok
+  end
+
+  test "set cookie via environment variable" do
+    on_exit(fn ->
+      :net_kernel.stop()
+      System.delete_env("RABBITMQ_ERLANG_COOKIE")
+    end)
+    :nocookie = Node.get_cookie()
+    System.put_env("RABBITMQ_ERLANG_COOKIE", "mycookie")
+    opts = %{}
+    Distribution.start(opts)
+    :mycookie = Node.get_cookie()
+  end
+
+  test "set cookie via argument" do
+    on_exit(fn ->
+      :net_kernel.stop()
+    end)
+    :nocookie = Node.get_cookie()
+    opts = %{erlang_cookie: :mycookie}
+    Distribution.start(opts)
+    :mycookie = Node.get_cookie()
+  end
+end

--- a/test/rabbitmqctl_test.exs
+++ b/test/rabbitmqctl_test.exs
@@ -27,9 +27,7 @@ defmodule RabbitMQCtlTest do
     set_scope(:all)
     on_exit([], fn ->
       :erlang.disconnect_node(get_rabbit_hostname())
-
     end)
-
     :ok
   end
 


### PR DESCRIPTION
Fixes #180 

Add new flag `--erlang-cookie` and environment variable `RABBITMQ_ERLANG_COOKIE`
to configure a cookie for CLI to connect to RabbitMQ node.