### PR TITLE
Implement the shutdown command (recently introduced in 3.6.x)

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/set_disk_free_limit_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_disk_free_limit_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetDiskFreeLimitCommand do
-  import RabbitMQ.CLI.Core.Helpers, only: [memory_unit_absolute: 2]
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
@@ -37,7 +37,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetDiskFreeLimitCommand do
     case Integer.parse(limit) do
       {_, ""} -> :ok
       {limit_val, units} ->
-        case memory_unit_absolute(limit_val, units) do
+        case Helpers.memory_unit_absolute(limit_val, units) do
           scaled_limit when is_integer(scaled_limit) -> :ok
           _ -> {:validation_failure, :bad_argument}
         end
@@ -101,7 +101,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetDiskFreeLimitCommand do
   end
 
   defp set_disk_free_limit_in_units([limit_val, units], opts) do
-    case memory_unit_absolute(limit_val, units) do
+    case Helpers.memory_unit_absolute(limit_val, units) do
       scaled_limit when is_integer(scaled_limit) ->
         set_disk_free_limit_absolute([scaled_limit], opts)
     end

--- a/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
@@ -1,0 +1,58 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule RabbitMQ.CLI.Ctl.Commands.ShutdownCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+  use RabbitMQ.CLI.DefaultOutput
+  alias RabbitMQ.CLI.Core.OsPid, as: OsPid
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.ErlangString
+
+  def merge_defaults(args, opts), do: {args, opts}
+
+  def validate([], _), do: :ok
+  def validate([_|_], _), do: {:validation_failure, :too_many_args}
+
+  def run([], %{node: node_name}) do
+    case :rabbit_misc.rpc_call(node_name, :os, :getpid, []) do
+      pid when is_list(pid) ->
+        shutdown_node_and_wait_pid_to_stop(node_name, pid)
+      other -> other
+    end
+  end
+
+  def shutdown_node_and_wait_pid_to_stop(node_name, pid) do
+    {:stream,
+      RabbitMQ.CLI.Core.Helpers.stream_until_error([
+        fn() -> "Shutting down RabbitMQ node #{node_name} running at PID #{pid}" end,
+        fn() ->
+          res = :rabbit_misc.rpc_call(node_name, :rabbit, :stop_and_halt, [])
+          case res do
+            :ok               -> "Waiting for PID #{pid} to terminate";
+            {:badrpc, err}    -> {:error, err}
+            {:error, _} = err -> err
+          end
+        end,
+        fn() ->
+          OsPid.wait_for_os_process_death(pid)
+          "RabbitMQ node #{node_name} running at PID #{pid} successfully shut down"
+        end])}
+  end
+
+  def usage, do: "shutdown"
+
+  def banner(_, _), do: nil
+end

--- a/lib/rabbitmq/cli/ctl/commands/stop_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/stop_command.ex
@@ -23,7 +23,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StopCommand do
 
   def validate([], _), do: :ok
   def validate([_pidfile_path], _), do: :ok
-  def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
+  def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
 
   def run([], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit, :stop_and_halt, [])
@@ -44,7 +44,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StopCommand do
 
   end
 
-  def usage, do: "stop"
+  def usage, do: "stop [<pidfile>]"
 
   def banner([pidfile_path], %{node: node_name}) do
     "Stopping and halting node #{node_name} (will monitor pid file #{pidfile_path}) ..."

--- a/lib/rabbitmq/cli/formatters/erlang_string.ex
+++ b/lib/rabbitmq/cli/formatters/erlang_string.ex
@@ -17,7 +17,6 @@
 # to format values instead of "~p~".
 defmodule RabbitMQ.CLI.Formatters.ErlangString do
   @behaviour RabbitMQ.CLI.FormatterBehaviour
-  alias RabbitMQ.CLI.Formatters.Erlang, as: E
 
   def format_output(output, _) do
     :io_lib.format("~s", [output])

--- a/lib/rabbitmq/cli/formatters/erlang_string.ex
+++ b/lib/rabbitmq/cli/formatters/erlang_string.ex
@@ -25,6 +25,9 @@ defmodule RabbitMQ.CLI.Formatters.ErlangString do
   end
 
   def format_stream(stream, options) do
-    E.format_stream(stream, options)
+    Stream.map(stream,
+      fn({:error, msg}) -> {:error, msg};
+        (element) -> format_output(element, options)
+      end)
   end
 end

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -21,8 +21,8 @@ defmodule RabbitMQCtl do
   alias RabbitMQ.CLI.Core.Output, as: Output
   alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
 
-  import RabbitMQ.CLI.Core.Helpers
-  import  RabbitMQ.CLI.Core.Parser
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Parser, as: Parser
 
   @type options() :: Map.t
   @type command_result() :: {:error, ExitCodes.exit_code, term()} | term()
@@ -47,7 +47,8 @@ defmodule RabbitMQCtl do
   end
 
   def exec_command(unparsed_command, output_fun) do
-    {command, command_name, arguments, parsed_options, invalid} = parse(unparsed_command)
+    {command, command_name, arguments, parsed_options, invalid} =
+      Parser.parse(unparsed_command)
     case {command, invalid} do
       {:no_command, _} ->
         command_not_found_string = case command_name do
@@ -108,7 +109,9 @@ defmodule RabbitMQCtl do
     |> merge_defaults_longnames
   end
 
-  defp merge_defaults_node(%{} = opts), do: Map.merge(%{node: get_rabbit_hostname()}, opts)
+  defp merge_defaults_node(%{} = opts) do
+    Map.merge(%{node: Helpers.get_rabbit_hostname()}, opts)
+  end
 
   defp merge_defaults_timeout(%{} = opts), do: Map.merge(%{timeout: :infinity}, opts)
 
@@ -121,7 +124,7 @@ defmodule RabbitMQCtl do
   end
 
   defp normalize_node(%{node: node} = opts) do
-    Map.merge(opts, %{node: parse_node(node)})
+    Map.merge(opts, %{node: Helpers.parse_node(node)})
   end
 
   defp normalize_timeout(%{timeout: timeout} = opts)
@@ -135,7 +138,7 @@ defmodule RabbitMQCtl do
 
   defp maybe_connect_to_rabbitmq(HelpCommand, _), do: nil
   defp maybe_connect_to_rabbitmq(_, node) do
-    connect_to_rabbitmq(node)
+    Helpers.connect_to_rabbitmq(node)
   end
 
   defp execute_command(options, command, arguments) do

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -85,8 +85,9 @@ defmodule RabbitMQCtl do
       true  -> :stdio;
       false -> :stderr
     end
+
     for line <- List.flatten([output]) do
-      IO.puts(output_device, line)
+      IO.puts(output_device, Helpers.string_or_inspect(line))
     end
     exit_program(exit_code)
   end

--- a/test/shutdown_command_test.exs
+++ b/test/shutdown_command_test.exs
@@ -1,0 +1,59 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule ShutdownCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Ctl.Commands.ShutdownCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+    :net_kernel.connect_node(get_rabbit_hostname())
+
+    on_exit([], fn ->
+      :erlang.disconnect_node(get_rabbit_hostname())
+
+    end)
+
+    :ok
+  end
+
+  setup do
+    {:ok, opts: %{node: get_rabbit_hostname()}}
+  end
+
+  test "validate accepts no arguments", context do
+    assert @command.validate([], context[:opts]) == :ok
+  end
+
+  test "validate: with extra arguments returns an arg count error", context do
+    assert @command.validate(["extra"], context[:opts]) == {:validation_failure, :too_many_args}
+  end
+
+  # TODO: we don't have integration tests yet.
+
+  test "run: request to a non-existent node returns nodedown" do
+    target = :jake@thedog
+    :net_kernel.connect_node(target)
+    opts = %{node: target}
+    assert match?({:badrpc, :nodedown}, @command.run([], opts))
+  end
+
+  test "empty banner", context do
+    nil = @command.banner([], context[:opts])
+  end
+end


### PR DESCRIPTION
Fixes #181 
Implemented `shutdown` command.
Fixed help message for `stop` command.
Added stream helpers.

`erlang_string` formatter now prints streams of lines without formatting.
