### PR TITLE
Do not try to connect to the RabbitMQ node before executing command

### DIFF
--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -37,14 +37,6 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     end
   end
 
-  def connect_to_rabbitmq, do:        :net_kernel.connect_node(get_rabbit_hostname())
-  def connect_to_rabbitmq(input) when is_atom(input), do: :net_kernel.connect_node(input)
-  def connect_to_rabbitmq(input) when is_binary(input) do
-    input
-    |> String.to_atom
-    |> :net_kernel.connect_node
-  end
-
   def hostname, do: :inet.gethostname() |> elem(1) |> List.to_string
 
   def validate_step(:ok, step) do

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -153,18 +153,11 @@ defmodule RabbitMQCtl do
     opts
   end
 
-
-  defp maybe_connect_to_rabbitmq(HelpCommand, _), do: nil
-  defp maybe_connect_to_rabbitmq(_, node) do
-    Helpers.connect_to_rabbitmq(node)
-  end
-
   defp execute_command(options, command, arguments) do
     {arguments, options} = command.merge_defaults(arguments, options)
     case command.validate(arguments, options) do
       :ok ->
         maybe_print_banner(command, arguments, options)
-        maybe_connect_to_rabbitmq(command, options[:node])
         maybe_run_command(command, arguments, options)
       {:validation_failure, _} = err -> err
     end

--- a/test/add_user_command_test.exs
+++ b/test/add_user_command_test.exs
@@ -22,12 +22,6 @@ defmodule AddUserCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
-
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -56,7 +50,7 @@ defmodule AddUserCommandTest do
   @tag user: "someone", password: "password"
   test "run: request to a non-existent node returns nodedown", context do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert match?({:badrpc, :nodedown}, @command.run([context[:user], context[:password]], opts))
   end

--- a/test/add_vhost_command_test.exs
+++ b/test/add_vhost_command_test.exs
@@ -23,12 +23,7 @@ defmodule AddVhostCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     {:ok, opts: %{node: get_rabbit_hostname()}}
   end
@@ -57,7 +52,7 @@ defmodule AddVhostCommandTest do
 
   test "run: A call to invalid or inactive RabbitMQ node returns a nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert @command.run(["na"], opts) == {:badrpc, :nodedown}
   end

--- a/test/args_processing_test.exs
+++ b/test/args_processing_test.exs
@@ -36,11 +36,6 @@ defmodule ArgsProcessingTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
     :ok
   end
 
@@ -49,7 +44,7 @@ defmodule ArgsProcessingTest do
     {:ok, opts: %{node: get_rabbit_hostname(), timeout: 50_000, vhost: "/"}}
   end
 
-  test "merge defaults does not fail because of args", context do
+  test "merge defaults does not fail because of args", _context do
     commands = all_commands()
     Enum.each(commands,
       fn(command) ->

--- a/test/authenticate_user_command_test.exs
+++ b/test/authenticate_user_command_test.exs
@@ -24,12 +24,7 @@ defmodule AuthenticateUserCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -57,7 +52,7 @@ defmodule AuthenticateUserCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert @command.run(["user", "password"], opts) == {:badrpc, :nodedown}
   end

--- a/test/cancel_sync_command_test.exs
+++ b/test/cancel_sync_command_test.exs
@@ -23,13 +23,13 @@ defmodule CancelSyncQueueCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     start_rabbitmq_app()
 
     on_exit([], fn ->
       start_rabbitmq_app()
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -64,7 +64,7 @@ defmodule CancelSyncQueueCommandTest do
 
   test "run: request to a non-existent RabbitMQ node returns a nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: @vhost}
     assert match?({:badrpc, :nodedown}, @command.run(["q1"], opts))
   end

--- a/test/change_cluster_node_type_command_test.exs
+++ b/test/change_cluster_node_type_command_test.exs
@@ -22,13 +22,13 @@ defmodule ChangeClusterNodeTypeCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     start_rabbitmq_app()
 
     on_exit([], fn ->
       start_rabbitmq_app()
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -76,7 +76,7 @@ defmodule ChangeClusterNodeTypeCommandTest do
 
   test "run: request to an unreachable node returns nodedown", _context do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{
       node: target
     }

--- a/test/change_password_command_test.exs
+++ b/test/change_password_command_test.exs
@@ -21,11 +21,9 @@ defmodule ChangePasswordCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-    end)
+
+
 
     :ok
   end
@@ -52,7 +50,7 @@ defmodule ChangePasswordCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert @command.run(["user", "password"], opts) == {:badrpc, :nodedown}
   end

--- a/test/clear_global_parameter_command_test.exs
+++ b/test/clear_global_parameter_command_test.exs
@@ -24,11 +24,9 @@ defmodule ClearGlobalParameterCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-    end)
+
+
 
     :ok
   end
@@ -62,7 +60,7 @@ defmodule ClearGlobalParameterCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert @command.run([@key], opts) == {:badrpc, :nodedown}
   end

--- a/test/clear_operator_policy_command_test.exs
+++ b/test/clear_operator_policy_command_test.exs
@@ -26,13 +26,13 @@ defmodule ClearOperatorPolicyCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -85,7 +85,7 @@ defmodule ClearOperatorPolicyCommandTest do
 
   test "run: an unreachable node throws a badrpc" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: "/"}
     assert @command.run([@key], opts) == {:badrpc, :nodedown}
   end

--- a/test/clear_parameter_command_test.exs
+++ b/test/clear_parameter_command_test.exs
@@ -27,7 +27,7 @@ defmodule ClearParameterCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
@@ -35,7 +35,7 @@ defmodule ClearParameterCommandTest do
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -83,7 +83,7 @@ defmodule ClearParameterCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: "/"}
     assert @command.run([@component_name, @key], opts) == {:badrpc, :nodedown}
   end

--- a/test/clear_password_command_test.exs
+++ b/test/clear_password_command_test.exs
@@ -21,12 +21,7 @@ defmodule ClearPasswordCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -52,7 +47,7 @@ defmodule ClearPasswordCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
 
     assert @command.run(["user"], opts) == {:badrpc, :nodedown}

--- a/test/clear_permissions_command_test.exs
+++ b/test/clear_permissions_command_test.exs
@@ -23,14 +23,14 @@ defmodule ClearPermissionsTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     add_user(@user, @password)
     add_vhost(@specific_vhost)
 
     on_exit([], fn ->
       delete_user(@user)
       delete_vhost(@specific_vhost)
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 

--- a/test/clear_policy_command_test.exs
+++ b/test/clear_policy_command_test.exs
@@ -26,7 +26,7 @@ defmodule ClearPolicyCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
@@ -34,7 +34,7 @@ defmodule ClearPolicyCommandTest do
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -87,7 +87,7 @@ defmodule ClearPolicyCommandTest do
 
   test "run: an unreachable node throws a badrpc" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: "/"}
     assert @command.run([@key], opts) == {:badrpc, :nodedown}
   end

--- a/test/clear_topic_permissions_command_test.exs
+++ b/test/clear_topic_permissions_command_test.exs
@@ -22,7 +22,7 @@ defmodule ClearTopicPermissionsTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     add_user(@user, @password)
     add_vhost(@specific_vhost)
 
@@ -30,7 +30,7 @@ defmodule ClearTopicPermissionsTest do
       clear_topic_permissions(@user, @specific_vhost)
       delete_user(@user)
       delete_vhost(@specific_vhost)
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 

--- a/test/clear_vhost_limits_command_test.exs
+++ b/test/clear_vhost_limits_command_test.exs
@@ -24,13 +24,13 @@ defmodule ClearVhostLimitsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
     end)
 
     :ok
@@ -69,7 +69,7 @@ defmodule ClearVhostLimitsCommandTest do
 
   test "run: an unreachable node throws a badrpc" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: "/"}
     assert @command.run([], opts) == {:badrpc, :nodedown}
   end

--- a/test/close_all_connections_command_test.exs
+++ b/test/close_all_connections_command_test.exs
@@ -28,12 +28,12 @@ defmodule CloseAllConnectionsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     close_all_connections(get_rabbit_hostname())
 
     on_exit([], fn ->
       close_all_connections(get_rabbit_hostname())
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -103,7 +103,7 @@ defmodule CloseAllConnectionsCommandTest do
 
   test "run: a close_all_connections request to non-existent RabbitMQ node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: @vhost, global: true, per_connection_delay: 0, limit: 0}
     assert match?({:badrpc, :nodedown}, @command.run(["test"], opts))
   end

--- a/test/close_connection_command_test.exs
+++ b/test/close_connection_command_test.exs
@@ -26,12 +26,12 @@ defmodule CloseConnectionCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     close_all_connections(get_rabbit_hostname())
 
     on_exit([], fn ->
       close_all_connections(get_rabbit_hostname())
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -68,7 +68,7 @@ defmodule CloseConnectionCommandTest do
 
   test "run: a close_connection request on nonexistent RabbitMQ node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert match?({:badrpc, :nodedown}, @command.run(["<rabbit@localhost.1.2.1>", "test"], opts))
   end

--- a/test/cluster_status_command_test.exs
+++ b/test/cluster_status_command_test.exs
@@ -22,12 +22,7 @@ defmodule ClusterStatusCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -48,7 +43,7 @@ defmodule ClusterStatusCommandTest do
 
   test "run: status request on nonexistent RabbitMQ node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
 
     assert @command.run([], opts) != nil

--- a/test/core/helpers_test.exs
+++ b/test/core/helpers_test.exs
@@ -29,39 +29,13 @@ defmodule HelpersTest do
     :ok
   end
 
-  setup context do
-    on_exit(context, fn -> :erlang.disconnect_node(context[:target]) end)
-    :ok
-  end
-
 ## --------------------- get_rabbit_hostname()/0 tests -------------------------
 
 test "RabbitMQ hostname is properly formed" do
     assert @subject.get_rabbit_hostname() |> Atom.to_string =~ ~r/rabbit@\w+/
   end
 
-## ------------------- connect_to_rabbitmq/0,1 tests --------------------
-
-  test "RabbitMQ default hostname connects" do
-    assert @subject.connect_to_rabbitmq() == true
-  end
-
-  @tag target: get_rabbit_hostname()
-  test "RabbitMQ specified hostname atom connects", context do
-    assert @subject.connect_to_rabbitmq(context[:target]) == true
-  end
-
-  @tag target: get_rabbit_hostname() |> Atom.to_string
-  test "RabbitMQ specified hostname string connects", context do
-    assert @subject.connect_to_rabbitmq(context[:target]) == true
-  end
-
-  @tag target: :jake@thedog
-  test "Invalid specified hostname atom doesn't connect", context do
-    assert @subject.connect_to_rabbitmq(context[:target]) == false
-  end
-
-  ## ------------------- memory_unit* tests --------------------
+## ------------------- memory_unit* tests --------------------
 
   test "an invalid memory unit fails " do
     assert @subject.memory_unit_absolute(10, "gigantibytes") == {:bad_argument, ["gigantibytes"]}

--- a/test/default_output_test.exs
+++ b/test/default_output_test.exs
@@ -16,7 +16,6 @@
 
 defmodule DefaultOutputTest do
   use ExUnit.Case, async: false
-  import RabbitMQ.CLI.Core.ExitCodes
 
   test "ok is passed as is" do
     assert match?(:ok, ExampleCommand.output(:ok, %{}))
@@ -40,7 +39,6 @@ defmodule DefaultOutputTest do
   end
 
   test "badrpc is an error" do
-    node = :example@node
     {:error, {:badrpc, :nodedown}} =
       ExampleCommand.output({:badrpc, :nodedown}, %{})
 
@@ -96,12 +94,12 @@ defmodule DefaultOutputTest do
     assert match?({:stream, [1,2,3]}, ExampleCommandWithCustomOutput.output([1,2,3], %{}))
 
     {:error, {:badrpc, :nodedown}} =
-      ExampleCommandWithCustomOutput.output({:badrpc, :nodedown}, %{node: node})
+      ExampleCommandWithCustomOutput.output({:badrpc, :nodedown}, %{})
     {:error, {:badrpc, :timeout}} =
       ExampleCommandWithCustomOutput.output({:badrpc, :timeout}, %{})
 
     error = %{i: [am: "arbitrary", error: 1]}
-    {:error, error} = ExampleCommandWithCustomOutput.output({:error, error}, %{})
+    {:error, ^error} = ExampleCommandWithCustomOutput.output({:error, error}, %{})
 
     {:error, "I am string"} =
       ExampleCommandWithCustomOutput.output({:error_string, "I am string"}, %{})

--- a/test/delete_user_command_test.exs
+++ b/test/delete_user_command_test.exs
@@ -24,13 +24,6 @@ defmodule DeleteUserCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
-
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
-
     :ok
   end
 
@@ -57,7 +50,7 @@ defmodule DeleteUserCommandTest do
 
   test "run: An invalid Rabbit node returns a bad rpc message" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
 
     assert @command.run(["username"], opts) == {:badrpc, :nodedown}

--- a/test/delete_vhost_command_test.exs
+++ b/test/delete_vhost_command_test.exs
@@ -23,12 +23,7 @@ defmodule DeleteVhostCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -62,7 +57,7 @@ defmodule DeleteVhostCommandTest do
 
   test "run: A call to invalid or inactive RabbitMQ node returns a nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
 
     assert @command.run(["na"], opts) == {:badrpc, :nodedown}

--- a/test/diagnostics/cipher_suites_command_test.exs
+++ b/test/diagnostics/cipher_suites_command_test.exs
@@ -22,12 +22,7 @@ defmodule CipherSuitesCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -67,7 +62,7 @@ defmodule CipherSuitesCommandTest do
   @tag test_timeout: 0
   test "run: targeting an unreachable node throws a badrpc", context do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert @command.run([], Map.merge(context[:opts], opts)) == {:badrpc, :nodedown}
   end

--- a/test/diagnostics/discover_peers_command_test.exs
+++ b/test/diagnostics/discover_peers_command_test.exs
@@ -20,13 +20,6 @@ defmodule DiscoverPeersCommandTest do
   @command RabbitMQ.CLI.Diagnostics.Commands.DiscoverPeersCommand
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
-
-
-    on_exit(fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-    end)
-
     :ok
   end
 

--- a/test/diagnostics/erlang_cookie_hash_command_test.exs
+++ b/test/diagnostics/erlang_cookie_hash_command_test.exs
@@ -22,12 +22,7 @@ defmodule ErlangCookieHashCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -54,7 +49,7 @@ defmodule ErlangCookieHashCommandTest do
   @tag test_timeout: 0
   test "run: targeting an unreachable node throws a badrpc", context do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert @command.run([], Map.merge(context[:opts], opts)) == {:badrpc, :nodedown}
   end

--- a/test/diagnostics/maybe_stuck_command_test.exs
+++ b/test/diagnostics/maybe_stuck_command_test.exs
@@ -22,12 +22,7 @@ defmodule MaybeStuckCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -54,7 +49,7 @@ defmodule MaybeStuckCommandTest do
   @tag test_timeout: 0
   test "run: targeting an unreachable node throws a badrpc", context do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert @command.run([], Map.merge(context[:opts], opts)) == {:badrpc, :nodedown}
   end

--- a/test/environment_command_test.exs
+++ b/test/environment_command_test.exs
@@ -22,12 +22,7 @@ defmodule EnvironmentCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -49,7 +44,7 @@ defmodule EnvironmentCommandTest do
 
   test "run: environment request on nonexistent RabbitMQ node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
 
     assert @command.run([], opts) == {:badrpc, :nodedown}

--- a/test/eval_command_test.exs
+++ b/test/eval_command_test.exs
@@ -23,13 +23,6 @@ defmodule EvalCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
-
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
-
     :ok
   end
 
@@ -53,7 +46,7 @@ defmodule EvalCommandTest do
 
   test "run: request to a non-existent node returns nodedown", _context do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
 
 

--- a/test/exec_command_test.exs
+++ b/test/exec_command_test.exs
@@ -16,8 +16,6 @@
 
 defmodule ExecCommandTest do
   use ExUnit.Case, async: false
-  import TestHelper
-  import ExUnit.CaptureIO
 
   @command RabbitMQ.CLI.Ctl.Commands.ExecCommand
 

--- a/test/force_boot_command_test.exs
+++ b/test/force_boot_command_test.exs
@@ -22,12 +22,7 @@ defmodule ForceBootCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end

--- a/test/force_reset_command_test.exs
+++ b/test/force_reset_command_test.exs
@@ -22,13 +22,13 @@ defmodule ForceResetCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     start_rabbitmq_app()
 
     on_exit([], fn ->
       start_rabbitmq_app()
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -63,7 +63,7 @@ defmodule ForceResetCommandTest do
 
   test "run: request to a non-existent node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert match?({:badrpc, :nodedown}, @command.run([], opts))
   end

--- a/test/forget_cluster_node_command_test.exs
+++ b/test/forget_cluster_node_command_test.exs
@@ -23,7 +23,6 @@ defmodule ForgetClusterNodeCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
-    :net_kernel.connect_node(node)
 
     start_rabbitmq_app()
     {:ok, plugins_dir} = :rabbit_misc.rpc_call(node,
@@ -34,8 +33,6 @@ defmodule ForgetClusterNodeCommandTest do
 
     on_exit([], fn ->
       start_rabbitmq_app()
-      :erlang.disconnect_node(node)
-
     end)
 
     {:ok, opts: %{rabbitmq_home: rabbitmq_home,

--- a/test/hipe_compile_command_test.exs
+++ b/test/hipe_compile_command_test.exs
@@ -24,13 +24,11 @@ defmodule HipeCompileCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     start_rabbitmq_app()
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-    end)
+
   end
 
   setup do

--- a/test/join_cluster_command_test.exs
+++ b/test/join_cluster_command_test.exs
@@ -22,13 +22,13 @@ defmodule JoinClusterCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     start_rabbitmq_app()
 
     on_exit([], fn ->
       start_rabbitmq_app()
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -83,7 +83,7 @@ defmodule JoinClusterCommandTest do
 
   test "run: request to a non-existent node returns nodedown", context do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{
       node: target,
       disc: true,
@@ -97,7 +97,7 @@ defmodule JoinClusterCommandTest do
 
   test "run: joining a non-existent node returns nodedown", context do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     stop_rabbitmq_app()
     assert match?(
       {:badrpc_multi, :nodedown, [_]},

--- a/test/list_bindings_command_test.exs
+++ b/test/list_bindings_command_test.exs
@@ -9,12 +9,7 @@ defmodule ListBindingsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end

--- a/test/list_channels_command_test.exs
+++ b/test/list_channels_command_test.exs
@@ -22,13 +22,13 @@ defmodule ListChannelsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     close_all_connections(get_rabbit_hostname())
 
     on_exit([], fn ->
       close_all_connections(get_rabbit_hostname())
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 

--- a/test/list_connections_command_test.exs
+++ b/test/list_connections_command_test.exs
@@ -8,13 +8,13 @@ defmodule ListConnectionsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     close_all_connections(get_rabbit_hostname())
 
     on_exit([], fn ->
       close_all_connections(get_rabbit_hostname())
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 

--- a/test/list_consumers_command_test.exs
+++ b/test/list_consumers_command_test.exs
@@ -11,12 +11,7 @@ defmodule ListConsumersCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end

--- a/test/list_exchanges_command_test.exs
+++ b/test/list_exchanges_command_test.exs
@@ -22,12 +22,7 @@ defmodule ListExchangesCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end

--- a/test/list_global_parameters_command_test.exs
+++ b/test/list_global_parameters_command_test.exs
@@ -25,13 +25,6 @@ defmodule ListGlobalParametersCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    node = get_rabbit_hostname()
-    :net_kernel.connect_node(node)
-
-    on_exit(fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-    end)
-
     :ok
   end
 

--- a/test/list_operator_policies_command_test.exs
+++ b/test/list_operator_policies_command_test.exs
@@ -29,13 +29,13 @@ defmodule ListOperatorPoliciesCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
     on_exit(fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -76,7 +76,7 @@ defmodule ListOperatorPoliciesCommandTest do
 
   test "run: an unreachable node throws a badrpc" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: @vhost, timeout: :infinity}
 
     assert @command.run([], opts) == {:badrpc, :nodedown}

--- a/test/list_parameters_command_test.exs
+++ b/test/list_parameters_command_test.exs
@@ -29,7 +29,7 @@ defmodule ListParametersCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
-    :net_kernel.connect_node(node)
+
 
     {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
                                                 :application, :get_env,
@@ -54,7 +54,7 @@ defmodule ListParametersCommandTest do
     on_exit(fn ->
       set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(), opts)
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -96,7 +96,7 @@ defmodule ListParametersCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: @vhost, timeout: :infinity}
 
     assert @command.run([], opts) == {:badrpc, :nodedown}

--- a/test/list_permissions_command_test.exs
+++ b/test/list_permissions_command_test.exs
@@ -27,14 +27,14 @@ defmodule ListPermissionsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
     set_permissions @user, @vhost, ["^guest-.*", ".*", ".*"]
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -67,8 +67,8 @@ defmodule ListPermissionsCommandTest do
 
   test "run: on a bad RabbitMQ node, return a badrpc" do
     target = :jake@thedog
-    opts = %{node: :jake@thedog, timeout: :infinity, vhost: "/"}
-    :net_kernel.connect_node(target)
+    opts = %{node: target, timeout: :infinity, vhost: "/"}
+
     assert @command.run([], opts) == {:badrpc, :nodedown}
   end
 

--- a/test/list_policies_command_test.exs
+++ b/test/list_policies_command_test.exs
@@ -29,7 +29,7 @@ defmodule ListPoliciesCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
@@ -37,7 +37,7 @@ defmodule ListPoliciesCommandTest do
 
     on_exit(fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -78,7 +78,7 @@ defmodule ListPoliciesCommandTest do
 
   test "run: an unreachable node throws a badrpc" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: @vhost, timeout: :infinity}
 
     assert @command.run([], opts) == {:badrpc, :nodedown}

--- a/test/list_queues_command_test.exs
+++ b/test/list_queues_command_test.exs
@@ -10,7 +10,7 @@ defmodule ListQueuesCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     reset_vm_memory_high_watermark()
     delete_all_queues()
@@ -19,7 +19,7 @@ defmodule ListQueuesCommandTest do
     on_exit([], fn ->
       delete_all_queues()
       close_all_connections(get_rabbit_hostname())
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 

--- a/test/list_topic_permissions_command_test.exs
+++ b/test/list_topic_permissions_command_test.exs
@@ -28,7 +28,7 @@ defmodule ListTopicPermissionsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost(@vhost)
     add_user(@user, @password)
@@ -39,7 +39,7 @@ defmodule ListTopicPermissionsCommandTest do
       clear_topic_permissions(@user, @vhost)
       delete_user(@user)
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -72,8 +72,8 @@ defmodule ListTopicPermissionsCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    opts = %{node: :jake@thedog, timeout: :infinity, vhost: "/"}
-    :net_kernel.connect_node(target)
+    opts = %{node: target, timeout: :infinity, vhost: "/"}
+
     assert @command.run([], opts) == {:badrpc, :nodedown}
   end
 

--- a/test/list_user_permissions_command_test.exs
+++ b/test/list_user_permissions_command_test.exs
@@ -22,12 +22,7 @@ defmodule ListUserPermissionsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -80,7 +75,7 @@ defmodule ListUserPermissionsCommandTest do
 
   test "run: invalid or inactive RabbitMQ node returns a bad RPC error" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, timeout: :infinity}
 
     assert @command.run(["guest"], opts) == {:badrpc, :nodedown}

--- a/test/list_user_topic_permissions_command_test.exs
+++ b/test/list_user_topic_permissions_command_test.exs
@@ -22,14 +22,14 @@ defmodule ListUserTopicPermissionsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     set_topic_permissions("guest", "/", "amq.topic", "^a", "^b")
     set_topic_permissions("guest", "/", "topic1", "^a", "^b")
 
     on_exit([], fn ->
       clear_topic_permissions("guest", "/")
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -72,7 +72,7 @@ defmodule ListUserTopicPermissionsCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, timeout: :infinity}
 
     assert @command.run(["guest"], opts) == {:badrpc, :nodedown}

--- a/test/list_users_command_test.exs
+++ b/test/list_users_command_test.exs
@@ -26,12 +26,7 @@ defmodule ListUsersCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     std_result = [
       [{:user,@guest},{:tags,[:administrator]}],

--- a/test/list_vhost_limits_command_test.exs
+++ b/test/list_vhost_limits_command_test.exs
@@ -27,13 +27,13 @@ defmodule ListVhostLimitsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
     end)
 
     :ok
@@ -101,7 +101,7 @@ defmodule ListVhostLimitsCommandTest do
 
   test "run: an unreachable node throws a badrpc" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: "/"}
 
     assert @command.run([], opts) == {:badrpc, :nodedown}

--- a/test/list_vhosts_command_test.exs
+++ b/test/list_vhosts_command_test.exs
@@ -26,7 +26,7 @@ defmodule ListVhostsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost1
     add_vhost @vhost2
@@ -35,7 +35,7 @@ defmodule ListVhostsCommandTest do
     on_exit([], fn ->
       delete_vhost @vhost1
       delete_vhost @vhost2
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -104,8 +104,8 @@ defmodule ListVhostsCommandTest do
 
   test "run: on a bad RabbitMQ node, return a badrpc" do
     target = :jake@thedog
-    opts = %{node: :jake@thedog, timeout: :infinity}
-    :net_kernel.connect_node(target)
+    opts = %{node: target, timeout: :infinity}
+
     assert @command.run(["name"], opts) == {:badrpc, :nodedown}
   end
 

--- a/test/node_health_check_command_test.exs
+++ b/test/node_health_check_command_test.exs
@@ -22,13 +22,13 @@ defmodule NodeHealthCheckCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     reset_vm_memory_high_watermark()
 
     on_exit([], fn ->
       reset_vm_memory_high_watermark()
 
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -68,7 +68,7 @@ defmodule NodeHealthCheckCommandTest do
 
   test "run: request to a non-existent node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
 
     assert match?({:badrpc, :nodedown}, @command.run([], %{node: target, timeout: 70000}))
   end

--- a/test/plugins/disable_plugins_command_test.exs
+++ b/test/plugins/disable_plugins_command_test.exs
@@ -22,7 +22,7 @@ defmodule DisablePluginsCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
-    :net_kernel.connect_node(node)
+
     {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
                                                 :application, :get_env,
                                                 [:rabbit, :enabled_plugins_file])
@@ -43,22 +43,18 @@ defmodule DisablePluginsCommandTest do
       set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(), opts)
     end)
 
-    :erlang.disconnect_node(node)
-
 
     {:ok, opts: opts}
   end
 
   setup context do
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation],
                         :online,
                         get_rabbit_hostname(),
                         context[:opts])
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-    end)
+
 
     {
       :ok,

--- a/test/plugins/enable_plugins_command_test.exs
+++ b/test/plugins/enable_plugins_command_test.exs
@@ -22,7 +22,7 @@ defmodule EnablePluginsCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
-    :net_kernel.connect_node(node)
+
     {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
                                                 :application, :get_env,
                                                 [:rabbit, :enabled_plugins_file])
@@ -43,22 +43,18 @@ defmodule EnablePluginsCommandTest do
       set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(), opts)
     end)
 
-    :erlang.disconnect_node(node)
-
 
     {:ok, opts: opts}
   end
 
   setup context do
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation],
                         :online,
                         get_rabbit_hostname(),
                         context[:opts])
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-    end)
+
 
     {
       :ok,

--- a/test/plugins/list_plugins_command_test.exs
+++ b/test/plugins/list_plugins_command_test.exs
@@ -28,7 +28,7 @@ defmodule ListPluginsCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
-    :net_kernel.connect_node(node)
+
     {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
                                                 :application, :get_env,
                                                 [:rabbit, :enabled_plugins_file])
@@ -49,19 +49,15 @@ defmodule ListPluginsCommandTest do
       set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(), opts)
     end)
 
-    :erlang.disconnect_node(node)
-
 
     {:ok, opts: opts}
   end
 
   setup context do
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     reset_enabled_plugins_to_preconfigured_defaults(context)
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-    end)
+
 
     {
       :ok,

--- a/test/plugins/set_plugins_command_test.exs
+++ b/test/plugins/set_plugins_command_test.exs
@@ -24,7 +24,7 @@ defmodule SetPluginsCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
-    :net_kernel.connect_node(node)
+
     {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
                                                 :application, :get_env,
                                                 [:rabbit, :enabled_plugins_file])
@@ -44,22 +44,15 @@ defmodule SetPluginsCommandTest do
       set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(),opts)
     end)
 
-    :erlang.disconnect_node(node)
-    #
-
     {:ok, opts: opts}
   end
 
   setup context do
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation],
                         :online,
                         get_rabbit_hostname(),
                         context[:opts])
-
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-    end)
 
     {
       :ok,

--- a/test/purge_queue_command_test.exs
+++ b/test/purge_queue_command_test.exs
@@ -24,12 +24,7 @@ defmodule PurgeQueueCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end

--- a/test/rabbitmqctl_test.exs
+++ b/test/rabbitmqctl_test.exs
@@ -23,11 +23,9 @@ defmodule RabbitMQCtlTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     set_scope(:all)
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-    end)
+
     :ok
   end
 

--- a/test/rename_cluster_node_command_test.exs
+++ b/test/rename_cluster_node_command_test.exs
@@ -23,7 +23,6 @@ defmodule RenameClusterNodeCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
     node = get_rabbit_hostname()
-    :net_kernel.connect_node(node)
 
     start_rabbitmq_app()
 
@@ -35,8 +34,6 @@ defmodule RenameClusterNodeCommandTest do
 
     on_exit([], fn ->
       start_rabbitmq_app()
-      :erlang.disconnect_node(node)
-
     end)
 
     {:ok, opts: %{rabbitmq_home: rabbitmq_home,

--- a/test/report_command_test.exs
+++ b/test/report_command_test.exs
@@ -22,12 +22,7 @@ defmodule ReportTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -49,7 +44,7 @@ defmodule ReportTest do
 
   test "run: report request on nonexistent RabbitMQ node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert match?({:badrpc, _}, @command.run([], opts))
   end

--- a/test/reset_command_test.exs
+++ b/test/reset_command_test.exs
@@ -22,13 +22,13 @@ defmodule ResetCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     start_rabbitmq_app()
 
     on_exit([], fn ->
       start_rabbitmq_app()
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -63,7 +63,7 @@ defmodule ResetCommandTest do
 
   test "run: request to a non-existent node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert match?({:badrpc, :nodedown}, @command.run([], opts))
   end

--- a/test/rotate_logs_command_test.exs
+++ b/test/rotate_logs_command_test.exs
@@ -22,12 +22,7 @@ defmodule RotateLogsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -46,7 +41,7 @@ defmodule RotateLogsCommandTest do
 
   test "run: request to a non-existent node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert match?({:badrpc, :nodedown}, @command.run([], opts))
   end

--- a/test/rpc_stream_test.exs
+++ b/test/rpc_stream_test.exs
@@ -1,19 +1,12 @@
 defmodule RpcStreamTest do
   use ExUnit.Case, async: false
 
-  import TestHelper
-
   require RabbitMQ.CLI.Ctl.RpcStream
   alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
 

--- a/test/set_cluster_name_command_test.exs
+++ b/test/set_cluster_name_command_test.exs
@@ -22,12 +22,7 @@ defmodule SetClusterNameCommandTest do
 
   setup_all do
     :net_kernel.start([:rabbitmqctl, :shortnames])
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end

--- a/test/set_disk_free_limit_command_test.exs
+++ b/test/set_disk_free_limit_command_test.exs
@@ -24,12 +24,12 @@ defmodule SetDiskFreeLimitCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     set_disk_free_limit(@default_limit)
 
     on_exit([], fn ->
       set_disk_free_limit(@default_limit)
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 

--- a/test/set_global_parameter_command_test.exs
+++ b/test/set_global_parameter_command_test.exs
@@ -25,11 +25,9 @@ defmodule SetGlobalParameterCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-    end)
+
+
 
     :ok
   end
@@ -65,7 +63,7 @@ defmodule SetGlobalParameterCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
 
     assert @command.run([@key, @value], opts) == {:badrpc, :nodedown}

--- a/test/set_operator_policy_command_test.exs
+++ b/test/set_operator_policy_command_test.exs
@@ -30,13 +30,13 @@ defmodule SetOperatorPolicyCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -103,7 +103,7 @@ defmodule SetOperatorPolicyCommandTest do
 
   test "run: an unreachable node throws a badrpc" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: "/", priority: 0, apply_to: "all"}
 
     assert @command.run([@key, @pattern, @value], opts) == {:badrpc, :nodedown}

--- a/test/set_parameter_command_test.exs
+++ b/test/set_parameter_command_test.exs
@@ -28,7 +28,7 @@ defmodule SetParameterCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
@@ -36,7 +36,7 @@ defmodule SetParameterCommandTest do
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -84,7 +84,7 @@ defmodule SetParameterCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: "/"}
 
     assert @command.run([@component_name, @key, @value], opts) == {:badrpc, :nodedown}

--- a/test/set_permissions_command_test.exs
+++ b/test/set_permissions_command_test.exs
@@ -26,13 +26,13 @@ defmodule SetPermissionsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -81,7 +81,7 @@ defmodule SetPermissionsCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: @vhost}
 
     assert @command.run([@user, ".*", ".*", ".*"], opts) == {:badrpc, :nodedown}

--- a/test/set_policy_command_test.exs
+++ b/test/set_policy_command_test.exs
@@ -30,7 +30,7 @@ defmodule SetPolicyCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
@@ -38,7 +38,7 @@ defmodule SetPolicyCommandTest do
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -105,7 +105,7 @@ defmodule SetPolicyCommandTest do
 
   test "run: an unreachable node throws a badrpc" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: "/", priority: 0, apply_to: "all"}
 
     assert @command.run([@key, @pattern, @value], opts) == {:badrpc, :nodedown}

--- a/test/set_topic_permissions_command_test.exs
+++ b/test/set_topic_permissions_command_test.exs
@@ -26,13 +26,13 @@ defmodule SetTopicPermissionsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -82,7 +82,7 @@ defmodule SetTopicPermissionsCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: @vhost}
 
     assert @command.run([@user, "amq.topic", "^a", "^b"], opts) == {:badrpc, :nodedown}

--- a/test/set_user_tags_command_test.exs
+++ b/test/set_user_tags_command_test.exs
@@ -25,12 +25,12 @@ defmodule SetUserTagsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     add_user @user, @password
 
     on_exit([], fn ->
       delete_user(@user)
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -50,7 +50,7 @@ defmodule SetUserTagsCommandTest do
 
   test "run: throws a badrpc when instructed to contact an unreachable RabbitMQ node" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
 
     assert @command.run([@user, :imperator], opts) == {:badrpc, :nodedown}

--- a/test/set_vhost_limits_command_test.exs
+++ b/test/set_vhost_limits_command_test.exs
@@ -25,13 +25,13 @@ defmodule SetVhostLimitsCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     add_vhost @vhost
 
     on_exit([], fn ->
       delete_vhost @vhost
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -88,7 +88,7 @@ defmodule SetVhostLimitsCommandTest do
 
   test "run: an unreachable node throws a badrpc" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: "/"}
 
     assert @command.run([@definition], opts) == {:badrpc, :nodedown}

--- a/test/set_vm_memory_high_watermark_command_test.exs
+++ b/test/set_vm_memory_high_watermark_command_test.exs
@@ -23,13 +23,13 @@ defmodule SetVmMemoryHighWatermarkCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     reset_vm_memory_high_watermark()
 
     on_exit([], fn ->
       reset_vm_memory_high_watermark()
 
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 

--- a/test/shutdown_command_test.exs
+++ b/test/shutdown_command_test.exs
@@ -22,12 +22,7 @@ defmodule ShutdownCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -48,7 +43,7 @@ defmodule ShutdownCommandTest do
 
   test "run: request to a non-existent node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert match?({:badrpc, :nodedown}, @command.run([], opts))
   end

--- a/test/start_app_command_test.exs
+++ b/test/start_app_command_test.exs
@@ -22,13 +22,13 @@ defmodule StartAppCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     start_rabbitmq_app()
 
     on_exit([], fn ->
       start_rabbitmq_app()
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -53,7 +53,7 @@ defmodule StartAppCommandTest do
 
   test "run: request to a non-existent node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert match?({:badrpc, :nodedown}, @command.run([], opts))
   end

--- a/test/status_command_test.exs
+++ b/test/status_command_test.exs
@@ -22,12 +22,7 @@ defmodule StatusCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -46,7 +41,7 @@ defmodule StatusCommandTest do
 
   test "run: request to a non-existent node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert match?({:badrpc, :nodedown}, @command.run([], opts))
   end

--- a/test/stop_app_command_test.exs
+++ b/test/stop_app_command_test.exs
@@ -22,13 +22,13 @@ defmodule StopAppCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     start_rabbitmq_app()
 
     on_exit([], fn ->
       start_rabbitmq_app()
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -52,7 +52,7 @@ defmodule StopAppCommandTest do
 
   test "run: request to a non-existent node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert match?({:badrpc, :nodedown}, @command.run([], opts))
   end

--- a/test/stop_command_test.exs
+++ b/test/stop_command_test.exs
@@ -22,12 +22,7 @@ defmodule StopCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end
@@ -52,7 +47,7 @@ defmodule StopCommandTest do
 
   test "run: request to a non-existent node returns nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target}
     assert match?({:badrpc, :nodedown}, @command.run([], opts))
   end

--- a/test/sync_queue_command_test.exs
+++ b/test/sync_queue_command_test.exs
@@ -23,13 +23,13 @@ defmodule SyncQueueCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     start_rabbitmq_app()
 
     on_exit([], fn ->
       start_rabbitmq_app()
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -64,7 +64,7 @@ defmodule SyncQueueCommandTest do
 
   test "run: request to a non-existent RabbitMQ node returns a nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: @vhost}
     assert match?({:badrpc, :nodedown}, @command.run(["q1"], opts))
   end

--- a/test/trace_off_command_test.exs
+++ b/test/trace_off_command_test.exs
@@ -25,12 +25,12 @@ defmodule TraceOffCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     add_vhost(@test_vhost)
 
     on_exit([], fn ->
       delete_vhost(@test_vhost)
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -62,7 +62,7 @@ defmodule TraceOffCommandTest do
 
   test "run: on an invalid RabbitMQ node, return a nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: "/"}
     assert @command.run([], opts) == {:badrpc, :nodedown}
   end

--- a/test/trace_on_command_test.exs
+++ b/test/trace_on_command_test.exs
@@ -25,12 +25,12 @@ defmodule TraceOnCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
     add_vhost(@test_vhost)
 
     on_exit([], fn ->
       delete_vhost(@test_vhost)
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -62,7 +62,7 @@ defmodule TraceOnCommandTest do
 
   test "run: on an invalid RabbitMQ node, return a nodedown" do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{node: target, vhost: "/"}
 
     assert @command.run([], opts) == {:badrpc, :nodedown}

--- a/test/update_cluster_nodes_command_test.exs
+++ b/test/update_cluster_nodes_command_test.exs
@@ -22,13 +22,13 @@ defmodule UpdateClusterNodesCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
+
 
     start_rabbitmq_app()
 
     on_exit([], fn ->
       start_rabbitmq_app()
-      :erlang.disconnect_node(get_rabbit_hostname())
+
 
     end)
 
@@ -61,7 +61,7 @@ defmodule UpdateClusterNodesCommandTest do
 
   test "run: request to an unreachable node returns nodedown", context do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     opts = %{
       node: target
     }
@@ -73,7 +73,7 @@ defmodule UpdateClusterNodesCommandTest do
 
   test "run: specifying an unreachable node as seed returns nodedown", context do
     target = :jake@thedog
-    :net_kernel.connect_node(target)
+
     stop_rabbitmq_app()
     assert match?(
       {:badrpc_multi, :nodedown, [_]},

--- a/test/wait_command_test.exs
+++ b/test/wait_command_test.exs
@@ -22,12 +22,7 @@ defmodule WaitCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-    :net_kernel.connect_node(get_rabbit_hostname())
 
-    on_exit([], fn ->
-      :erlang.disconnect_node(get_rabbit_hostname())
-
-    end)
 
     :ok
   end


### PR DESCRIPTION
Fixes #189 

Commands are supposed to return bardpc errors, which are handled by output,
so there is no need to connect to the node before calling the run function.