### PR TITLE
Rename <user> to <username> to standarise all rabbitmqctl commands

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
@@ -47,7 +47,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPermissionsCommand do
     )
   end
 
-  def usage, do: "set_permissions [-p <vhost>] <user> <conf> <write> <read>"
+  def usage, do: "set_permissions [-p <vhost>] <username> <conf> <write> <read>"
 
 
   def banner([user|_], %{vhost: vhost}), do: "Setting permissions for user \"#{user}\" in vhost \"#{vhost}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/set_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_topic_permissions_command.ex
@@ -46,7 +46,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetTopicPermissionsCommand do
     )
   end
 
-  def usage, do: "set_topic_permissions [-p <vhost>] <user> <exchange> <write_pattern> <read_pattern>"
+  def usage, do: "set_topic_permissions [-p <vhost>] <username> <exchange> <write_pattern> <read_pattern>"
 
 
   def banner([user, exchange, _, _], %{vhost: vhost}), do: "Setting topic permissions on \"#{exchange}\" for user \"#{user}\" in vhost \"#{vhost}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
@@ -33,7 +33,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetUserTagsCommand do
     )
   end
 
-  def usage, do: "set_user_tags <user> <tag> [...]"
+  def usage, do: "set_user_tags <username> <tag> [...]"
 
 
   def banner([user | tags], _) do


### PR DESCRIPTION
Most commands use <username> in the help description