### PR TITLE
Use the output of multirpc to report the down or timed out nodes

### DIFF
--- a/lib/rabbitmq/cli/core/exit_codes.ex
+++ b/lib/rabbitmq/cli/core/exit_codes.ex
@@ -41,10 +41,12 @@ defmodule RabbitMQ.CLI.Core.ExitCodes do
   def exit_code_for({:validation_failure, :eperm}),                do: exit_dataerr()
   def exit_code_for({:validation_failure, {:bad_option, _}}),      do: exit_usage()
   def exit_code_for({:validation_failure, _}),                     do: exit_usage()
+  def exit_code_for({:badrpc_multi, :timeout, _}),       do: exit_tempfail()
   def exit_code_for({:badrpc, :timeout}),       do: exit_tempfail()
   def exit_code_for({:badrpc, {:timeout, _}}),  do: exit_tempfail()
   def exit_code_for(:timeout),                  do: exit_tempfail()
   def exit_code_for({:timeout, _}),             do: exit_tempfail()
+  def exit_code_for({:badrpc_multi, :nodedown, _}),      do: exit_unavailable()
   def exit_code_for({:badrpc, :nodedown}),      do: exit_unavailable()
   def exit_code_for({:error, _}),               do: exit_software()
 

--- a/lib/rabbitmq/cli/default_output.ex
+++ b/lib/rabbitmq/cli/default_output.ex
@@ -39,7 +39,7 @@ defmodule RabbitMQ.CLI.DefaultOutput do
   defp normalize_output(:ok), do: :ok
   defp normalize_output({:ok, _} = input), do: input
   defp normalize_output({:stream, _} = input), do: input
-  defp normalize_output({:badrpc_multi, err, _}), do: {:error, {:badrpc, err}}
+  defp normalize_output({:badrpc_multi, _, _} = input), do: {:error, input}
   defp normalize_output({:badrpc, :nodedown} = input), do: {:error, input}
   defp normalize_output({:badrpc, :timeout} = input), do: {:error, input}
   defp normalize_output({:error, format, args})

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -251,6 +251,18 @@ defmodule RabbitMQCtl do
     exit({:shutdown, code})
   end
 
+  defp format_error({:error, {:badrpc_multi, :nodedown, [node | _]} = result}, opts, _) do
+    diagnostics = get_node_diagnostics(node)
+    {:error, ExitCodes.exit_code_for(result),
+     "Error: unable to connect to node '#{node}': nodedown\n" <>
+     diagnostics}
+  end
+  defp format_error({:error, {:badrpc_multi, :timeout, [node | _]} = result}, opts, _) do
+    diagnostics = get_node_diagnostics(node)
+    {:error, ExitCodes.exit_code_for(result),
+     "Error: unable to connect to node '#{node}': nodedown\n" <>
+     diagnostics}
+  end
   defp format_error({:error, {:badrpc, :nodedown} = result}, opts, _) do
     diagnostics = get_node_diagnostics(opts[:node])
     {:error, ExitCodes.exit_code_for(result),

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -251,13 +251,13 @@ defmodule RabbitMQCtl do
     exit({:shutdown, code})
   end
 
-  defp format_error({:error, {:badrpc_multi, :nodedown, [node | _]} = result}, opts, _) do
+  defp format_error({:error, {:badrpc_multi, :nodedown, [node | _]} = result}, _opts, _) do
     diagnostics = get_node_diagnostics(node)
     {:error, ExitCodes.exit_code_for(result),
      "Error: unable to connect to node '#{node}': nodedown\n" <>
      diagnostics}
   end
-  defp format_error({:error, {:badrpc_multi, :timeout, [node | _]} = result}, opts, _) do
+  defp format_error({:error, {:badrpc_multi, :timeout, [node | _]} = result}, opts, module) do
     op = CommandModules.module_to_command(module)
     {:error, ExitCodes.exit_code_for(result),
      "Error: operation #{op} on node #{node} timed out. Timeout: #{opts[:timeout]}"}

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -251,13 +251,13 @@ defmodule RabbitMQCtl do
     exit({:shutdown, code})
   end
 
-  defp format_error({:error, {:badrpc_multi, :nodedown, [node | _]} = result}, _opts, _) do
+  defp format_error({:error, {:badrpc_multi, :nodedown, [node | _]} = result}, opts, _) do
     diagnostics = get_node_diagnostics(node)
     {:error, ExitCodes.exit_code_for(result),
      "Error: unable to connect to node '#{node}': nodedown\n" <>
      diagnostics}
   end
-  defp format_error({:error, {:badrpc_multi, :timeout, [node | _]} = result}, opts, module) do
+  defp format_error({:error, {:badrpc_multi, :timeout, [node | _]} = result}, opts, _) do
     op = CommandModules.module_to_command(module)
     {:error, ExitCodes.exit_code_for(result),
      "Error: operation #{op} on node #{node} timed out. Timeout: #{opts[:timeout]}"}

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -258,10 +258,9 @@ defmodule RabbitMQCtl do
      diagnostics}
   end
   defp format_error({:error, {:badrpc_multi, :timeout, [node | _]} = result}, opts, _) do
-    diagnostics = get_node_diagnostics(node)
+    op = CommandModules.module_to_command(module)
     {:error, ExitCodes.exit_code_for(result),
-     "Error: unable to connect to node '#{node}': nodedown\n" <>
-     diagnostics}
+     "Error: operation #{op} on node #{node} timed out. Timeout: #{opts[:timeout]}"}
   end
   defp format_error({:error, {:badrpc, :nodedown} = result}, opts, _) do
     diagnostics = get_node_diagnostics(opts[:node])


### PR DESCRIPTION
Most commands do rpc's only to the target node, but join_cluster
triggers an rpc between nodes. If the rpc to the remote down returns
down/timeout, we must use that value to run the diagnostics.
Using the node from command options in diagnostics will report as down
the wrong node.

Closes #197 