### PR TITLE
Handle error in `rabbit_mnesia:cluster_nodes/1` on cluster_status command

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
@@ -33,7 +33,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
         case :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :cluster_nodes, [:running]) do
           {:badrpc, _} = err ->
             err
-          {:error, {corrupt_or_missing_cluster_files, _, _}} = err ->
+          {:error, {:corrupt_or_missing_cluster_files, _, _}} ->
             {:error, "Could not read mnesia files containing cluster status"}
           nodes ->
             alarms_by_node = Enum.map(nodes, &alarms_by_node/1)

--- a/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
@@ -33,6 +33,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
         case :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :cluster_nodes, [:running]) do
           {:badrpc, _} = err ->
             err
+          {:error, {corrupt_or_missing_cluster_files, _, _}} = err ->
+            {:error, "Could not read mnesia files containing cluster status"}
           nodes ->
             alarms_by_node = Enum.map(nodes, &alarms_by_node/1)
             status ++ [{:alarms, alarms_by_node}]


### PR DESCRIPTION
If the error is ignored, an Enum exception is triggered which is not
meaningful for the final user. Notifying that something is wrong accessing
to Mnesia files provides a hint. Can be eventually reproduced while
the node is restarting.

Fixes #199