### PR TITLE
Introduce a memory breakdown command

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -59,11 +59,11 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
 
     @behaviour RabbitMQ.CLI.FormatterBehaviour
 
-    def format_output(output, options) do
+    def format_output(output, %{unit: unit}) do
       Enum.reduce(output, "", fn({key, %{bytes: bytes, percentage: percentage}}, acc) ->
         # TODO: should output functions take options with
         #       merged defaults?
-        u = String.downcase(Map.get(options, :unit, "gb"))
+        u = String.downcase(unit)
         acc <> "#{key}: #{IU.convert(bytes, u)} #{u} (#{percentage}%)\n"
       end)
     end

--- a/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -1,0 +1,102 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{unit: "gb"}, opts)}
+  end
+
+  def switches(), do: [unit: :string]
+
+  def validate(args, _) when length(args) > 0 do
+    {:validation_failure, :too_many_args}
+  end
+  def validate(_, %{unit: unit}) when unit == "gigabytes" or
+                                      unit == "gb" or
+                                      unit == "GB" or
+                                      unit == "megabytes" or
+                                      unit == "mb" or
+                                      unit == "MB" or
+                                      unit == "bytes" do
+    :ok
+  end
+  def validate(_, %{unit: unit}) do
+    {:validation_failure, "unit '#{unit}' is not supported. Please use one of: bytes, mb, gb"}
+  end
+
+  def usage, do: "memory_breakdown [--unit <unit>]"
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    :rabbit_misc.rpc_call(node_name, :rabbit_vm, :memory, [], timeout)
+  end
+
+  def output(result, _options) do
+    {:ok, compute_relative_values(result)}
+  end
+
+  def banner([], %{node: node_name}) do
+    "Reporting memory breakdown on node #{node_name}..."
+  end
+
+  defmodule Formatter do
+    alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
+    alias RabbitMQ.CLI.InformationUnit, as: IU
+
+    @behaviour RabbitMQ.CLI.FormatterBehaviour
+
+    def format_output(output, options) do
+      Enum.reduce(output, "", fn({key, %{bytes: bytes, percentage: percentage}}, acc) ->
+        # TODO: should output functions take options with
+        #       merged defaults?
+        u = String.downcase(Map.get(options, :unit, "gb"))
+        acc <> "#{key}: #{IU.convert(bytes, u)} #{u} (#{percentage}%)\n"
+      end)
+    end
+
+    def format_stream(stream, options) do
+      Stream.map(stream,
+        FormatterHelpers.without_errors_1(
+          fn(el) ->
+            format_output(el, options)
+          end))
+    end
+  end
+
+  def formatter(), do: Formatter
+
+
+  #
+  # Implementation
+  #
+
+  defp compute_relative_values(all_pairs) do
+    pairs = Keyword.delete(all_pairs, :total)
+    total = Enum.reduce(pairs, 0, fn({_, bytes}, acc) -> acc + bytes end)
+
+    pairs
+    |> Enum.map(fn({k, v}) ->
+      pg = (v / total) |> fraction_to_percent()
+      {k, %{bytes: v, percentage: pg}}
+    end)
+    |> Enum.sort_by(fn({_key, %{bytes: bytes}}) -> bytes end, &>=/2)
+  end
+
+  defp fraction_to_percent(x) do
+    Float.round(x * 100, 2)
+  end
+end

--- a/lib/rabbitmq/cli/information_unit.ex
+++ b/lib/rabbitmq/cli/information_unit.ex
@@ -14,11 +14,18 @@
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.InformationUnit do
+  require MapSet
+
   @kilobyte_bytes 1000
   @megabyte_bytes @kilobyte_bytes * 1000
   @gigabyte_bytes @megabyte_bytes * 1000
   @terabyte_bytes @gigabyte_bytes * 1000
 
+  @known_units    MapSet.new(["bytes",
+                              "kb", "kilobytes",
+                              "mb", "megabytes",
+                              "gb", "gigabytes",
+                              "tb", "terabytes"])
 
   def convert(bytes, "bytes") do
     bytes
@@ -27,6 +34,12 @@ defmodule RabbitMQ.CLI.InformationUnit do
   def convert(bytes, unit) do
     do_convert(bytes, String.downcase(unit))
   end
+
+  def known_unit?(val) do
+    MapSet.member?(@known_units, String.downcase(val))
+  end
+
+
 
   defp do_convert(bytes, "kb") do
     Float.round(bytes / @kilobyte_bytes, 4)

--- a/lib/rabbitmq/cli/information_unit.ex
+++ b/lib/rabbitmq/cli/information_unit.ex
@@ -1,0 +1,54 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.InformationUnit do
+  @kilobyte_bytes 1000
+  @megabyte_bytes @kilobyte_bytes * 1000
+  @gigabyte_bytes @megabyte_bytes * 1000
+  @terabyte_bytes @gigabyte_bytes * 1000
+
+
+  def convert(bytes, "bytes") do
+    bytes
+  end
+
+  def convert(bytes, unit) do
+    do_convert(bytes, String.downcase(unit))
+  end
+
+  defp do_convert(bytes, "kb") do
+    Float.round(bytes / @kilobyte_bytes, 4)
+  end
+
+  defp do_convert(bytes, "kilobytes"), do: do_convert(bytes, "kb")
+
+  defp do_convert(bytes, "mb") do
+    Float.round(bytes / @megabyte_bytes, 4)
+  end
+
+  defp do_convert(bytes, "megabytes"), do: do_convert(bytes, "mb")
+
+  defp do_convert(bytes, "gb") do
+    Float.round(bytes / @gigabyte_bytes, 4)
+  end
+
+  defp do_convert(bytes, "gigabytes"), do: do_convert(bytes, "gb")
+
+  defp do_convert(bytes, "tb") do
+    Float.round(bytes / @terabyte_bytes, 4)
+  end
+
+  defp do_convert(bytes, "terabytes"), do: do_convert(bytes, "tb")
+end

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -66,8 +66,9 @@ defmodule RabbitMQCtl do
                          unparsed_command, parsed_options);
       _ ->
         options = parsed_options |> merge_all_defaults |> normalize_options
+        {arguments, options} = command.merge_defaults(arguments, options)
         with_distribution(options, fn() ->
-          execute_command(options, command, arguments)
+          validate_and_run_command(options, command, arguments)
           |> handle_command_output(command, options, unparsed_command, output_fun)
         end)
     end
@@ -153,8 +154,7 @@ defmodule RabbitMQCtl do
     opts
   end
 
-  defp execute_command(options, command, arguments) do
-    {arguments, options} = command.merge_defaults(arguments, options)
+  defp validate_and_run_command(options, command, arguments) do
     case command.validate(arguments, options) do
       :ok ->
         maybe_print_banner(command, arguments, options)

--- a/test/cancel_sync_command_test.exs
+++ b/test/cancel_sync_command_test.exs
@@ -29,8 +29,6 @@ defmodule CancelSyncQueueCommandTest do
 
     on_exit([], fn ->
       start_rabbitmq_app()
-
-
     end)
 
     :ok

--- a/test/diagnostics/memory_breakdown_command_test.exs
+++ b/test/diagnostics/memory_breakdown_command_test.exs
@@ -1,0 +1,84 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is Pivotal Software, Inc.
+## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
+
+defmodule MemoryBreakdownCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+
+    start_rabbitmq_app()
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup do
+    {:ok, opts: %{
+      node: get_rabbit_hostname(),
+      timeout: 5000,
+      unit: "gb"
+    }}
+  end
+
+  test "validate: specifying a positional argument fails validation", context do
+    assert @command.validate(["abc"], context[:opts]) ==
+    {:validation_failure, :too_many_args}
+
+    assert @command.validate(["abc", "def"], context[:opts]) ==
+      {:validation_failure, :too_many_args}
+  end
+
+  test "validate: specifying no positional arguments and no options succeeds", context do
+    assert @command.validate([], context[:opts]) == :ok
+  end
+
+  test "validate: specifying gigabytes as a --unit succeeds", context do
+    assert @command.validate([], Map.merge(context[:opts], %{unit: "mb"})) == :ok
+  end
+
+  test "validate: specifying bytes as a --unit succeeds", context do
+    assert @command.validate([], Map.merge(context[:opts], %{unit: "mb"})) == :ok
+  end
+
+  test "validate: specifying megabytes as a --unit succeeds", context do
+    assert @command.validate([], Map.merge(context[:opts], %{unit: "mb"})) == :ok
+  end
+
+  test "validate: specifying glip-glops as a --unit fails validation", context do
+    assert @command.validate([], Map.merge(context[:opts], %{unit: "glip-glops"})) ==
+    {:validation_failure, "unit 'glip-glops' is not supported. Please use one of: bytes, mb, gb"}
+  end
+
+  test "run: request to a non-existent RabbitMQ node returns a nodedown" do
+    target = :jake@thedog
+
+    opts = %{node: target, timeout: 5000, unit: "gb"}
+    assert match?({:badrpc, :nodedown}, @command.run([], opts))
+  end
+
+  test "banner", context do
+    s = @command.banner([], context[:opts])
+
+    assert s =~ ~r/Reporting memory breakdown on node/
+  end
+end

--- a/test/diagnostics/memory_breakdown_command_test.exs
+++ b/test/diagnostics/memory_breakdown_command_test.exs
@@ -53,11 +53,11 @@ defmodule MemoryBreakdownCommandTest do
   end
 
   test "validate: specifying gigabytes as a --unit succeeds", context do
-    assert @command.validate([], Map.merge(context[:opts], %{unit: "mb"})) == :ok
+    assert @command.validate([], Map.merge(context[:opts], %{unit: "gb"})) == :ok
   end
 
   test "validate: specifying bytes as a --unit succeeds", context do
-    assert @command.validate([], Map.merge(context[:opts], %{unit: "mb"})) == :ok
+    assert @command.validate([], Map.merge(context[:opts], %{unit: "bytes"})) == :ok
   end
 
   test "validate: specifying megabytes as a --unit succeeds", context do

--- a/test/information_unit.exs
+++ b/test/information_unit.exs
@@ -1,0 +1,53 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule InformationUnitTest do
+  use ExUnit.Case, async: true
+
+  alias RabbitMQ.CLI.InformationUnit, as: IU
+
+  test "bytes, MB, GB, TB are known units" do
+    Enum.each(["bytes", "mb", "MB", "gb", "GB", "tb", "TB"],
+              fn x -> assert IU.known_unit?(x) end)
+  end
+
+  test "glip-glops, millibars, gold pressed latinum bars and looney and are not known units" do
+    Enum.each(["glip-glops", "millibars", "gold pressed latinum bars", "looney"],
+              fn x -> assert not IU.known_unit?(x) end)
+  end
+
+  test "conversion to bytes" do
+    assert IU.convert(0, "bytes") == 0
+    assert IU.convert(100, "bytes") == 100
+    assert IU.convert(9988, "bytes") == 9988
+  end
+
+  test "conversion to MB" do
+    assert IU.convert(1000000, "mb") == 1.0
+    assert IU.convert(9500000, "mb") == 9.5
+    assert IU.convert(97893000, "mb") == 97.893
+    assert IU.convert(978930000, "mb") == 978.93
+  end
+
+  test "conversion to GB" do
+    assert IU.convert(978930000, "gb") == 0.9789
+
+    assert IU.convert(1000000000, "gb") == 1.0
+    assert IU.convert(9500000000, "gb") == 9.5
+    assert IU.convert(97893000000, "gb") == 97.893
+    assert IU.convert(978930000000, "gb") == 978.93
+  end
+end

--- a/test/set_vm_memory_high_watermark_command_test.exs
+++ b/test/set_vm_memory_high_watermark_command_test.exs
@@ -28,9 +28,6 @@ defmodule SetVmMemoryHighWatermarkCommandTest do
 
     on_exit([], fn ->
       reset_vm_memory_high_watermark()
-
-
-
     end)
 
     {:ok, opts: %{node: get_rabbit_hostname()}}


### PR DESCRIPTION
Similar to what management UI has had for a while. Here are some output examples:

```
./escript/rabbitmq-diagnostics memory_breakdown
Reporting memory breakdown on node rabbit@mercurio...
code: 0.0265 gb (27.59%)
other_proc: 0.0243 gb (25.3%)
other_system: 0.0187 gb (19.52%)
queue_procs: 0.0118 gb (12.31%)
binary: 0.0093 gb (9.75%)
other_ets: 0.0028 gb (2.89%)
atom: 0.001 gb (1.09%)
connection_channels: 0.0004 gb (0.47%)
connection_writers: 0.0003 gb (0.36%)
metrics: 0.0002 gb (0.21%)
connection_other: 0.0002 gb (0.2%)
connection_readers: 0.0001 gb (0.1%)
mnesia: 0.0001 gb (0.09%)
plugins: 0.0001 gb (0.08%)
msg_index: 0.0 gb (0.03%)
queue_slave_procs: 0.0 gb (0.0%)
mgmt_db: 0.0 gb (0.0%)
```

```
./escript/rabbitmq-diagnostics memory_breakdown --unit "mb"
Reporting memory breakdown on node rabbit@mercurio...
code: 26.4681 mb (32.44%)
other_proc: 19.3973 mb (23.77%)
other_system: 18.7338 mb (22.96%)
queue_procs: 7.6718 mb (9.4%)
binary: 4.2315 mb (5.19%)
other_ets: 2.7734 mb (3.4%)
atom: 1.0416 mb (1.28%)
connection_writers: 0.3032 mb (0.37%)
connection_channels: 0.2445 mb (0.3%)
metrics: 0.2005 mb (0.25%)
connection_other: 0.1966 mb (0.24%)
connection_readers: 0.1316 mb (0.16%)
mnesia: 0.0884 mb (0.11%)
plugins: 0.0778 mb (0.1%)
msg_index: 0.0328 mb (0.04%)
queue_slave_procs: 0.0 mb (0.0%)
mgmt_db: 0.0 mb (0.0%)
```

```
./escript/rabbitmq-diagnostics memory_breakdown --unit "bytes"
Reporting memory breakdown on node rabbit@mercurio...
code: 26468066 bytes (29.15%)
other_system: 18737813 bytes (20.63%)
other_proc: 18184056 bytes (20.02%)
queue_procs: 15315072 bytes (16.86%)
binary: 7005048 bytes (7.71%)
other_ets: 2773456 bytes (3.05%)
atom: 1041593 bytes (1.15%)
connection_writers: 288752 bytes (0.32%)
connection_channels: 276456 bytes (0.3%)
metrics: 200512 bytes (0.22%)
connection_other: 196560 bytes (0.22%)
connection_readers: 126568 bytes (0.14%)
mnesia: 88392 bytes (0.1%)
plugins: 77824 bytes (0.09%)
msg_index: 32752 bytes (0.04%)
queue_slave_procs: 0 bytes (0.0%)
mgmt_db: 0 bytes (0.0%)
```

As a drive-by change this makes sure that combined `options` (user-provided plus command's defaults) are propagated to all command lifecycle functions, not just `run/2`.