### PR TITLE
Recompile regexes at runtime.

### DIFF
--- a/lib/rabbitmq/cli/core/command_modules.ex
+++ b/lib/rabbitmq/cli/core/command_modules.ex
@@ -87,9 +87,10 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
   end
 
   defp make_module_map(modules, scope) do
+    commands_ns = Regex.recompile!(@commands_ns)
     modules
     |> Enum.filter(fn(mod) ->
-                     to_string(mod) =~ @commands_ns
+                     to_string(mod) =~ commands_ns
                      and
                      module_exists?(mod)
                      and
@@ -167,7 +168,7 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
       true  ->
         cmd.scopes()
       false ->
-        @commands_ns
+        Regex.recompile!(@commands_ns)
         |> Regex.run(to_string(cmd), capture: :all_but_first)
         |> List.first
         |> to_snake_case

--- a/lib/rabbitmq/cli/core/os_pid.ex
+++ b/lib/rabbitmq/cli/core/os_pid.ex
@@ -35,7 +35,8 @@ defmodule RabbitMQ.CLI.Core.OsPid do
   def read_pid_from_file(pidfile_path, should_wait) do
     case {:file.read_file(pidfile_path), should_wait} do
       {{:ok, contents}, _} ->
-        case Regex.named_captures(@pid_regex, contents)["pid"] do
+        pid_regex = Regex.recompile!(@pid_regex)
+        case Regex.named_captures(pid_regex, contents)["pid"] do
           # e.g. the file is empty
           nil        -> {:error, :could_not_read_pid_from_file, {:contents, contents}};
           pid_string ->


### PR DESCRIPTION
Because the regex engine may change between OTP versions it is necessary
to recompile any compiled regexes at runtime in case the engine is not
compatible.

Fixes #208 

[#149227527]