### PR TITLE
Do not crash command loading if unable to read enabled plugins file.

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -34,7 +34,7 @@ use Mix.Config
 #
 # Or configure a 3rd-party app:
 #
-config :logger, level: :warn
+config :logger, [level: :warn, console: [device: :standard_error]]
 #
 
 # It is also possible to import configuration files, relative to this

--- a/lib/rabbitmq/cli/core/command_modules.ex
+++ b/lib/rabbitmq/cli/core/command_modules.ex
@@ -67,10 +67,10 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
       catch err ->
         {:ok, enabled_plugins_file} = PluginsHelpers.enabled_plugins_file(opts)
         require Logger
-        Logger.warn("Unable to read enebled plugins file.\n" <>
+        Logger.warn("Unable to read the enebled plugins file.\n" <>
                     "  Reason: #{inspect(err)}\n" <>
-                    "  Plugins commands will not be available.\n" <>
-                    "  Please make sure you have access to\n" <>
+                    "  Commands provided by plugins will not be available.\n" <>
+                    "  Please make sure your user has sufficient permissions to read to\n" <>
                     "    #{enabled_plugins_file}")
         []
       end


### PR DESCRIPTION
Some distributions set no permissions to read the enabled plugins
file location. This can cause a crash when running not as root or
rabbitmq user.
It was decided that plugins commands can be skipped when printing
the help message if the user have no access to the enabled plugins
file.
The warning message will be displayed in that case.

Addresses https://github.com/rabbitmq/rabbitmq-server/issues/1296