### PR TITLE
Use RPC to call rabbit:is_running

### DIFF
--- a/lib/rabbitmq/cli/command_behaviour.ex
+++ b/lib/rabbitmq/cli/command_behaviour.ex
@@ -29,7 +29,8 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
                       scopes: 0,
                       usage_additional: 0,
                       switches: 0,
-                      aliases: 0
+                      aliases: 0,
+                      offline_ok?: 0
 
   @callback switches() :: Keyword.t
   @callback aliases() :: Keyword.t
@@ -37,4 +38,7 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
   @callback formatter() :: Atom.t
   @callback scopes() :: [Atom.t]
   @callback usage_additional() :: String.t | [String.t]
+
+  # Returns true if rabbit app can be offline
+  @callback offline_ok?() :: Boolean.t
 end

--- a/lib/rabbitmq/cli/command_behaviour.ex
+++ b/lib/rabbitmq/cli/command_behaviour.ex
@@ -30,7 +30,8 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
                       usage_additional: 0,
                       switches: 0,
                       aliases: 0,
-                      offline_ok?: 0
+                      requires_rabbit_app_running?: 0,
+                      requires_rabbit_app_running?: 1
 
   @callback switches() :: Keyword.t
   @callback aliases() :: Keyword.t
@@ -39,6 +40,7 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
   @callback scopes() :: [Atom.t]
   @callback usage_additional() :: String.t | [String.t]
 
-  # Returns true if rabbit app can be offline
-  @callback offline_ok?() :: Boolean.t
+  # Returns true if rabbit app must be running for command to run
+  @callback requires_rabbit_app_running? :: Boolean.t
+  @callback requires_rabbit_app_running?(Map.t) :: Boolean.t
 end

--- a/lib/rabbitmq/cli/core/exit_codes.ex
+++ b/lib/rabbitmq/cli/core/exit_codes.ex
@@ -40,6 +40,7 @@ defmodule RabbitMQ.CLI.Core.ExitCodes do
   def exit_code_for({:validation_failure, :bad_argument}),         do: exit_dataerr()
   def exit_code_for({:validation_failure, :eperm}),                do: exit_dataerr()
   def exit_code_for({:validation_failure, {:bad_option, _}}),      do: exit_usage()
+  def exit_code_for({:validation_failure, {:rabbit_app_not_running, _}}), do: exit_tempfail()
   def exit_code_for({:validation_failure, _}),                     do: exit_usage()
   # a special case of bad_argument
   def exit_code_for({:no_such_vhost, _}),       do: exit_dataerr()

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -51,11 +51,12 @@ defmodule RabbitMQ.CLI.Core.Helpers do
 
   def validate_rabbit_app_running(%{node: node_name, timeout: timeout}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit, :is_running, [], timeout) do
+      :true -> :ok
       :false ->
         errmsg = "rabbit application is not running on node #{node_name}.\
  Suggestion: start it with 'rabbitmqctl start_app' and try again"
         {:validation_failure, errmsg}
-      :true -> :ok
+      error -> {:validation_failure, {error, node_name}}
     end
   end
 

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -183,16 +183,6 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     :net_adm.ping(node) == :pong
   end
 
-  def rabbit_app_running?(%{node: node, timeout: timeout}) do
-    case :rabbit_misc.rpc_call(node, :rabbit, :is_running, [], timeout) do
-      true -> :ok
-      false ->
-        {:validation_failure, {:rabbit_app_not_running, node}}
-      error ->
-        error
-    end
-  end
-
   # Convert function to stream
   def defer(fun) do
     Stream.iterate(:ok, fn(_) -> fun.() end)

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -49,6 +49,16 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     {:validation_failure, err}
   end
 
+  def validate_rabbit_app_running(%{node: node_name, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit, :is_running, [], timeout) do
+      :false ->
+        errmsg = "rabbit application is not running on node #{node_name}.\
+ Suggestion: start it with 'rabbitmqctl start_app' and try again"
+        {:validation_failure, errmsg}
+      :true -> :ok
+    end
+  end
+
   def memory_units do
     ["k", "kiB", "M", "MiB", "G", "GiB", "kB", "MB", "GB", ""]
   end

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -53,10 +53,9 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     case :rabbit_misc.rpc_call(node_name, :rabbit, :is_running, [], timeout) do
       :true -> :ok
       :false ->
-        errmsg = "rabbit application is not running on node #{node_name}.\
- Suggestion: start it with 'rabbitmqctl start_app' and try again"
-        {:validation_failure, errmsg}
-      error -> {:validation_failure, {error, node_name}}
+        {:validation_failure, {:rabbit_app_not_running, node_name}}
+      error ->
+        {:validation_failure, {error, node_name}}
     end
   end
 

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -189,7 +189,7 @@ defmodule RabbitMQ.CLI.Core.Helpers do
       false ->
         {:validation_failure, {:rabbit_app_not_running, node}}
       error ->
-        {:validation_failure, {error, node}}
+        error
     end
   end
 

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -183,6 +183,16 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     :net_adm.ping(node) == :pong
   end
 
+  def rabbit_app_running?(%{node: node, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node, :rabbit, :is_running, [], timeout) do
+      true -> :ok
+      false ->
+        {:validation_failure, {:rabbit_app_not_running, node}}
+      error ->
+        error
+    end
+  end
+
   # Convert function to stream
   def defer(fun) do
     Stream.iterate(:ok, fn(_) -> fun.() end)

--- a/lib/rabbitmq/cli/core/validators.ex
+++ b/lib/rabbitmq/cli/core/validators.ex
@@ -60,4 +60,13 @@ defmodule RabbitMQ.CLI.Core.Validators do
       {:error, err} -> {:validation_failure, err}
     end
   end
+
+  def rabbit_app_running?(%{node: node, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node, :rabbit, :is_running, [], timeout) do
+      true -> :ok
+      false ->
+        {:validation_failure, {:rabbit_app_not_running, node}}
+      error -> error
+    end
+  end
 end

--- a/lib/rabbitmq/cli/core/validators.ex
+++ b/lib/rabbitmq/cli/core/validators.ex
@@ -60,13 +60,4 @@ defmodule RabbitMQ.CLI.Core.Validators do
       {:error, err} -> {:validation_failure, err}
     end
   end
-
-  def rabbit_app_running?(%{node: node, timeout: timeout}) do
-    case :rabbit_misc.rpc_call(node, :rabbit, :is_running, [], timeout) do
-      true -> :ok
-      false ->
-        {:validation_failure, {:rabbit_app_not_running, node}}
-      error -> error
-    end
-  end
 end

--- a/lib/rabbitmq/cli/core/validators.ex
+++ b/lib/rabbitmq/cli/core/validators.ex
@@ -17,9 +17,18 @@
 # Small helper functions, mostly related to connecting to RabbitMQ and
 # handling memory units.
 
-defmodule RabbitMQ.CLI.Ctl.Validators do
+defmodule RabbitMQ.CLI.Core.Validators do
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
+  def validate_step(:ok, step) do
+    case step.() do
+      {:error, err} -> {:validation_failure, err};
+      _             -> :ok
+    end
+  end
+  def validate_step({:validation_failure, err}, _) do
+    {:validation_failure, err}
+  end
 
   def chain([validator | rest], args) do
     case apply(validator, args) do

--- a/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -32,7 +32,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
   def validate(["", _], _) do
     {:validation_failure, {:bad_argument, "user cannot be empty string."}}
   end
-  def validate(_, _), do: :ok
+  def validate([_,_], _), do: :ok
 
   def run([_, _] = args, %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -32,9 +32,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
   def validate(["", _], _) do
     {:validation_failure, {:bad_argument, "user cannot be empty string."}}
   end
-  def validate(_, opts) do
-    Helpers.validate_rabbit_app_running(opts)
-  end
+  def validate(_, _), do: :ok
 
   def run([_, _] = args, %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -34,8 +34,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
   def validate(["", _], _) do
     {:validation_failure, {:bad_argument, "user cannot be empty string."}}
   end
-
-  def validate([_,_], _), do: :ok
+  def validate(_, opts) do
+    Helpers.validate_rabbit_app_running(opts)
+  end
 
   def run([_, _] = args, %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -15,11 +15,9 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
-
+  @behaviour RabbitMQ.CLI.CommandBehaviour
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
   alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
-
-  @behaviour RabbitMQ.CLI.CommandBehaviour
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -21,9 +21,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
 
   def validate([], _), do: {:validation_failure, :not_enough_args}
   def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
-  def validate([_], opts) do
-    Helpers.validate_rabbit_app_running(opts)
-  end
+  def validate([_], _), do: :ok
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -15,16 +15,18 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
-
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+
   def validate([], _), do: {:validation_failure, :not_enough_args}
   def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
-  def validate([_], _), do: :ok
+  def validate([_], opts) do
+    Helpers.validate_rabbit_app_running(opts)
+  end
 
   def merge_defaults(args, opts), do: {args, opts}
+
   def run([vhost], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, Helpers.cli_acting_user()])
   end
@@ -32,5 +34,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
   def usage, do: "add_vhost <vhost>"
 
   def banner([vhost], _), do: "Adding vhost \"#{vhost}\" ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
@@ -16,9 +16,14 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.AuthenticateUserCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+
   def validate(args, _) when length(args) < 2, do: {:validation_failure, :not_enough_args}
   def validate(args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
-  def validate([_,_], _), do: :ok
+  def validate([_,_], opts) do
+    Helpers.validate_rabbit_app_running(opts)
+  end
+
   def merge_defaults(args, opts), do: {args, opts}
 
   def run([user, password], %{node: node_name}) do
@@ -32,7 +37,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AuthenticateUserCommand do
   def usage, do: "authenticate_user <username> <password>"
 
   def banner([username, _password], _), do: "Authenticating user \"#{username}\" ..."
-
 
   def output({:refused, user, msg, args}, _) do
     {:error, RabbitMQ.CLI.Core.ExitCodes.exit_dataerr,

--- a/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
@@ -16,13 +16,10 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.AuthenticateUserCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   def validate(args, _) when length(args) < 2, do: {:validation_failure, :not_enough_args}
   def validate(args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
-  def validate([_,_], opts) do
-    Helpers.validate_rabbit_app_running(opts)
-  end
+  def validate([_,_], _), do: :ok
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/ctl/commands/cancel_sync_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/cancel_sync_queue_command.ex
@@ -16,6 +16,7 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.CancelSyncQueueCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   def merge_defaults(args, opts) do
     {args, Map.merge(default_opts(), opts)}
@@ -23,9 +24,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CancelSyncQueueCommand do
 
   def usage, do: "cancel_sync_queue [-p <vhost>] queue"
 
-  def validate([], _),  do: {:validation_failure, :not_enough_args}
-  def validate([_], _), do: :ok
-  def validate(_, _),   do: {:validation_failure, :too_many_args}
+  def validate([], _), do: {:validation_failure, :not_enough_args}
+  def validate([_], opts) do
+    Helpers.validate_rabbit_app_running(opts)
+  end
+  def validate(_, _), do: {:validation_failure, :too_many_args}
 
   def run([queue], %{vhost: vhost, node: node_name}) do
     :rpc.call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/cancel_sync_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/cancel_sync_queue_command.ex
@@ -16,7 +16,6 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.CancelSyncQueueCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   def merge_defaults(args, opts) do
     {args, Map.merge(default_opts(), opts)}
@@ -25,9 +24,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CancelSyncQueueCommand do
   def usage, do: "cancel_sync_queue [-p <vhost>] queue"
 
   def validate([], _), do: {:validation_failure, :not_enough_args}
-  def validate([_], opts) do
-    Helpers.validate_rabbit_app_running(opts)
-  end
+  def validate([_], _), do: :ok
   def validate(_, _), do: {:validation_failure, :too_many_args}
 
   def run([queue], %{vhost: vhost, node: node_name}) do

--- a/lib/rabbitmq/cli/ctl/commands/change_cluster_node_type_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/change_cluster_node_type_command.ex
@@ -13,13 +13,14 @@
 ## The Initial Developer of the Original Code is Pivotal Software, Inc.
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.ChangeClusterNodeTypeCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
   def merge_defaults(args, opts) do
     {args, opts}
   end
+
+  def requires_rabbit_app_running?, do: false
 
   def validate([], _),  do: {:validation_failure, :not_enough_args}
 

--- a/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
@@ -15,16 +15,17 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ChangePasswordCommand do
-
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+
   def merge_defaults(args, opts), do: {args, opts}
 
   def validate(args, _) when length(args) < 2, do: {:validation_failure, :not_enough_args}
   def validate([_|_] = args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
-  def validate(_, _), do: :ok
+  def validate(_, opts) do
+    Helpers.validate_rabbit_app_running(opts)
+  end
 
   def run([_user, _] = args, %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,
@@ -34,5 +35,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ChangePasswordCommand do
   def usage, do: "change_password <username> <password>"
 
   def banner([user| _], _), do: "Changing password for user \"#{user}\" ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
@@ -23,9 +23,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ChangePasswordCommand do
 
   def validate(args, _) when length(args) < 2, do: {:validation_failure, :not_enough_args}
   def validate([_|_] = args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
-  def validate(_, opts) do
-    Helpers.validate_rabbit_app_running(opts)
-  end
+  def validate(_, _), do: :ok
 
   def run([_user, _] = args, %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/clear_global_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_global_parameter_command.ex
@@ -15,11 +15,10 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearGlobalParameterCommand do
-
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+
   def merge_defaults(args, opts) do
     {args, opts}
   end
@@ -30,7 +29,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearGlobalParameterCommand do
   def validate([_|_] = args, _) when length(args) > 1 do
     {:validation_failure, :too_many_args}
   end
-  def validate([_], _), do: :ok
+  def validate([_], opts) do
+    Helpers.validate_rabbit_app_running(opts)
+  end
 
   def run([key], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/clear_global_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_global_parameter_command.ex
@@ -29,9 +29,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearGlobalParameterCommand do
   def validate([_|_] = args, _) when length(args) > 1 do
     {:validation_failure, :too_many_args}
   end
-  def validate([_], opts) do
-    Helpers.validate_rabbit_app_running(opts)
-  end
+  def validate([_], _), do: :ok
 
   def run([key], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
@@ -29,9 +29,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearOperatorPolicyCommand do
   def validate([_,_|_], _) do
     {:validation_failure, :too_many_args}
   end
-  def validate([_], opts) do
-    Helpers.validate_rabbit_app_running(opts)
-  end
+  def validate([_], _), do: :ok
 
   def run([key], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
@@ -15,11 +15,10 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearOperatorPolicyCommand do
-
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}
   end
@@ -30,7 +29,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearOperatorPolicyCommand do
   def validate([_,_|_], _) do
     {:validation_failure, :too_many_args}
   end
-  def validate([_], _), do: :ok
+  def validate([_], opts) do
+    Helpers.validate_rabbit_app_running(opts)
+  end
 
   def run([key], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
@@ -38,7 +39,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearOperatorPolicyCommand do
   end
 
   def usage, do: "clear_operator_policy [-p <vhost>] <key>"
-
 
   def banner([key], %{vhost: vhost}) do
     "Clearing operator policy \"#{key}\" on vhost \"#{vhost}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
@@ -13,14 +13,17 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def requires_rabbit_app_running?, do: false
+
   def merge_defaults(args, opts), do: {args, opts}
+
   def validate(args, _) when length(args) != 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
+
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
   def scopes(), do: [:ctl, :diagnostics]
@@ -43,7 +46,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
   end
 
   def usage, do: "cluster_status"
-
 
   defp alarms_by_node(node) do
     alarms = :rabbit_misc.rpc_call(node, :rabbit, :alarms, [])

--- a/lib/rabbitmq/cli/ctl/commands/decode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/decode_command.ex
@@ -19,6 +19,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def requires_rabbit_app_running?, do: false
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{
         cipher:       :rabbit_pbe.default_cipher(),
@@ -76,5 +78,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
   defp supports_cipher(cipher), do: Enum.member?(:rabbit_pbe.supported_ciphers(), cipher)
 
   defp supports_hash(hash), do: Enum.member?(:rabbit_pbe.supported_hashes(), hash)
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/encode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/encode_command.ex
@@ -19,6 +19,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def requires_rabbit_app_running?, do: false
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{
         cipher:       :rabbit_pbe.default_cipher(),
@@ -72,5 +74,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
   defp supports_cipher(cipher), do: Enum.member?(:rabbit_pbe.supported_ciphers(), cipher)
 
   defp supports_hash(hash), do: Enum.member?(:rabbit_pbe.supported_hashes(), hash)
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/environment_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/environment_command.ex
@@ -13,14 +13,16 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.EnvironmentCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def requires_rabbit_app_running?, do: false
+
+  def merge_defaults(args, opts), do: {args, opts}
+
   def validate([_|_], _), do: {:validation_failure, :too_many_args}
   def validate(_, _), do: :ok
-  def merge_defaults(args, opts), do: {args, opts}
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
@@ -32,5 +34,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EnvironmentCommand do
   def usage, do: "environment"
 
   def banner(_, %{node: node_name}), do: "Application environment of node #{node_name} ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/eval_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/eval_command.ex
@@ -13,10 +13,11 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts), do: {args, opts}
 
@@ -76,5 +77,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
   defp format_parse_error({_line, mod, err}) do
     to_string(:lists.flatten(mod.format_error(err)))
   end
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
@@ -13,11 +13,12 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.Config, as: Config
-
 defmodule RabbitMQ.CLI.Ctl.Commands.ForceBootCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+  alias RabbitMQ.CLI.Core.Config, as: Config
+
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts), do: {args, opts}
 
@@ -49,5 +50,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceBootCommand do
   def usage, do: "force_boot"
 
   def banner(_, _), do: nil
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
@@ -13,10 +13,10 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.ForceResetCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
@@ -27,7 +27,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceResetCommand do
   end
 
   def usage, do: "force_reset"
-
 
   def banner(_, %{node: node_name}), do: "Forcefully resetting node #{node_name} ..."
 

--- a/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
@@ -17,10 +17,18 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   import Rabbitmq.Atom.Coerce
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
   alias RabbitMQ.CLI.Core.Validators, as: Validators
   alias RabbitMQ.CLI.Core.Distribution, as: Distribution
 
   def switches(), do: [offline: :boolean]
+
+  def requires_rabbit_app_running?(%{offline: true}) do
+    false
+  end
+  def requires_rabbit_app_running?(%{offline: false}) do
+    true
+  end
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{offline: false}, opts)}
@@ -41,7 +49,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
   def run([node_to_remove], %{node: node_name, offline: true} = opts) do
     Stream.concat([
       become(node_name, opts),
-      RabbitMQ.CLI.Core.Helpers.defer(fn() ->
+      Helpers.defer(fn() ->
         :rabbit_event.start_link()
         :rabbit_mnesia.forget_cluster_node(to_atom(node_to_remove), true)
       end)])
@@ -61,7 +69,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
     "Removing node #{node_to_remove} from the cluster"
   end
 
-
   defp become(node_name, opts) do
     :error_logger.tty(false)
     case :net_adm.ping(node_name) do
@@ -69,11 +76,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
         :pang -> :ok = :net_kernel.stop()
                  Stream.concat([
                    ["  * Impersonating node: #{node_name}..."],
-                   RabbitMQ.CLI.Core.Helpers.defer(fn() ->
+                   Helpers.defer(fn() ->
                      {:ok, _} = Distribution.start_as(node_name, opts)
                      " done"
                    end),
-                   RabbitMQ.CLI.Core.Helpers.defer(fn() ->
+                   Helpers.defer(fn() ->
                      dir = :mnesia.system_info(:directory)
                      "  * Mnesia directory: #{dir}..."
                    end)])

--- a/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
@@ -13,14 +13,12 @@
 ## The Initial Developer of the Original Code is Pivotal Software, Inc.
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Ctl.Validators, as: Validators
-alias RabbitMQ.CLI.Core.Distribution,   as: Distribution
-
 defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
-  import Rabbitmq.Atom.Coerce
-
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+  import Rabbitmq.Atom.Coerce
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
+  alias RabbitMQ.CLI.Core.Distribution, as: Distribution
 
   def switches(), do: [offline: :boolean]
 

--- a/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -13,14 +13,14 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
 
   alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
   alias RabbitMQ.CLI.Core.ExitCodes,      as: ExitCodes
   alias RabbitMQ.CLI.Core.Config,         as: Config
 
-  @behaviour RabbitMQ.CLI.CommandBehaviour
+  def requires_rabbit_app_running?, do: false
 
   def validate(_, _), do: :ok
 

--- a/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
@@ -14,14 +14,10 @@
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.HipeCompileCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
-
-  #
-  # API
-  #
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
 
   def merge_defaults(args, opts) do
     {args, opts}
@@ -34,13 +30,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HipeCompileCommand do
   def validate([], _),  do: {:validation_failure, :not_enough_args}
   def validate([target_dir], opts) do
     :ok
-    |> Helpers.validate_step(fn() ->
+    |> Validators.validate_step(fn() ->
       case acceptable_path?(target_dir) do
         true  -> :ok
         false -> {:error, {:bad_argument, "Target directory path cannot be blank"}}
       end
     end)
-    |> Helpers.validate_step(fn() ->
+    |> Validators.validate_step(fn() ->
       case File.dir?(target_dir) do
         true  -> :ok
         false ->
@@ -51,7 +47,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HipeCompileCommand do
           end
       end
     end)
-    |> Helpers.validate_step(fn() -> Helpers.require_rabbit(opts) end)
+    |> Validators.validate_step(fn() -> Helpers.require_rabbit(opts) end)
   end
   def validate(_, _),   do: {:validation_failure, :too_many_args}
 

--- a/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
@@ -19,6 +19,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HipeCompileCommand do
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
   alias RabbitMQ.CLI.Core.Validators, as: Validators
 
+  def requires_rabbit_app_running?, do: false
+
   def merge_defaults(args, opts) do
     {args, opts}
   end

--- a/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
@@ -13,7 +13,6 @@
 ## The Initial Developer of the Original Code is Pivotal Software, Inc.
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
@@ -25,6 +24,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
       ram: :boolean
     ]
   end
+
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{disc: false, ram: false}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/list_ciphers_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_ciphers_command.ex
@@ -17,6 +17,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListCiphersCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def requires_rabbit_app_running?, do: false
+
   def merge_defaults(args, opts) do
     {args, opts}
   end
@@ -35,5 +37,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListCiphersCommand do
   def usage, do: "list_ciphers"
 
   def banner(_, _), do: "Listing supported ciphers ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_hashes_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_hashes_command.ex
@@ -17,6 +17,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListHashesCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def requires_rabbit_app_running?, do: false
+
   def merge_defaults(args, opts) do
     {args, opts}
   end
@@ -35,5 +37,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListHashesCommand do
   def usage, do: "list_hashes"
 
   def banner(_, _), do: "Listing supported hash algorithms ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
@@ -13,17 +13,16 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
   require RabbitMQ.CLI.Ctl.InfoKeys
   require RabbitMQ.CLI.Ctl.RpcStream
+
+  use RabbitMQ.CLI.DefaultOutput
 
   alias RabbitMQ.CLI.Ctl.InfoKeys, as: InfoKeys
   alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-
-  @behaviour RabbitMQ.CLI.CommandBehaviour
-  use RabbitMQ.CLI.DefaultOutput
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 

--- a/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
@@ -27,9 +27,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUsersCommand do
   def validate([_|_], _) do
     {:validation_failure, :too_many_args}
   end
-  def validate(_, opts) do
-    Helpers.validate_rabbit_app_running(opts)
-  end
+  def validate(_, _), do: :ok
 
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_auth_backend_internal, :list_users, [], timeout)

--- a/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
@@ -17,6 +17,7 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.ListUsersCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+  alias RabbitMQ.CLI.Core.Helpers
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
   def merge_defaults(args, opts), do: {args, opts}
@@ -26,7 +27,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUsersCommand do
   def validate([_|_], _) do
     {:validation_failure, :too_many_args}
   end
-  def validate(_, _), do: :ok
+  def validate(_, opts) do
+    Helpers.validate_rabbit_app_running(opts)
+  end
 
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_auth_backend_internal, :list_users, [], timeout)

--- a/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
@@ -17,7 +17,7 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.ListUsersCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
-  alias RabbitMQ.CLI.Core.Helpers
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
   def merge_defaults(args, opts), do: {args, opts}
@@ -38,5 +38,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUsersCommand do
   def usage, do: "list_users"
 
   def banner(_,_), do: "Listing users ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
@@ -22,6 +22,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RenameClusterNodeCommand do
 
   def switches(), do: [mnesia_dir: :string, rabbitmq_home: :string]
 
+  def requires_rabbit_app_running?, do: false
+
   def merge_defaults(args, opts), do: {args, opts}
 
   def validate([], _),  do: {:validation_failure, :not_enough_args}

--- a/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
@@ -13,15 +13,12 @@
 ## The Initial Developer of the Original Code is Pivotal Software, Inc.
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
-require Integer
-
-alias RabbitMQ.CLI.Ctl.Validators, as: Validators
-
 defmodule RabbitMQ.CLI.Ctl.Commands.RenameClusterNodeCommand do
-  import Rabbitmq.Atom.Coerce
-
   @behaviour RabbitMQ.CLI.CommandBehaviour
+  import Rabbitmq.Atom.Coerce
+  require Integer
   use RabbitMQ.CLI.DefaultOutput
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
 
   def switches(), do: [mnesia_dir: :string, rabbitmq_home: :string]
 

--- a/lib/rabbitmq/cli/ctl/commands/reset_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/reset_command.ex
@@ -13,10 +13,10 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.ResetCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
@@ -28,9 +28,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ResetCommand do
 
   def usage, do: "reset"
 
-
   def banner(_, %{node: node_name}), do: "Resetting node #{node_name} ..."
-
 
   def output({:error, :mnesia_unexpectedly_running}, %{node: node_name}) do
     {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software,

--- a/lib/rabbitmq/cli/ctl/commands/rotate_logs_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/rotate_logs_command.ex
@@ -13,11 +13,11 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.RotateLogsCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
@@ -28,7 +28,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RotateLogsCommand do
   end
 
   def usage, do: "rotate_logs"
-
 
   def banner(_, %{node: node_name}), do: "Rotating logs for node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
@@ -13,7 +13,6 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.ShutdownCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
@@ -55,4 +54,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ShutdownCommand do
   def usage, do: "shutdown"
 
   def banner(_, _), do: nil
+
+  def requires_rabbit_app_running?, do: false
 end

--- a/lib/rabbitmq/cli/ctl/commands/start_app_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/start_app_command.ex
@@ -13,11 +13,9 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.StartAppCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
-
 
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
@@ -29,6 +27,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StartAppCommand do
 
   def usage, do: "start_app"
 
-
   def banner(_, %{node: node_name}), do: "Starting node #{node_name} ..."
+
+  def requires_rabbit_app_running?, do: false
 end

--- a/lib/rabbitmq/cli/ctl/commands/status_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/status_command.ex
@@ -13,15 +13,17 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts), do: {args, opts}
+
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
+
   def scopes(), do: [:ctl, :diagnostics]
 
   def run([], %{node: node_name}) do
@@ -31,7 +33,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
   def usage, do: "status"
-
 
   def banner(_, %{node: node_name}), do: "Status of node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/stop_app_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/stop_app_command.ex
@@ -13,11 +13,9 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.StopAppCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
-
 
   def merge_defaults(args, opts), do: {args, opts}
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
@@ -29,6 +27,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StopAppCommand do
 
   def usage, do: "stop_app"
 
-
   def banner(_, %{node: node_name}), do: "Stopping rabbit application on node #{node_name} ..."
+
+  def requires_rabbit_app_running?, do: false
 end

--- a/lib/rabbitmq/cli/ctl/commands/stop_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/stop_command.ex
@@ -13,7 +13,6 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.StopCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
@@ -50,4 +49,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StopCommand do
     "Stopping and halting node #{node_name} (will monitor pid file #{pidfile_path}) ..."
   end
   def banner(_, %{node: node_name}), do: "Stopping and halting node #{node_name} ..."
+
+  def requires_rabbit_app_running?, do: false
 end

--- a/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
@@ -13,11 +13,12 @@
 ## The Initial Developer of the Original Code is Pivotal Software, Inc.
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.UpdateClusterNodesCommand do
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts) do
     {args, opts}

--- a/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -13,7 +13,6 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   @default_timeout 10_000
@@ -41,6 +40,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
+  def requires_rabbit_app_running?, do: false
 
   def run([pid_file], %{node: node_name, timeout: timeout} = opts) do
     app_names = :rabbit_and_plugins

--- a/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -13,11 +13,12 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
 defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   @default_timeout 10_000
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
 
   def merge_defaults(args, opts) do
     timeout = case opts[:timeout] do
@@ -30,9 +31,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
 
   def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
   def validate([_], %{pid: _}), do: {:validation_failure, "Cannot specify both pid and pidfile"}
-  def validate([],  %{pid: _} = opts), do: RabbitMQ.CLI.Ctl.Validators.rabbit_is_loaded([], opts)
+  def validate([],  %{pid: _} = opts), do: Validators.rabbit_is_loaded([], opts)
   def validate([],  _), do: {:validation_failure, "No pid or pidfile specified"}
-  def validate([_], opts), do: RabbitMQ.CLI.Ctl.Validators.rabbit_is_loaded([], opts)
+  def validate([_], opts), do: Validators.rabbit_is_loaded([], opts)
 
   def switches(), do: [pid: :integer]
 

--- a/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -13,10 +13,11 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts), do: {args, Map.merge(%{openssl_format: false}, opts)}
 

--- a/lib/rabbitmq/cli/diagnostics/commands/discover_peers_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/discover_peers_command.ex
@@ -13,9 +13,10 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Diagnostics.Commands.DiscoverPeersCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts), do: {args, opts}
 
@@ -45,6 +46,4 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.DiscoverPeersCommand do
   def usage, do: "discover_peers"
 
   def banner(_,_), do: "Discovering peers nodes ..."
-
-
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_hash_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_hash_command.ex
@@ -13,9 +13,10 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieHashCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/diagnostics/commands/erlang_version_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/erlang_version_command.ex
@@ -13,9 +13,10 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangVersionCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{details: false}, opts)}

--- a/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
@@ -13,10 +13,11 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Diagnostics.Commands.MaybeStuckCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -13,11 +13,12 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
   alias RabbitMQ.CLI.InformationUnit, as: IU
 
-  @behaviour RabbitMQ.CLI.CommandBehaviour
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{unit: "gb"}, opts)}
@@ -75,11 +76,9 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
 
   def formatter(), do: Formatter
 
-
   #
   # Implementation
   #
-
   defp compute_relative_values(all_pairs) do
     pairs = Keyword.delete(all_pairs, :total)
     total = Enum.reduce(pairs, 0, fn({_, bytes}, acc) -> acc + bytes end)

--- a/lib/rabbitmq/cli/diagnostics/commands/server_version_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/server_version_command.ex
@@ -13,9 +13,10 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Diagnostics.Commands.ServerVersionCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/formatters/report.ex
+++ b/lib/rabbitmq/cli/formatters/report.ex
@@ -13,11 +13,13 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
-alias RabbitMQ.CLI.Core.Output, as: Output
-
 defmodule RabbitMQ.CLI.Formatters.Report do
   @behaviour RabbitMQ.CLI.FormatterBehaviour
+
+  alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
+  alias RabbitMQ.CLI.Core.Output, as: Output
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+
   def format_output(_, _) do
     raise "format_output is not implemented for report formatter"
   end
@@ -40,7 +42,7 @@ defmodule RabbitMQ.CLI.Formatters.Report do
   end
 
   def format_result(command, output, options) do
-    formatter = RabbitMQCtl.default_formatter(command)
+    formatter = Helpers.default_formatter(command)
     case Output.format_output(output, formatter, options) do
       :ok               -> [];
       {:ok, val}        -> [val];

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -15,12 +15,11 @@
 
 
 defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
 
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
-
-  @behaviour RabbitMQ.CLI.CommandBehaviour
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Plugins
 
@@ -45,9 +44,9 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
 
   def validate(_plugins, opts) do
     :ok
-    |> Helpers.validate_step(fn() -> Helpers.require_rabbit_and_plugins(opts) end)
-    |> Helpers.validate_step(fn() -> PluginHelpers.enabled_plugins_file(opts) end)
-    |> Helpers.validate_step(fn() -> Helpers.plugins_dir(opts) end)
+    |> Validators.validate_step(fn() -> Helpers.require_rabbit_and_plugins(opts) end)
+    |> Validators.validate_step(fn() -> PluginHelpers.enabled_plugins_file(opts) end)
+    |> Validators.validate_step(fn() -> Helpers.plugins_dir(opts) end)
   end
 
   def usage, do: "enable <plugin>|--all [--offline] [--online]"

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -13,7 +13,6 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -32,10 +31,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
                        all: :boolean]
 
   def requires_rabbit_app_running?(%{online: online, offline: offline}) do
-    case get_mode(online, offline) do
-      :online -> true
-      :offline -> false
-    end
+    PluginHelpers.requires_rabbit_app_running?(online, offline)
   end
 
   def validate([], %{all: false}) do
@@ -89,7 +85,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
       MapSet.new(enabled),
       MapSet.difference(MapSet.new(plugins), enabled_implicitly))
 
-    mode = get_mode(online, offline)
+    mode = PluginHelpers.get_mode(online, offline)
 
     case PluginHelpers.set_enabled_plugins(MapSet.to_list(plugins_to_set), opts) do
       {:ok, enabled_plugins} ->
@@ -107,15 +103,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
                end)])};
       {:error, _} = err ->
         err
-    end
-  end
-
-  defp get_mode(online, offline) do
-    case {online, offline} do
-      {true, false}  -> :online
-      {false, true}  -> :offline
-      # fallback to online mode
-      {false, false} -> :online
     end
   end
 

--- a/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -13,19 +13,17 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
-
-  import RabbitCommon.Records
-
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-
-  alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
-
   @behaviour RabbitMQ.CLI.CommandBehaviour
+  import RabbitCommon.Records
   use RabbitMQ.CLI.DefaultOutput
 
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
+
   def formatter(), do: RabbitMQ.CLI.Formatters.Plugins
+
+  def requires_rabbit_app_running?, do: false
 
   def merge_defaults([], opts), do: merge_defaults([".*"], opts)
   def merge_defaults(args, opts), do: {args, Map.merge(default_opts(), opts)}
@@ -68,7 +66,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
   def usage, do: "list [pattern] [--verbose] [--minimal] [--enabled] [--implicitly-enabled]"
 
   def banner([pattern], _), do: "Listing plugins with pattern \"#{pattern}\" ..."
-
 
   def run([pattern], %{node: node_name} = opts) do
     %{verbose: verbose, minimal: minimal,
@@ -162,5 +159,4 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
     %{minimal: false, verbose: false,
       enabled: false, implicitly_enabled: false}
   end
-
 end

--- a/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -12,12 +12,29 @@
 ##
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
-alias RabbitMQ.CLI.Core.Helpers, as: CliHelpers
-alias RabbitMQ.CLI.Core.Config, as: Config
 
 defmodule RabbitMQ.CLI.Plugins.Helpers do
   import Rabbitmq.Atom.Coerce
   import RabbitCommon.Records
+
+  alias RabbitMQ.CLI.Core.Helpers, as: CliHelpers
+  alias RabbitMQ.CLI.Core.Config, as: Config
+
+  def requires_rabbit_app_running?(online, offline) do
+    case get_mode(online, offline) do
+      :online -> true
+      :offline -> false
+    end
+  end
+
+  def get_mode(online, offline) do
+    case {online, offline} do
+      {true, false}  -> :online
+      {false, true}  -> :offline
+      # fallback to online mode
+      {false, false} -> :online
+    end
+  end
 
   def list(opts) do
     {:ok, dir} = CliHelpers.plugins_dir(opts)

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -23,7 +23,6 @@ defmodule RabbitMQCtl do
 
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
   alias RabbitMQ.CLI.Core.Parser, as: Parser
-  alias RabbitMQ.CLI.Core.Validators, as: Validators
 
   alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
 
@@ -231,7 +230,7 @@ defmodule RabbitMQCtl do
           end
       end
     case requires_rabbit_app_running do
-      true -> Validators.rabbit_app_running?(options)
+      true -> Helpers.rabbit_app_running?(options)
       false -> :ok
     end
   end
@@ -272,6 +271,10 @@ defmodule RabbitMQCtl do
     {:error, ExitCodes.exit_code_for({:validation_failure, err_detail}), message}
   end
 
+  defp format_validation_error({{:badrpc, :nodedown}, node}) do
+     diagnostics = get_node_diagnostics(node)
+     badrpc_error_message_header(node) <> diagnostics
+  end
   defp format_validation_error({:rabbit_app_not_running, node}) do
     ~s"""
       Error: rabbit application is not running on node #{node}.

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQCtl do
-  alias RabbitMQ.CLI.Core.Distribution,  as: Distribution
+  alias RabbitMQ.CLI.Core.Distribution, as: Distribution
 
   alias RabbitMQ.CLI.Ctl.Commands.HelpCommand, as: HelpCommand
   alias RabbitMQ.CLI.Core.Output, as: Output

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -235,7 +235,11 @@ defmodule RabbitMQCtl do
 
   defp validation_error(err_detail, command, unparsed_command, options) do
     err = format_validation_error(err_detail) # TODO format the error better
-    base_error = "#{err}\nGiven:\n\t#{unparsed_command |> Enum.join(" ")}"
+    err = case String.ends_with?(err, "\n") do
+            :true -> err
+            :false -> err <> "\n"
+          end
+    base_error = "#{err}Given:\n\t#{unparsed_command |> Enum.join(" ")}"
     usage = HelpCommand.base_usage(command, options)
     message = base_error <> "\n" <> usage
     {:error, ExitCodes.exit_code_for({:validation_failure, err_detail}), message}
@@ -246,8 +250,10 @@ defmodule RabbitMQCtl do
      badrpc_error_message_header(node) <> diagnostics
   end
   defp format_validation_error({:rabbit_app_not_running, node}) do
-    errmsg = "Error: rabbit application is not running on node #{node}.\n" <>
-             "Suggestion: start it with \"rabbitmqctl start_app\" and try again"
+    ~s"""
+      Error: rabbit application is not running on node #{node}.
+      Suggestion: start it with "rabbitmqctl start_app" and try again
+      """
   end
   defp format_validation_error(:not_enough_args), do: "Error: not enough arguments."
   defp format_validation_error({:not_enough_args, detail}), do: "Error: not enough arguments. #{detail}"

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -241,6 +241,10 @@ defmodule RabbitMQCtl do
     {:error, ExitCodes.exit_code_for({:validation_failure, err_detail}), message}
   end
 
+  defp format_validation_error({{:badrpc, :nodedown}, node}) do
+     diagnostics = get_node_diagnostics(node)
+     badrpc_error_message_header(node) <> diagnostics
+  end
   defp format_validation_error(:not_enough_args), do: "not enough arguments."
   defp format_validation_error({:not_enough_args, detail}), do: "not enough arguments. #{detail}"
   defp format_validation_error(:too_many_args), do: "too many arguments."
@@ -258,10 +262,10 @@ defmodule RabbitMQCtl do
     exit({:shutdown, code})
   end
 
-  defp format_error({:error, {:badrpc_multi, :nodedown, [node | _]} = result}, opts, _) do
+  defp format_error({:error, {:badrpc_multi, :nodedown, [node | _]} = result}, _opts, _) do
     diagnostics = get_node_diagnostics(node)
     {:error, ExitCodes.exit_code_for(result),
-     badrpc_error_message_header(node, opts) <> diagnostics}
+     badrpc_error_message_header(node) <> diagnostics}
   end
   defp format_error({:error, {:badrpc_multi, :timeout, [node | _]} = result}, opts, module) do
     op = CommandModules.module_to_command(module)
@@ -271,7 +275,7 @@ defmodule RabbitMQCtl do
   defp format_error({:error, {:badrpc, :nodedown} = result}, opts, _) do
     diagnostics = get_node_diagnostics(opts[:node])
     {:error, ExitCodes.exit_code_for(result),
-     badrpc_error_message_header(opts[:node], opts) <> diagnostics}
+     badrpc_error_message_header(opts[:node]) <> diagnostics}
   end
   defp format_error({:error, {:badrpc, :timeout} = result}, opts, module) do
     op = CommandModules.module_to_command(module)
@@ -309,7 +313,7 @@ defmodule RabbitMQCtl do
     to_string(:rabbit_nodes_common.diagnostics([node_name]))
   end
 
-  defp badrpc_error_message_header(node, _opts) do
+  defp badrpc_error_message_header(node) do
     """
     Error: unable to perform an operation on node '#{node}'. Please see diagnostics information and suggestions below.
 

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -23,6 +23,7 @@ defmodule RabbitMQCtl do
 
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
   alias RabbitMQ.CLI.Core.Parser, as: Parser
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
 
   alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
 
@@ -230,7 +231,7 @@ defmodule RabbitMQCtl do
           end
       end
     case requires_rabbit_app_running do
-      true -> Helpers.rabbit_app_running?(options)
+      true -> Validators.rabbit_app_running?(options)
       false -> :ok
     end
   end
@@ -271,10 +272,6 @@ defmodule RabbitMQCtl do
     {:error, ExitCodes.exit_code_for({:validation_failure, err_detail}), message}
   end
 
-  defp format_validation_error({{:badrpc, :nodedown}, node}) do
-     diagnostics = get_node_diagnostics(node)
-     badrpc_error_message_header(node) <> diagnostics
-  end
   defp format_validation_error({:rabbit_app_not_running, node}) do
     ~s"""
       Error: rabbit application is not running on node #{node}.

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -235,7 +235,7 @@ defmodule RabbitMQCtl do
 
   defp validation_error(err_detail, command, unparsed_command, options) do
     err = format_validation_error(err_detail) # TODO format the error better
-    base_error = "Error: #{err}\nGiven:\n\t#{unparsed_command |> Enum.join(" ")}"
+    base_error = "#{err}\nGiven:\n\t#{unparsed_command |> Enum.join(" ")}"
     usage = HelpCommand.base_usage(command, options)
     message = base_error <> "\n" <> usage
     {:error, ExitCodes.exit_code_for({:validation_failure, err_detail}), message}
@@ -245,17 +245,21 @@ defmodule RabbitMQCtl do
      diagnostics = get_node_diagnostics(node)
      badrpc_error_message_header(node) <> diagnostics
   end
-  defp format_validation_error(:not_enough_args), do: "not enough arguments."
-  defp format_validation_error({:not_enough_args, detail}), do: "not enough arguments. #{detail}"
-  defp format_validation_error(:too_many_args), do: "too many arguments."
-  defp format_validation_error({:too_many_args, detail}), do: "too many arguments. #{detail}"
-  defp format_validation_error(:bad_argument), do: "Bad argument."
-  defp format_validation_error({:bad_argument, detail}), do: "Bad argument. #{detail}"
+  defp format_validation_error({:rabbit_app_not_running, node}) do
+    errmsg = "Error: rabbit application is not running on node #{node}.\n" <>
+             "Suggestion: start it with \"rabbitmqctl start_app\" and try again"
+  end
+  defp format_validation_error(:not_enough_args), do: "Error: not enough arguments."
+  defp format_validation_error({:not_enough_args, detail}), do: "Error: not enough arguments. #{detail}"
+  defp format_validation_error(:too_many_args), do: "Error: too many arguments."
+  defp format_validation_error({:too_many_args, detail}), do: "Error: too many arguments. #{detail}"
+  defp format_validation_error(:bad_argument), do: "Error: bad argument."
+  defp format_validation_error({:bad_argument, detail}), do: "Error: bad argument. #{detail}"
   defp format_validation_error({:bad_option, opts}) do
-    header = "Invalid options for this command:"
+    header = "Error: invalid options for this command:"
     Enum.join([header | for {key, val} <- opts do "#{key} : #{val}" end], "\n")
   end
-  defp format_validation_error(err), do: inspect err
+  defp format_validation_error(err), do: "Error: " <> inspect err
 
   defp exit_program(code) do
     :net_kernel.stop

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule RabbitMQCtl.MixfileBase do
     [
       app: :rabbitmqctl,
       version: "0.0.1",
-      elixir: "~> 1.4.4 or 1.5.0",
+      elixir: "~> 1.4.4 or ~> 1.5",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       escript: [main_module: RabbitMQCtl,

--- a/test/decode_command_test.exs
+++ b/test/decode_command_test.exs
@@ -82,7 +82,6 @@ defmodule DecodeCommandTest do
   end
 
   defp encrypt_decrypt(secret) do
-    secret_as_erlang_term = format_as_erlang_term(secret)
     passphrase = "passphrase"
     cipher = :rabbit_pbe.default_cipher()
     hash = :rabbit_pbe.default_hash()

--- a/test/list_vhost_limits_command_test.exs
+++ b/test/list_vhost_limits_command_test.exs
@@ -106,7 +106,7 @@ defmodule ListVhostLimitsCommandTest do
   end
 
   @tag vhost: "bad-vhost"
-  test "run: providing a non-existent vhost reports an error", context do
+  test "run: providing a non-existent vhost reports an error", _context do
     s = "non-existent-vhost-a9sd89"
 
     assert @command.run([], %{node: get_rabbit_hostname(),
@@ -114,8 +114,6 @@ defmodule ListVhostLimitsCommandTest do
   end
 
   test "banner", context do
-    vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
-
     assert @command.banner([], %{vhost: context[:vhost]})
       == "Listing limits for vhost \"#{context[:vhost]}\" ..."
     assert @command.banner([], %{global: true})

--- a/test/rabbitmqctl_test.exs
+++ b/test/rabbitmqctl_test.exs
@@ -109,7 +109,7 @@ defmodule RabbitMQCtlTest do
     command1 = ["--invalid=true", "list_permissions", "-p", "/"]
     assert capture_io(:stderr, fn ->
       error_check(command1, exit_usage())
-    end) =~ ~r/Error: Invalid options for this command/
+    end) =~ ~r/Error: invalid options for this command/
 
     command2 = ["--node", "rabbit", "status", "quack"]
     assert capture_io(:stderr, fn ->
@@ -150,12 +150,12 @@ defmodule RabbitMQCtlTest do
     command1 = ["status", "--nod=rabbit"]
     assert capture_io(:stderr, fn ->
       error_check(command1, exit_usage())
-    end) =~ ~r/Error: Invalid options for this command/
+    end) =~ ~r/Error: invalid options for this command/
 
     command2 = ["list_permissions", "-o", "/"]
     assert capture_io(:stderr, fn ->
       error_check(command2, exit_usage())
-    end) =~ ~r/Error: Invalid options for this command/
+    end) =~ ~r/Error: invalid options for this command/
   end
 
 ## ------------------------- Auto-complete ------------------------------------


### PR DESCRIPTION
Certain commands need to ensure that the `rabbit` application is running. These changes add a helper function that will do so and can be used during the validation phase of running a command.

Fixes #214 

Example output for `list_users`:

```
$ ./escript/rabbitmqctl list_users
Error: "rabbit application is not running on node rabbit@MESSIAEN. Suggestion: start it with 'rabbitmqctl start_app' and try again"
Given:
	list_users
Usage:
rabbitmqctl [-n <node>] [-t <timeout>] [-q] list_users
```

@hairyhum I'd like to get your thoughts on using a new function in `Helpers` versus other means of implementing this. Thanks!