### PR TITLE
Execution environment validation

### DIFF
--- a/lib/rabbitmq/cli/command_behaviour.ex
+++ b/lib/rabbitmq/cli/command_behaviour.ex
@@ -29,7 +29,8 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
                       scopes: 0,
                       usage_additional: 0,
                       switches: 0,
-                      aliases: 0
+                      aliases: 0,
+                      required_rabbit_app_state: 2
 
   @callback switches() :: Keyword.t
   @callback aliases() :: Keyword.t

--- a/lib/rabbitmq/cli/command_behaviour.ex
+++ b/lib/rabbitmq/cli/command_behaviour.ex
@@ -16,6 +16,7 @@
 
 defmodule RabbitMQ.CLI.CommandBehaviour do
   @callback usage() :: String.t | [String.t]
+  # validates CLI arguments
   @callback validate(List.t, Map.t) :: :ok | {:validation_failure, Atom.t | {Atom.t, String.t}}
   @callback merge_defaults(List.t, Map.t) :: {List.t, Map.t}
   @callback banner(List.t, Map.t) :: String.t | nil
@@ -30,8 +31,10 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
                       usage_additional: 0,
                       switches: 0,
                       aliases: 0,
-                      required_rabbit_app_state: 2,
+                      # validates execution environment, e.g. file presence,
+                      # whether RabbitMQ is in an expected state on a node, etc
                       validate_execution_environment: 2
+                      
 
   @callback switches() :: Keyword.t
   @callback aliases() :: Keyword.t

--- a/lib/rabbitmq/cli/command_behaviour.ex
+++ b/lib/rabbitmq/cli/command_behaviour.ex
@@ -17,7 +17,7 @@
 defmodule RabbitMQ.CLI.CommandBehaviour do
   @callback usage() :: String.t | [String.t]
   # validates CLI arguments
-  @callback validate(List.t, Map.t) :: :ok | {:validation_failure, Atom.t | {Atom.t, String.t}}
+  @callback validate(List.t, Map.t) :: :ok | {:validation_failure, Atom.t | {Atom.t, any}}
   @callback merge_defaults(List.t, Map.t) :: {List.t, Map.t}
   @callback banner(List.t, Map.t) :: String.t | nil
   @callback run(List.t, Map.t) :: any
@@ -35,7 +35,7 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
                       # whether RabbitMQ is in an expected state on a node, etc
                       validate_execution_environment: 2
 
-  @callback validate_execution_environment(List.t, Map.t) :: :ok | {:validation_failure, Atom.t | {Atom.t, String.t}}
+  @callback validate_execution_environment(List.t, Map.t) :: :ok | {:validation_failure, Atom.t | {Atom.t, any}}
   @callback switches() :: Keyword.t
   @callback aliases() :: Keyword.t
 

--- a/lib/rabbitmq/cli/command_behaviour.ex
+++ b/lib/rabbitmq/cli/command_behaviour.ex
@@ -34,8 +34,8 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
                       # validates execution environment, e.g. file presence,
                       # whether RabbitMQ is in an expected state on a node, etc
                       validate_execution_environment: 2
-                      
 
+  @callback validate_execution_environment(List.t, Map.t) :: :ok | {:validation_failure, Atom.t | {Atom.t, String.t}}
   @callback switches() :: Keyword.t
   @callback aliases() :: Keyword.t
 

--- a/lib/rabbitmq/cli/command_behaviour.ex
+++ b/lib/rabbitmq/cli/command_behaviour.ex
@@ -30,7 +30,8 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
                       usage_additional: 0,
                       switches: 0,
                       aliases: 0,
-                      required_rabbit_app_state: 2
+                      required_rabbit_app_state: 2,
+                      validate_execution_environment: 2
 
   @callback switches() :: Keyword.t
   @callback aliases() :: Keyword.t

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -120,6 +120,14 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     end
   end
 
+  def rabbit_app_running?(%{node: node, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node, :rabbit, :is_running, [], timeout) do
+      true  -> true
+      false -> false
+      other -> {:error, other}
+    end
+  end
+  
   def add_plugins_to_load_path(opts) do
     with {:ok, plugins_dir} <- plugins_dir(opts)
     do
@@ -185,14 +193,6 @@ defmodule RabbitMQ.CLI.Core.Helpers do
 
   def node_running?(node) do
     :net_adm.ping(node) == :pong
-  end
-
-  def rabbit_app_running?(%{node: node, timeout: timeout}) do
-    case :rabbit_misc.rpc_call(node, :rabbit, :is_running, [], timeout) do
-      true  -> true
-      false -> false
-      other -> {:error, other}
-    end
   end
 
   # Convert function to stream

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -187,6 +187,14 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     :net_adm.ping(node) == :pong
   end
 
+  def rabbit_app_running?(%{node: node, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node, :rabbit, :is_running, [], timeout) do
+      true  -> true
+      false -> false
+      other -> {:error, other}
+    end
+  end
+
   # Convert function to stream
   def defer(fun) do
     Stream.iterate(:ok, fn(_) -> fun.() end)

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -81,6 +81,10 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     end
   end
 
+  def plugins_dir(_, opts) do
+    plugins_dir(opts)
+  end
+
   def plugins_dir(opts) do
     case Config.get_option(:plugins_dir, opts) do
       nil -> {:error, :no_plugins_dir};
@@ -93,10 +97,18 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     end
   end
 
+  def require_rabbit_and_plugins(_, opts) do
+    require_rabbit_and_plugins(opts)
+  end
+
   def require_rabbit_and_plugins(opts) do
     with :ok <- require_rabbit(opts),
          :ok <- add_plugins_to_load_path(opts),
          do: :ok
+  end
+
+  def require_rabbit(_, opts) do
+    require_rabbit(opts)
   end
 
   def require_rabbit(opts) do
@@ -127,7 +139,11 @@ defmodule RabbitMQ.CLI.Core.Helpers do
       other -> {:error, other}
     end
   end
-  
+
+  def rabbit_app_running?(_, opts) do
+    rabbit_app_running?(opts)
+  end
+
   def add_plugins_to_load_path(opts) do
     with {:ok, plugins_dir} <- plugins_dir(opts)
     do

--- a/lib/rabbitmq/cli/core/requires_rabbit_app_running.ex
+++ b/lib/rabbitmq/cli/core/requires_rabbit_app_running.ex
@@ -13,27 +13,14 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
-defmodule RabbitMQ.CLI.Ctl.Commands.EnvironmentCommand do
-  @behaviour RabbitMQ.CLI.CommandBehaviour
-  use RabbitMQ.CLI.DefaultOutput
-
-  def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
-
-  def scopes(), do: [:ctl, :diagnostics]
-
-  def merge_defaults(args, opts), do: {args, opts}
-
-  def validate([_|_], _), do: {:validation_failure, :too_many_args}
-  def validate(_, _), do: :ok
-
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-
-  def run([], %{node: node_name}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit, :environment, [])
+# Should be used by commands that require rabbit app to be running
+# but need no other execution environment validators.
+defmodule RabbitMQ.CLI.Core.RequiresRabbitAppRunning do
+  defmacro __using__(_) do
+    quote do
+      def validate_execution_environment(args, opts) do
+        RabbitMQ.CLI.Core.Validators.rabbit_is_running(args, opts)
+      end
+    end
   end
-
-  def usage, do: "environment"
-
-  def banner(_, %{node: node_name}), do: "Application environment of node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/core/requires_rabbit_app_stopped.ex
+++ b/lib/rabbitmq/cli/core/requires_rabbit_app_stopped.ex
@@ -13,27 +13,14 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
-defmodule RabbitMQ.CLI.Ctl.Commands.EnvironmentCommand do
-  @behaviour RabbitMQ.CLI.CommandBehaviour
-  use RabbitMQ.CLI.DefaultOutput
-
-  def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
-
-  def scopes(), do: [:ctl, :diagnostics]
-
-  def merge_defaults(args, opts), do: {args, opts}
-
-  def validate([_|_], _), do: {:validation_failure, :too_many_args}
-  def validate(_, _), do: :ok
-
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-
-  def run([], %{node: node_name}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit, :environment, [])
+# Should be used by commands that require rabbit app to be stopped
+# but need no other execution environment validators.
+defmodule RabbitMQ.CLI.Core.RequiresRabbitAppStopped do
+  defmacro __using__(_) do
+    quote do
+      def validate_execution_environment(args, opts) do
+        RabbitMQ.CLI.Core.Validators.rabbit_is_not_running(args, opts)
+      end
+    end
   end
-
-  def usage, do: "environment"
-
-  def banner(_, %{node: node_name}), do: "Application environment of node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/core/validators.ex
+++ b/lib/rabbitmq/cli/core/validators.ex
@@ -26,7 +26,6 @@ defmodule RabbitMQ.CLI.Core.Validators do
       {:ok, _}                   -> chain(rest, args)
       {:validation_failure, err} -> {:validation_failure, err}
       {:error, err}              -> {:validation_failure, err}
-      other                      -> other
     end
   end
   def chain([], _) do

--- a/lib/rabbitmq/cli/core/validators.ex
+++ b/lib/rabbitmq/cli/core/validators.ex
@@ -22,8 +22,11 @@ defmodule RabbitMQ.CLI.Core.Validators do
 
   def chain([validator | rest], args) do
     case apply(validator, args) do
-      :ok -> chain(rest, args);
-      err -> err
+      :ok                        -> chain(rest, args)
+      {:ok, _}                   -> chain(rest, args)
+      {:validation_failure, err} -> {:validation_failure, err}
+      {:error, err}              -> {:validation_failure, err}
+      other                      -> other
     end
   end
   def chain([], _) do
@@ -58,6 +61,13 @@ defmodule RabbitMQ.CLI.Core.Validators do
       other    -> other
     end
   end
+
+  def rabbit_is_running_or_offline_flag_used(_args, %{offline: true}) do
+    :ok
+  end
+  def rabbit_is_running_or_offline_flag_used(args, opts) do
+    rabbit_is_running(args, opts)
+  end  
 
   def rabbit_is_not_running(args, opts) do
     case rabbit_app_state(args, opts) do

--- a/lib/rabbitmq/cli/core/validators.ex
+++ b/lib/rabbitmq/cli/core/validators.ex
@@ -13,10 +13,7 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
-# Small helper functions, mostly related to connecting to RabbitMQ and
-# handling memory units.
-
+# Provides common validation functions.
 defmodule RabbitMQ.CLI.Core.Validators do
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 

--- a/lib/rabbitmq/cli/core/validators.ex
+++ b/lib/rabbitmq/cli/core/validators.ex
@@ -31,18 +31,6 @@ defmodule RabbitMQ.CLI.Core.Validators do
   def chain([], _) do
     :ok
   end
-  def chain([validator | rest], args, error_key) do
-    case apply(validator, args) do
-      :ok                        -> chain(rest, args, error_key)
-      {:ok, _}                   -> chain(rest, args, error_key)
-      {:validation_failure, err} -> {error_key, err}
-      {:error, err}              -> {error_key, err}
-    end
-  end
-  def chain([], _, _) do
-    :ok
-  end
-
 
   def node_is_not_running(_, %{node: node_name}) do
     case Helpers.node_running?(node_name) do

--- a/lib/rabbitmq/cli/core/validators.ex
+++ b/lib/rabbitmq/cli/core/validators.ex
@@ -17,9 +17,8 @@
 # Small helper functions, mostly related to connecting to RabbitMQ and
 # handling memory units.
 
-defmodule RabbitMQ.CLI.Ctl.Validators do
+defmodule RabbitMQ.CLI.Core.Validators do
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-
 
   def chain([validator | rest], args) do
     case apply(validator, args) do
@@ -51,4 +50,29 @@ defmodule RabbitMQ.CLI.Ctl.Validators do
       {:error, err} -> {:validation_failure, err}
     end
   end
+
+  def rabbit_is_running(args, opts) do
+    case rabbit_app_state(args, opts) do
+      :running -> :ok;
+      :stopped -> {:validation_failure, :rabbit_app_is_stopped};
+      other    -> other
+    end
+  end
+
+  def rabbit_is_not_running(args, opts) do
+    case rabbit_app_state(args, opts) do
+      :running -> {:validation_failure, :rabbit_app_is_running};
+      :stopped -> :ok;
+      other    -> other
+    end
+  end
+
+  def rabbit_app_state(_, opts) do
+    case Helpers.rabbit_app_running?(opts) do
+      true          -> :running;
+      false         -> :stopped;
+      {:error, err} -> {:error, err}
+    end
+  end
+
 end

--- a/lib/rabbitmq/cli/core/validators.ex
+++ b/lib/rabbitmq/cli/core/validators.ex
@@ -32,6 +32,18 @@ defmodule RabbitMQ.CLI.Core.Validators do
   def chain([], _) do
     :ok
   end
+  def chain([validator | rest], args, error_key) do
+    case apply(validator, args) do
+      :ok                        -> chain(rest, args, error_key)
+      {:ok, _}                   -> chain(rest, args, error_key)
+      {:validation_failure, err} -> {error_key, err}
+      {:error, err}              -> {error_key, err}
+    end
+  end
+  def chain([], _, _) do
+    :ok
+  end
+
 
   def node_is_not_running(_, %{node: node_name}) do
     case Helpers.node_running?(node_name) do
@@ -67,7 +79,7 @@ defmodule RabbitMQ.CLI.Core.Validators do
   end
   def rabbit_is_running_or_offline_flag_used(args, opts) do
     rabbit_is_running(args, opts)
-  end  
+  end
 
   def rabbit_is_not_running(args, opts) do
     case rabbit_app_state(args, opts) do

--- a/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -37,6 +37,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
 
   def validate([_,_], _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([_, _] = args, %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_auth_backend_internal,

--- a/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -20,11 +20,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+
+  def merge_defaults(args, opts), do: {args, opts}
+
   def validate([], _), do: {:validation_failure, :not_enough_args}
   def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
   def validate([_], _), do: :ok
 
-  def merge_defaults(args, opts), do: {args, opts}
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([vhost], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, Helpers.cli_acting_user()])
   end
@@ -32,5 +36,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
   def usage, do: "add_vhost <vhost>"
 
   def banner([vhost], _), do: "Adding vhost \"#{vhost}\" ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
@@ -16,10 +16,14 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.AuthenticateUserCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def merge_defaults(args, opts), do: {args, opts}
+
   def validate(args, _) when length(args) < 2, do: {:validation_failure, :not_enough_args}
   def validate(args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
   def validate([_,_], _), do: :ok
-  def merge_defaults(args, opts), do: {args, opts}
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([user, password], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,
@@ -32,7 +36,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AuthenticateUserCommand do
   def usage, do: "authenticate_user <username> <password>"
 
   def banner([username, _password], _), do: "Authenticating user \"#{username}\" ..."
-
 
   def output({:refused, user, msg, args}, _) do
     {:error, RabbitMQ.CLI.Core.ExitCodes.exit_dataerr,

--- a/lib/rabbitmq/cli/ctl/commands/cancel_sync_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/cancel_sync_queue_command.ex
@@ -27,6 +27,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CancelSyncQueueCommand do
   def validate([_], _), do: :ok
   def validate(_, _),   do: {:validation_failure, :too_many_args}
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([queue], %{vhost: vhost, node: node_name}) do
     :rpc.call(node_name,
       :rabbit_mirror_queue_misc,

--- a/lib/rabbitmq/cli/ctl/commands/change_cluster_node_type_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/change_cluster_node_type_command.ex
@@ -31,6 +31,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ChangeClusterNodeTypeCommand do
   def validate([_], _), do: {:validation_failure, {:bad_argument, "The node type must be either disc or ram."}}
   def validate(_, _),   do: {:validation_failure, :too_many_args}
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
+
   def run([node_type_arg], %{node: node_name}) do
     normalized_type = normalize_type(String.to_atom(node_type_arg))
     current_type = :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
@@ -26,6 +26,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ChangePasswordCommand do
   def validate([_|_] = args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
   def validate(_, _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([_user, _] = args, %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_auth_backend_internal, :change_password, args ++ [Helpers.cli_acting_user()])

--- a/lib/rabbitmq/cli/ctl/commands/clear_global_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_global_parameter_command.ex
@@ -32,6 +32,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearGlobalParameterCommand do
   end
   def validate([_], _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([key], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_runtime_parameters,

--- a/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
@@ -32,6 +32,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearOperatorPolicyCommand do
   end
   def validate([_], _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([key], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_policy, :delete_op, [vhost, key, Helpers.cli_acting_user()])

--- a/lib/rabbitmq/cli/ctl/commands/clear_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_parameter_command.ex
@@ -32,6 +32,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearParameterCommand do
   end
   def validate([_,_], _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([component_name, key], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_runtime_parameters,

--- a/lib/rabbitmq/cli/ctl/commands/clear_password_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_password_command.ex
@@ -20,10 +20,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearPasswordCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+
+  def merge_defaults(args, opts), do: {args, opts}
+
   def validate([], _), do: {:validation_failure, :not_enough_args}
   def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
   def validate([_], _), do: :ok
-  def merge_defaults(args, opts), do: {args, opts}
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([_user] = args, %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_auth_backend_internal, :clear_password,

--- a/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
@@ -15,7 +15,6 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearPermissionsCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
@@ -19,6 +19,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearPermissionsCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}
   end

--- a/lib/rabbitmq/cli/ctl/commands/clear_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_policy_command.ex
@@ -15,7 +15,6 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearPolicyCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -31,6 +30,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearPolicyCommand do
     {:validation_failure, :too_many_args}
   end
   def validate([_], _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([key], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/clear_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_topic_permissions_command.ex
@@ -33,6 +33,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearTopicPermissionsCommand do
   def validate([_], _), do: :ok
   def validate([_, _], _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([username], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_auth_backend_internal, :clear_topic_permissions, [username, vhost, Helpers.cli_acting_user()])

--- a/lib/rabbitmq/cli/ctl/commands/clear_vhost_limits_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_vhost_limits_command.ex
@@ -15,7 +15,6 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearVhostLimitsCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -41,8 +40,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearVhostLimitsCommand do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost_limit, :clear, [vhost, Helpers.cli_acting_user()])
   end
 
-  def usage, do: "clear_vhost_limits [-p <vhost>]"
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
+  def usage, do: "clear_vhost_limits [-p <vhost>]"
 
   def banner([], %{vhost: vhost}) do
     "Clearing vhost \"#{vhost}\" limits ..."

--- a/lib/rabbitmq/cli/ctl/commands/close_all_connections_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/close_all_connections_command.ex
@@ -24,6 +24,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseAllConnectionsCommand do
   def validate(args, _) when length(args) < 1, do: {:validation_failure, :not_enough_args}
   def validate([_], _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([explanation], %{node: node_name, vhost: vhost, global: global_opt,
                            per_connection_delay: delay, limit: limit}) do
     conns = case global_opt do

--- a/lib/rabbitmq/cli/ctl/commands/close_connection_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/close_connection_command.ex
@@ -18,10 +18,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseConnectionCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
   def merge_defaults(args, opts), do: {args, opts}
+
   def validate(args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
   def validate(args, _) when length(args) < 2, do: {:validation_failure, :not_enough_args}
   def validate([_,_], _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+  
   def run([pid, explanation], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_networking,
       :close_connection,
@@ -29,7 +32,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseConnectionCommand do
   end
 
   def usage, do: "close_connection <connectionpid> <explanation>"
-
 
   def banner([pid, explanation], _), do: "Closing connection #{pid}, reason: #{explanation}..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
@@ -19,11 +19,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def merge_defaults(args, opts), do: {args, opts}
+
   def validate(args, _) when length(args) != 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
-  def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
-  def scopes(), do: [:ctl, :diagnostics]
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :status, []) do
@@ -42,8 +42,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
     end
   end
 
-  def usage, do: "cluster_status"
+  def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
+  def scopes(), do: [:ctl, :diagnostics]
+
+  def usage, do: "cluster_status"
 
   defp alarms_by_node(node) do
     alarms = :rabbit_misc.rpc_call(node, :rabbit, :alarms, [])

--- a/lib/rabbitmq/cli/ctl/commands/decode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/decode_command.ex
@@ -19,6 +19,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def switches() do
+      [
+        cipher: :atom,
+        hash: :atom,
+        iterations: :integer
+      ]
+  end
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{
         cipher:       :rabbit_pbe.default_cipher(),
@@ -43,13 +51,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
     end
   end
 
-  def switches() do
-      [
-        cipher: :atom,
-        hash: :atom,
-        iterations: :integer
-      ]
-  end
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([value, passphrase], %{cipher: cipher, hash: hash, iterations: iterations}) do
     try do

--- a/lib/rabbitmq/cli/ctl/commands/decode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/decode_command.ex
@@ -51,8 +51,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
     end
   end
 
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-
   def run([value, passphrase], %{cipher: cipher, hash: hash, iterations: iterations}) do
     try do
       term_value = Helpers.evaluate_input_as_term(value)

--- a/lib/rabbitmq/cli/ctl/commands/delete_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/delete_user_command.ex
@@ -15,15 +15,19 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.DeleteUserCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+
+  def merge_defaults(args, opts), do: {args, opts}
+
   def validate([], _), do: {:validation_failure, :not_enough_args}
   def validate(args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
   def validate([_], _), do: :ok
-  def merge_defaults(args, opts), do: {args, opts}
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([username], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_auth_backend_internal,

--- a/lib/rabbitmq/cli/ctl/commands/delete_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/delete_vhost_command.ex
@@ -15,16 +15,19 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.DeleteVhostCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+
+  def merge_defaults(args, opts), do: {args, opts}
+  
   def validate([], _), do: {:validation_failure, :not_enough_args}
   def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
   def validate([_], _), do: :ok
-  def merge_defaults(args, opts), do: {args, opts}
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+  
   def run([arg], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :delete, [arg, Helpers.cli_acting_user()])
   end
@@ -32,6 +35,5 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteVhostCommand do
   def usage, do: "delete_vhost <vhost>"
 
   def banner([arg], _), do: "Deleting vhost \"#{arg}\" ..."
-
 end
 

--- a/lib/rabbitmq/cli/ctl/commands/encode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/encode_command.ex
@@ -51,8 +51,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
     end
   end
 
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-
   def run([value, passphrase], %{cipher: cipher, hash: hash, iterations: iterations}) do
     try do
       term_value = Helpers.evaluate_input_as_term(value)

--- a/lib/rabbitmq/cli/ctl/commands/encode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/encode_command.ex
@@ -13,11 +13,19 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-
 defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+
+  def switches() do
+    [
+      cipher: :atom,
+      hash: :atom,
+      iterations: :integer
+    ]
+  end
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{
@@ -43,13 +51,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
     end
   end
 
-  def switches() do
-      [
-        cipher: :atom,
-        hash: :atom,
-        iterations: :integer
-      ]
-    end
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([value, passphrase], %{cipher: cipher, hash: hash, iterations: iterations}) do
     try do
@@ -72,5 +74,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
   defp supports_cipher(cipher), do: Enum.member?(:rabbit_pbe.supported_ciphers(), cipher)
 
   defp supports_hash(hash), do: Enum.member?(:rabbit_pbe.supported_hashes(), hash)
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/environment_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/environment_command.ex
@@ -27,8 +27,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EnvironmentCommand do
   def validate([_|_], _), do: {:validation_failure, :too_many_args}
   def validate(_, _), do: :ok
 
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-
   def run([], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit, :environment, [])
   end

--- a/lib/rabbitmq/cli/ctl/commands/eval_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/eval_command.ex
@@ -13,14 +13,11 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
   def merge_defaults(args, opts), do: {args, opts}
-
-  def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
   def validate([], _) do
     {:validation_failure, :not_enough_args}
@@ -37,6 +34,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
     end
   end
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([expr | arguments],  %{node: node_name} = opts) do
     {:ok, parsed} = parse_expr(expr)
     bindings = make_bindings(arguments, opts)
@@ -45,6 +44,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
       err                -> err
     end
   end
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
   def usage, do: "eval <expr>"
 
@@ -76,5 +77,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
   defp format_parse_error({_line, mod, err}) do
     to_string(:lists.flatten(mod.format_error(err)))
   end
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/eval_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/eval_command.ex
@@ -34,8 +34,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
     end
   end
 
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-
   def run([expr | arguments],  %{node: node_name} = opts) do
     {:ok, parsed} = parse_expr(expr)
     bindings = make_bindings(arguments, opts)

--- a/lib/rabbitmq/cli/ctl/commands/exec_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/exec_command.ex
@@ -20,8 +20,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExecCommand do
 
   def merge_defaults(args, opts), do: {args, opts}
 
-  def formatter(), do: RabbitMQ.CLI.Formatters.Inspect
-
   def validate([], _) do
     {:validation_failure, :not_enough_args}
   end
@@ -46,6 +44,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExecCommand do
     end
   end
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([expr], %{} = opts) do
     try do
       {val, _} = Code.eval_string(expr, [options: opts], __ENV__)
@@ -55,8 +55,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExecCommand do
     end
   end
 
+  def formatter(), do: RabbitMQ.CLI.Formatters.Inspect
+
   def usage, do: "exec <expr>"
 
   def banner(_, _), do: nil
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/exec_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/exec_command.ex
@@ -44,8 +44,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExecCommand do
     end
   end
 
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-
   def run([expr], %{} = opts) do
     try do
       {val, _} = Code.eval_string(expr, [options: opts], __ENV__)

--- a/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
@@ -32,6 +32,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceBootCommand do
     end
   end
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
+  
   def run([], %{node: node_name} = opts) do
     case :rabbit_misc.rpc_call(node_name,
                                :rabbit_mnesia, :force_load_next_boot, []) do

--- a/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
@@ -17,10 +17,12 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.ForceResetCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-
   def merge_defaults(args, opts), do: {args, opts}
+
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
 
   def run([], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :force_reset, [])

--- a/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
@@ -13,10 +13,9 @@
 ## The Initial Developer of the Original Code is Pivotal Software, Inc.
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Ctl.Validators, as: Validators
-alias RabbitMQ.CLI.Core.Distribution,   as: Distribution
-
 defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
+  alias RabbitMQ.CLI.Core.Distribution, as: Distribution
   import Rabbitmq.Atom.Coerce
 
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
@@ -28,14 +28,17 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
   end
 
   def validate([], _),  do: {:validation_failure, :not_enough_args}
-  def validate([_,_|_], _),   do: {:validation_failure, :too_many_args}
-  def validate([_node_to_remove] = args, %{offline: true} = opts) do
+  def validate([_,_|_], _), do: {:validation_failure, :too_many_args}
+  def validate([_], _), do: :ok
+
+
+  def validate_execution_environment([_node_to_remove] = args, %{offline: true} = opts) do
     Validators.chain([&Validators.node_is_not_running/2,
                       &Validators.mnesia_dir_is_set/2,
                       &Validators.rabbit_is_loaded/2],
                      [args, opts])
   end
-  def validate([_], %{offline: false}) do
+  def validate_execution_environment([_], %{offline: false}) do
     :ok
   end
 

--- a/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
@@ -54,7 +54,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HipeCompileCommand do
     |> Helpers.validate_step(fn() -> Helpers.require_rabbit(opts) end)
   end
   def validate(_, _),   do: {:validation_failure, :too_many_args}
-
+  
   def run([target_dir], _opts) do
     Code.ensure_loaded(:rabbit_hipe)
     hipe_compile(String.trim(target_dir))

--- a/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
@@ -54,7 +54,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HipeCompileCommand do
     |> Helpers.validate_step(fn() -> Helpers.require_rabbit(opts) end)
   end
   def validate(_, _),   do: {:validation_failure, :too_many_args}
-  
+
   def run([target_dir], _opts) do
     Code.ensure_loaded(:rabbit_hipe)
     hipe_compile(String.trim(target_dir))

--- a/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
@@ -38,6 +38,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
   def validate([_], _), do: :ok
   def validate(_, _),   do: {:validation_failure, :too_many_args}
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
+
   def run([target_node], %{node: node_name, ram: ram, disc: disc}) do
     node_type = case {ram, disc} do
       {true, false}  -> :ram

--- a/lib/rabbitmq/cli/ctl/commands/list_bindings_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_bindings_command.ex
@@ -29,13 +29,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListBindingsCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def validate(args, _) do
-      case InfoKeys.validate_info_keys(args, @info_keys) do
-        {:ok, _} -> :ok
-        err -> err
-      end
-  end
-
   def merge_defaults([], opts) do
     {~w(source_name source_kind
              destination_name destination_kind
@@ -45,14 +38,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListBindingsCommand do
     {args, Map.merge(default_opts(), opts)}
   end
 
-  def usage() do
-      "list_bindings [-p <vhost>] [<bindinginfoitem> ...]"
+
+  def validate(args, _) do
+      case InfoKeys.validate_info_keys(args, @info_keys) do
+        {:ok, _} -> :ok
+        err -> err
+      end
   end
 
-  def usage_additional() do
-      "<bindinginfoitem> must be a member of the list [" <>
-      Enum.join(@info_keys, ", ") <> "]."
-  end
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([_|_] = args, %{node: node_name, timeout: timeout, vhost: vhost}) do
       info_keys = InfoKeys.prepare_info_keys(args)
@@ -61,6 +55,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListBindingsCommand do
         [vhost, info_keys],
         timeout,
         info_keys)
+  end
+
+  def usage() do
+      "list_bindings [-p <vhost>] [<bindinginfoitem> ...]"
+  end
+
+  def usage_additional() do
+      "<bindinginfoitem> must be a member of the list [" <>
+      Enum.join(@info_keys, ", ") <> "]."
   end
 
   defp default_opts() do

--- a/lib/rabbitmq/cli/ctl/commands/list_channels_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_channels_command.ex
@@ -34,25 +34,19 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListChannelsCommand do
 
   def info_keys(), do: @info_keys
 
+  def merge_defaults([], opts) do
+    {~w(pid user consumer_count messages_unacknowledged), opts}
+  end
+  def merge_defaults(args, opts), do: {args, opts}
+
   def validate(args, _) do
       case InfoKeys.validate_info_keys(args, @info_keys) do
         {:ok, _} -> :ok
         err -> err
       end
   end
-  def merge_defaults([], opts) do
-    {~w(pid user consumer_count messages_unacknowledged), opts}
-  end
-  def merge_defaults(args, opts), do: {args, opts}
 
-  def usage() do
-      "list_channels [<channelinfoitem> ...]"
-  end
-
-  def usage_additional() do
-      "<channelinfoitem> must be a member of the list [" <>
-      Enum.join(@info_keys, ", ") <> "]."
-  end
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], opts) do
       run(~w(pid user consumer_count messages_unacknowledged), opts)
@@ -68,6 +62,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListChannelsCommand do
                                      info_keys,
                                      Kernel.length(nodes))
       end)
+  end
+
+  def usage() do
+      "list_channels [<channelinfoitem> ...]"
+  end
+
+  def usage_additional() do
+      "<channelinfoitem> must be a member of the list [" <>
+      Enum.join(@info_keys, ", ") <> "]."
   end
 
   def banner(_, _), do: "Listing channels ..."

--- a/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
@@ -35,25 +35,19 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConnectionsCommand do
 
   def info_keys(), do: @info_keys
 
+  def merge_defaults([], opts) do
+    {~w(user peer_host peer_port state), opts}
+  end
+  def merge_defaults(args, opts), do: {args, opts}
+
   def validate(args, _) do
       case InfoKeys.validate_info_keys(args, @info_keys) do
         {:ok, _} -> :ok
         err -> err
       end
   end
-  def merge_defaults([], opts) do
-    {~w(user peer_host peer_port state), opts}
-  end
-  def merge_defaults(args, opts), do: {args, opts}
 
-  def usage() do
-      "list_connections [<connectioninfoitem> ...]"
-  end
-
-  def usage_additional() do
-      "<connectioninfoitem> must be a member of the list [" <>
-      Enum.join(@info_keys, ", ") <> "]."
-  end
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([_|_] = args, %{node: node_name, timeout: timeout}) do
       info_keys = InfoKeys.prepare_info_keys(args)
@@ -68,6 +62,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConnectionsCommand do
       end)
   end
 
+  def usage() do
+      "list_connections [<connectioninfoitem> ...]"
+  end
+
+  def usage_additional() do
+      "<connectioninfoitem> must be a member of the list [" <>
+      Enum.join(@info_keys, ", ") <> "]."
+  end
 
   def banner(_, _), do: "Listing connections ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
@@ -31,6 +31,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
 
   def info_keys(), do: @info_keys
 
+  def merge_defaults([], opts) do
+    {Enum.map(@info_keys, &Atom.to_string/1), Map.merge(%{vhost: "/"}, opts)}
+  end
+  def merge_defaults(args, opts), do: {args, Map.merge(%{vhost: "/"}, opts)}
+
   def validate(args, _) do
       case InfoKeys.validate_info_keys(args, @info_keys) do
         {:ok, _} -> :ok
@@ -38,20 +43,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
       end
   end
 
-  def merge_defaults([], opts) do
-    {Enum.map(@info_keys, &Atom.to_string/1), Map.merge(%{vhost: "/"}, opts)}
-  end
-  def merge_defaults(args, opts), do: {args, Map.merge(%{vhost: "/"}, opts)}
-
-
-  def usage() do
-      "list_consumers [-p vhost] [<consumerinfoitem> ...]"
-  end
-
-  def usage_additional() do
-      "<consumerinfoitem> must be a member of the list [" <>
-      Enum.join(@info_keys, ", ") <> "]."
-  end
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([_|_] = args, %{node: node_name, timeout: timeout, vhost: vhost}) do
       info_keys = InfoKeys.prepare_info_keys(args)
@@ -60,6 +52,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
           :rabbit_amqqueue, :emit_consumers_all,
           [nodes, vhost], timeout, info_keys)
       end)
+  end
+
+  def usage() do
+      "list_consumers [-p vhost] [<consumerinfoitem> ...]"
+  end
+
+  def usage_additional() do
+      "<consumerinfoitem> must be a member of the list [" <>
+      Enum.join(@info_keys, ", ") <> "]."
   end
 
   def banner(_, %{vhost: vhost}), do: "Listing consumers on vhost #{vhost} ..."

--- a/lib/rabbitmq/cli/ctl/commands/list_global_parameters_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_global_parameters_command.ex
@@ -31,6 +31,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListGlobalParametersCommand do
   end
   def validate([], _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+  
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_runtime_parameters,

--- a/lib/rabbitmq/cli/ctl/commands/list_operator_policies_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_operator_policies_command.ex
@@ -32,6 +32,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListOperatorPoliciesCommand do
   end
   def validate([], _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([], %{node: node_name, timeout: timeout, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_policy,

--- a/lib/rabbitmq/cli/ctl/commands/list_parameters_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_parameters_command.ex
@@ -19,11 +19,12 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListParametersCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
+
+  def scopes(), do: [:ctl, :diagnostics]
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}
   end
-
-  def scopes(), do: [:ctl, :diagnostics]
 
   def validate([_|_], _) do
     {:validation_failure, :too_many_args}
@@ -41,5 +42,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListParametersCommand do
   def usage, do: "list_parameters [-p <vhost>]"
 
   def banner(_, %{vhost: vhost}), do: "Listing runtime parameters for vhost \"#{vhost}\" ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_parameters_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_parameters_command.ex
@@ -17,6 +17,7 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.ListParametersCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 

--- a/lib/rabbitmq/cli/ctl/commands/list_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_permissions_command.ex
@@ -20,17 +20,18 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListPermissionsCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
+  def scopes(), do: [:ctl, :diagnostics]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}
   end
 
-  def scopes(), do: [:ctl, :diagnostics]
-
   def validate([_|_], _) do
     {:validation_failure, :too_many_args}
   end
   def validate([], _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, timeout: timeout, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/list_policies_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_policies_command.ex
@@ -20,7 +20,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListPoliciesCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
-
   def scopes(), do: [:ctl, :diagnostics]
 
   def merge_defaults(args, opts) do
@@ -31,6 +30,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListPoliciesCommand do
     {:validation_failure, :too_many_args}
   end
   def validate([], _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, timeout: timeout, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
@@ -43,5 +44,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListPoliciesCommand do
   def usage, do: "list_policies [-p <vhost>]"
 
   def banner(_, %{vhost: vhost}), do: "Listing policies for vhost \"#{vhost}\" ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
@@ -41,12 +41,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def validate(args, _opts) do
-      case InfoKeys.validate_info_keys(args, @info_keys) do
-        {:ok, _} -> :ok
-        err -> err
-      end
+  defp default_opts() do
+    %{vhost: "/", offline: false, online: false, local: false}
   end
+
   def merge_defaults([_|_] = args, opts) do
     timeout = case opts[:timeout] do
       nil       -> @default_timeout;
@@ -62,14 +60,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
 
   def switches(), do: [offline: :boolean, online: :boolean, local: :boolean]
 
-  def usage() do
-      "list_queues [-p <vhost>] [--online] [--offline] [--local] [<queueinfoitem> ...]"
+  def validate(args, _opts) do
+      case InfoKeys.validate_info_keys(args, @info_keys) do
+        {:ok, _} -> :ok
+        err -> err
+      end
   end
 
-  def usage_additional() do
-      "<queueinfoitem> must be a member of the list [" <>
-      Enum.join(@info_keys, ", ") <> "]."
-  end
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([_|_] = args, %{node: node_name, timeout: timeout, vhost: vhost,
                           online: online_opt, offline: offline_opt,
@@ -98,8 +96,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
       end)
   end
 
-  defp default_opts() do
-    %{vhost: "/", offline: false, online: false, local: false}
+  def usage() do
+      "list_queues [-p <vhost>] [--online] [--offline] [--local] [<queueinfoitem> ...]"
+  end
+
+  def usage_additional() do
+      "<queueinfoitem> must be a member of the list [" <>
+      Enum.join(@info_keys, ", ") <> "]."
   end
 
   def banner(_,%{vhost: vhost, timeout: timeout}) do

--- a/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
@@ -41,6 +41,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
+  def switches(), do: [offline: :boolean, online: :boolean, local: :boolean]
+
   defp default_opts() do
     %{vhost: "/", offline: false, online: false, local: false}
   end
@@ -55,53 +57,53 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
         Map.merge(opts, %{timeout: timeout}))}
   end
   def merge_defaults([], opts) do
-      merge_defaults(~w(name messages), opts)
+    merge_defaults(~w(name messages), opts)
   end
-
-  def switches(), do: [offline: :boolean, online: :boolean, local: :boolean]
 
   def validate(args, _opts) do
-      case InfoKeys.validate_info_keys(args, @info_keys) do
-        {:ok, _} -> :ok
-        err -> err
-      end
+    case InfoKeys.validate_info_keys(args, @info_keys) do
+      {:ok, _} -> :ok
+      err -> err
+    end
   end
 
+  # note that --offline for this command has a different meaning:
+  # it lists queues with unavailable masters
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([_|_] = args, %{node: node_name, timeout: timeout, vhost: vhost,
                           online: online_opt, offline: offline_opt,
                           local: local_opt}) do
-      {online, offline} = case {online_opt, offline_opt} do
+    {online, offline} = case {online_opt, offline_opt} do
         {false, false} -> {true, true};
         other          -> other
+    end
+    info_keys = InfoKeys.prepare_info_keys(args)
+    Helpers.with_nodes_in_cluster(node_name, fn(nodes) ->
+      offline_mfa = {:rabbit_amqqueue, :emit_info_down, [vhost, info_keys]}
+      local_mfa = {:rabbit_amqqueue, :emit_info_local, [vhost, info_keys]}
+      online_mfa  = {:rabbit_amqqueue, :emit_info_all, [nodes, vhost, info_keys]}
+      {chunks, mfas} = case {local_opt, offline, online} do
+        # Local takes precedence
+        {true, _, _}      -> {1, [local_mfa]};
+        {_, true, true}   -> {Kernel.length(nodes) + 1, [offline_mfa, online_mfa]};
+        {_, false, true}  -> {Kernel.length(nodes), [online_mfa]};
+        {_, true, false}  -> {1, [offline_mfa]}
       end
-      info_keys = InfoKeys.prepare_info_keys(args)
-      Helpers.with_nodes_in_cluster(node_name, fn(nodes) ->
-        offline_mfa = {:rabbit_amqqueue, :emit_info_down, [vhost, info_keys]}
-        local_mfa = {:rabbit_amqqueue, :emit_info_local, [vhost, info_keys]}
-        online_mfa  = {:rabbit_amqqueue, :emit_info_all, [nodes, vhost, info_keys]}
-        {chunks, mfas} = case {local_opt, offline, online} do
-          # Local takes precedence
-          {true, _, _}      -> {1, [local_mfa]};
-          {_, true, true}   -> {Kernel.length(nodes) + 1, [offline_mfa, online_mfa]};
-          {_, false, true}  -> {Kernel.length(nodes), [online_mfa]};
-          {_, true, false}  -> {1, [offline_mfa]}
-        end
-        RpcStream.receive_list_items_with_fun(node_name, mfas, timeout, info_keys, chunks,
-          fn({{:error, {:badrpc, {:timeout, to}}}, :finished}) ->
-            {{:error, {:badrpc, {:timeout, to, "Some queue(s) are unresponsive, use list_unresponsive_queues command."}}}, :finished};
-            (any) -> any
-          end)
-      end)
+      RpcStream.receive_list_items_with_fun(node_name, mfas, timeout, info_keys, chunks,
+        fn({{:error, {:badrpc, {:timeout, to}}}, :finished}) ->
+          {{:error, {:badrpc, {:timeout, to, "Some queue(s) are unresponsive, use list_unresponsive_queues command."}}}, :finished};
+          (any) -> any
+        end)
+    end)
   end
 
   def usage() do
-      "list_queues [-p <vhost>] [--online] [--offline] [--local] [<queueinfoitem> ...]"
+    "list_queues [-p <vhost>] [--online] [--offline] [--local] [<queueinfoitem> ...]"
   end
 
   def usage_additional() do
-      "<queueinfoitem> must be a member of the list [" <>
+    "<queueinfoitem> must be a member of the list [" <>
       Enum.join(@info_keys, ", ") <> "]."
   end
 

--- a/lib/rabbitmq/cli/ctl/commands/list_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_topic_permissions_command.ex
@@ -20,17 +20,18 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListTopicPermissionsCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
+  def scopes(), do: [:ctl, :diagnostics]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}
   end
 
-  def scopes(), do: [:ctl, :diagnostics]
-
   def validate([_|_], _) do
     {:validation_failure, :too_many_args}
   end
   def validate([], _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, timeout: timeout, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
@@ -44,5 +45,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListTopicPermissionsCommand do
   def usage, do: "list_topic_permissions [-p <vhost>]"
 
   def banner(_, %{vhost: vhost}), do: "Listing topic permissions for vhost \"#{vhost}\" ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_unresponsive_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_unresponsive_queues_command.ex
@@ -34,30 +34,27 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUnresponsiveQueuesCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def validate(args, _opts) do
-      case InfoKeys.validate_info_keys(args, @info_keys) do
-        {:ok, _} -> :ok
-        err -> err
-      end
+  def switches(), do: [queue_timeout: :integer, local: :boolean]
+
+  defp default_opts() do
+    %{vhost: "/", local: false, queue_timeout: 15}
   end
 
   def merge_defaults([_|_] = args, opts) do
     {args, Map.merge(default_opts(), opts)}
   end
   def merge_defaults([], opts) do
-      merge_defaults(~w(name), opts)
+    merge_defaults(~w(name), opts)
   end
 
-  def switches(), do: [queue_timeout: :integer, local: :boolean]
-
-  def usage() do
-    "list_unresponsive_queues [--local] [--queue-timeout <queue-timeout>] [<unresponsiveq_ueueinfoitem> ...]"
+  def validate(args, _opts) do
+    case InfoKeys.validate_info_keys(args, @info_keys) do
+      {:ok, _} -> :ok
+      err -> err
+    end
   end
 
-  def usage_additional() do
-      "<unresponsive_queueinfoitem> must be a member of the list [" <>
-      Enum.join(@info_keys, ", ") <> "]."
-  end
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run(args, %{node: node_name, vhost: vhost, timeout: timeout,
                   queue_timeout: qtimeout, local: local_opt}) do
@@ -74,8 +71,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUnresponsiveQueuesCommand do
       end)
   end
 
-  defp default_opts() do
-    %{vhost: "/", local: false, queue_timeout: 15}
+  def usage() do
+    "list_unresponsive_queues [--local] [--queue-timeout <queue-timeout>] [<unresponsiveq_ueueinfoitem> ...]"
+  end
+
+  def usage_additional() do
+      "<unresponsive_queueinfoitem> must be a member of the list [" <>
+      Enum.join(@info_keys, ", ") <> "]."
   end
 
   def banner(_,%{vhost: vhost}), do: "Listing unresponsive queues for vhost #{vhost} ..."

--- a/lib/rabbitmq/cli/ctl/commands/list_user_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_user_permissions_command.ex
@@ -20,13 +20,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserPermissionsCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
+  def scopes(), do: [:ctl, :diagnostics]
+
+  def merge_defaults(args, opts), do: {args, opts}
+
   def validate([], _), do: {:validation_failure, :not_enough_args}
   def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
   def validate([_], _), do: :ok
 
-  def scopes(), do: [:ctl, :diagnostics]
-
-  def merge_defaults(args, opts), do: {args, opts}
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([username], %{node: node_name, timeout: time_out}) do
     :rabbit_misc.rpc_call(node_name,
@@ -40,5 +42,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserPermissionsCommand do
   def usage, do: "list_user_permissions <username>"
 
   def banner([username], _), do: "Listing permissions for user \"#{username}\" ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_user_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_user_topic_permissions_command.ex
@@ -20,13 +20,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserTopicPermissionsCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
+  def scopes(), do: [:ctl, :diagnostics]
+
+  def merge_defaults(args, opts), do: {args, opts}
+
   def validate([], _), do: {:validation_failure, :not_enough_args}
   def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
   def validate([_], _), do: :ok
 
-  def scopes(), do: [:ctl, :diagnostics]
-
-  def merge_defaults(args, opts), do: {args, opts}
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([username], %{node: node_name, timeout: time_out}) do
     :rabbit_misc.rpc_call(node_name,
@@ -40,5 +42,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserTopicPermissionsCommand do
   def usage, do: "list_user_topic_permissions <username>"
 
   def banner([username], _), do: "Listing topic permissions for user \"#{username}\" ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
@@ -19,14 +19,17 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUsersCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
-  def merge_defaults(args, opts), do: {args, opts}
 
   def scopes(), do: [:ctl, :diagnostics]
+
+  def merge_defaults(args, opts), do: {args, opts}
 
   def validate([_|_], _) do
     {:validation_failure, :too_many_args}
   end
   def validate(_, _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_auth_backend_internal, :list_users, [], timeout)
@@ -35,5 +38,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUsersCommand do
   def usage, do: "list_users"
 
   def banner(_,_), do: "Listing users ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_vhost_limits_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_vhost_limits_command.ex
@@ -34,6 +34,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostLimitsCommand do
   end
   def validate(_, _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([], %{node: node_name, global: true}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_vhost_limit, :list, []) do
       []              -> []

--- a/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
@@ -28,14 +28,17 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostsCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
+  def merge_defaults([], opts), do: {["name"], opts}
+  def merge_defaults(args, opts), do: {args, opts}
+
   def validate(args, _) do
     case InfoKeys.validate_info_keys(args, @info_keys) do
       {:ok, _} -> :ok
       err -> err
     end
   end
-  def merge_defaults([], opts), do: {["name"], opts}
-  def merge_defaults(args, opts), do: {args, opts}
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([_|_] = args, %{node: node_name, timeout: time_out}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :info_all, [], time_out)
@@ -65,5 +68,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostsCommand do
   end
 
   def banner(_,_), do: "Listing vhosts ..."
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
@@ -20,8 +20,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def validate(args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
-  def validate([], _), do: :ok
+  def switches(), do: [timeout: :integer]
 
   def merge_defaults(args, opts) do
     timeout = case opts[:timeout] do
@@ -32,14 +31,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand do
     {args, Map.merge(opts, %{timeout: timeout})}
   end
 
-  def switches(), do: [timeout: :integer]
+  def validate(args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
+  def validate([], _), do: :ok
 
-  def usage, do: "node_health_check"
-
-  def banner(_, %{node: node_name, timeout: timeout}) do
-    ["Timeout: #{timeout / 1000} seconds ...",
-     "Checking health of node #{node_name} ..."]
-  end
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, timeout: timeout}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_health_check, :node, [node_name, timeout]) do
@@ -66,4 +61,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand do
      "Error: healthcheck failed. Message: #{message}"}
   end
   use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "node_health_check"
+
+  def banner(_, %{node: node_name, timeout: timeout}) do
+    ["Timeout: #{timeout / 1000} seconds ...",
+     "Checking health of node #{node_name} ..."]
+  end
 end

--- a/lib/rabbitmq/cli/ctl/commands/purge_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/purge_queue_command.ex
@@ -18,8 +18,21 @@ defmodule RabbitMQ.CLI.Ctl.Commands.PurgeQueueCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{vhost: "/"}, opts)}
+  end
 
-  def usage, do: "purge_queue <queue>"
+  def validate(args, _) when length(args) > 1 do
+    {:validation_failure, :too_many_args}
+  end
+
+  def validate([], _) do
+    {:validation_failure, :not_enough_args}
+  end
+
+  def validate(_, _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([queue], %{node: node_name, vhost: vhost, timeout: timeout}) do
     res = :rabbit_misc.rpc_call(node_name,
@@ -39,19 +52,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.PurgeQueueCommand do
     end
   end
 
-  def merge_defaults(args, opts) do
-    {args, Map.merge(%{vhost: "/"}, opts)}
-  end
-
-  def validate(args, _) when length(args) > 1 do
-    {:validation_failure, :too_many_args}
-  end
-
-  def validate([], _) do
-    {:validation_failure, :not_enough_args}
-  end
-
-  def validate(_, _), do: :ok
+  def usage, do: "purge_queue <queue>"
 
   def banner([queue], %{vhost: vhost}) do
     "Purging queue '#{queue}' in vhost '#{vhost}' ..."

--- a/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
@@ -28,13 +28,27 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RenameClusterNodeCommand do
 
   def validate([], _),  do: {:validation_failure, :not_enough_args}
   def validate([_], _), do: {:validation_failure, :not_enough_args}
-  def validate(args, opts) do
+  def validate(_, _) do
+    :ok
+  end
+
+  def validate_execution_environment(args, opts) do
     Validators.chain([&validate_args_count_even/2,
                       &Validators.node_is_not_running/2,
                       &Validators.mnesia_dir_is_set/2,
                       &Validators.rabbit_is_loaded/2],
                      [args, opts])
   end
+
+  def run(nodes, %{node: node_name}) do
+    node_pairs = make_node_pairs(nodes)
+    try do
+      :rabbit_mnesia_rename.rename(node_name, node_pairs)
+    catch _, reason ->
+      {:rename_failed, reason}
+    end
+  end
+
 
   defp validate_args_count_even(args, _) do
     case agrs_count_even?(args) do
@@ -47,15 +61,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RenameClusterNodeCommand do
 
   defp agrs_count_even?(args) do
     Integer.is_even(length(args))
-  end
-
-  def run(nodes, %{node: node_name}) do
-    node_pairs = make_node_pairs(nodes)
-    try do
-      :rabbit_mnesia_rename.rename(node_name, node_pairs)
-    catch _, reason ->
-      {:rename_failed, reason}
-    end
   end
 
   defp make_node_pairs([]) do

--- a/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
@@ -15,9 +15,8 @@
 
 require Integer
 
-alias RabbitMQ.CLI.Ctl.Validators, as: Validators
-
 defmodule RabbitMQ.CLI.Ctl.Commands.RenameClusterNodeCommand do
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
   import Rabbitmq.Atom.Coerce
 
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/ctl/commands/report_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/report_command.ex
@@ -43,12 +43,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
   end
   def validate([], _), do: :ok
 
-  defp run_command(command, args, opts) do
-    {args, opts} = command.merge_defaults(args, opts)
-    banner = command.banner(args, opts)
-    command_result = command.run(args, opts) |> command.output(opts)
-    {command, banner, command_result}
-  end
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name} = opts) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :list, []) do
@@ -74,6 +69,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
         data ++ vhost_data
     end
   end
+
+  defp run_command(command, args, opts) do
+    {args, opts} = command.merge_defaults(args, opts)
+    banner = command.banner(args, opts)
+    command_result = command.run(args, opts) |> command.output(opts)
+    {command, banner, command_result}
+  end
+
 
   defp info_keys(command) do
     command.info_keys()

--- a/lib/rabbitmq/cli/ctl/commands/reset_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/reset_command.ex
@@ -17,11 +17,13 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.ResetCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-
   def merge_defaults(args, opts), do: {args, opts}
+
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
+  
   def run([], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :reset, [])
   end

--- a/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
@@ -18,10 +18,12 @@ alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
 defmodule RabbitMQ.CLI.Ctl.Commands.RestartVhostCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
+  def merge_defaults(args, opts), do: {args, Map.merge(%{vhost: "/"}, opts)}
+
   def validate([], _),  do: :ok
   def validate(_, _),   do: {:validation_failure, :too_many_args}
 
-  def merge_defaults(args, opts), do: {args, Map.merge(%{vhost: "/"}, opts)}
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, vhost: vhost, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost_sup_sup, :start_vhost, [vhost], timeout)
@@ -45,5 +47,4 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RestartVhostCommand do
       "Reason: #{inspect(err)}"]}
   end
   use RabbitMQ.CLI.DefaultOutput
-
 end

--- a/lib/rabbitmq/cli/ctl/commands/rotate_logs_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/rotate_logs_command.ex
@@ -18,17 +18,18 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RotateLogsCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
-
   def merge_defaults(args, opts), do: {args, opts}
+
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit, :rotate_logs, [])
   end
 
   def usage, do: "rotate_logs"
-
 
   def banner(_, %{node: node_name}), do: "Rotating logs for node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/set_cluster_name_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_cluster_name_command.ex
@@ -15,7 +15,6 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetClusterNameCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -33,14 +32,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetClusterNameCommand do
 
   def validate(_, _), do: :ok
 
-  def banner([cluster_name], _) do
-    "Setting cluster name to #{cluster_name} ..."
-  end
-
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([cluster_name], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_nodes, :set_cluster_name, [cluster_name, Helpers.cli_acting_user()])
+  end
+
+  def banner([cluster_name], _) do
+    "Setting cluster name to #{cluster_name} ..."
   end
 
   def usage, do: "set_cluster_name <name>"

--- a/lib/rabbitmq/cli/ctl/commands/set_disk_free_limit_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_disk_free_limit_command.ex
@@ -56,6 +56,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetDiskFreeLimitCommand do
     {:validation_failure, :too_many_args}
   end
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run(["mem_relative", _] = args, opts) do
     set_disk_free_limit_relative(args, opts)
   end

--- a/lib/rabbitmq/cli/ctl/commands/set_global_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_global_parameter_command.ex
@@ -15,12 +15,10 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetGlobalParameterCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
-
 
   def merge_defaults(args, opts) do
     {args, opts}
@@ -39,6 +37,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetGlobalParameterCommand do
   end
 
   def validate(_, _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([name, value], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,

--- a/lib/rabbitmq/cli/ctl/commands/set_operator_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_operator_policy_command.ex
@@ -15,7 +15,6 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetOperatorPolicyCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -41,6 +40,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetOperatorPolicyCommand do
 
   def validate(_, _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([name, pattern, definition], %{node: node_name,
                                          vhost: vhost,
                                          priority: priority,
@@ -58,7 +59,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetOperatorPolicyCommand do
   end
 
   def usage, do: "set_operator_policy [-p <vhost>] [--priority <priority>] [--apply-to <apply-to>] <name> <pattern>  <definition>"
-
 
   def banner([name, pattern, definition], %{vhost: vhost, priority: priority}) do
     "Setting operator policy override \"#{name}\" for pattern \"#{pattern}\" to \"#{definition}\" with priority \"#{priority}\" for vhost \"#{vhost}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
@@ -15,7 +15,6 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetParameterCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -39,6 +38,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetParameterCommand do
 
   def validate(_, _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([component_name, name, value], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_runtime_parameters,
@@ -48,7 +49,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetParameterCommand do
   end
 
   def usage, do: "set_parameter [-p <vhost>] <component_name> <name> <value>"
-
 
   def banner([component_name, name, value], _) do
     "Setting runtime parameter \"#{component_name}\" for component \"#{name}\" to \"#{value}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
@@ -15,12 +15,10 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetPermissionsCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
-
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}
@@ -39,6 +37,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPermissionsCommand do
   end
   def validate(_, _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+  
   def run([user, conf, write, read], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_auth_backend_internal,
@@ -48,7 +48,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPermissionsCommand do
   end
 
   def usage, do: "set_permissions [-p <vhost>] <username> <conf> <write> <read>"
-
 
   def banner([user|_], %{vhost: vhost}), do: "Setting permissions for user \"#{user}\" in vhost \"#{vhost}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/set_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_policy_command.ex
@@ -15,7 +15,6 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetPolicyCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -41,6 +40,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPolicyCommand do
 
   def validate(_, _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([name, pattern, definition], %{node: node_name,
                                          vhost: vhost,
                                          priority: priority,
@@ -58,7 +59,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPolicyCommand do
   end
 
   def usage, do: "set_policy [-p <vhost>] [--priority <priority>] [--apply-to <apply-to>] <name> <pattern>  <definition>"
-
 
   def banner([name, pattern, definition], %{vhost: vhost, priority: priority}) do
     "Setting policy \"#{name}\" for pattern \"#{pattern}\" to \"#{definition}\" with priority \"#{priority}\" for vhost \"#{vhost}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/set_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_topic_permissions_command.ex
@@ -15,12 +15,10 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetTopicPermissionsCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
-
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}
@@ -38,6 +36,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetTopicPermissionsCommand do
   end
   def validate(_, _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([user, exchange, write_pattern, read_pattern], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_auth_backend_internal,
@@ -47,7 +47,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetTopicPermissionsCommand do
   end
 
   def usage, do: "set_topic_permissions [-p <vhost>] <username> <exchange> <write_pattern> <read_pattern>"
-
 
   def banner([user, exchange, _, _], %{vhost: vhost}), do: "Setting topic permissions on \"#{exchange}\" for user \"#{user}\" in vhost \"#{vhost}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
@@ -15,7 +15,6 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetUserTagsCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -25,6 +24,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetUserTagsCommand do
 
   def validate([], _), do: {:validation_failure, :not_enough_args}
   def validate(_, _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+  
   def run([user | tags], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_auth_backend_internal,
@@ -34,7 +36,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetUserTagsCommand do
   end
 
   def usage, do: "set_user_tags <username> <tag> [...]"
-
 
   def banner([user | tags], _) do
     "Setting tags for user \"#{user}\" to [#{tags |> Enum.join(", ")}] ..."

--- a/lib/rabbitmq/cli/ctl/commands/set_vhost_limits_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_vhost_limits_command.ex
@@ -15,7 +15,6 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetVhostLimitsCommand do
-
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -35,13 +34,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetVhostLimitsCommand do
 
   def validate(_, _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+  
   def run([definition], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
                           :rabbit_vhost_limit, :parse_set, [vhost, definition, Helpers.cli_acting_user()])
   end
 
   def usage, do: "set_vhost_limits [-p <vhost>] <definition>"
-
 
   def banner([definition], %{vhost: vhost}) do
     "Setting vhost limits to \"#{definition}\" for vhost \"#{vhost}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/set_vm_memory_high_watermark_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_vm_memory_high_watermark_command.ex
@@ -67,6 +67,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetVmMemoryHighWatermarkCommand do
   end
   def validate(_, _), do: :ok
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+  
   def run(["absolute", arg], opts) do
     case Integer.parse(arg) do
       {num, rest}   ->  valid_units = rest in Helpers.memory_units
@@ -97,7 +99,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetVmMemoryHighWatermarkCommand do
   end
 
   def usage, do: ["set_vm_memory_high_watermark <fraction>", "set_vm_memory_high_watermark absolute <value>"]
-
 
   def banner(["absolute", arg], %{node: node_name}), do: "Setting memory threshold on #{node_name} to #{arg} bytes ..."
   def banner([arg], %{node: node_name}), do: "Setting memory threshold on #{node_name} to #{arg} ..."

--- a/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
@@ -26,6 +26,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ShutdownCommand do
   def validate([], _), do: :ok
   def validate([_|_], _), do: {:validation_failure, :too_many_args}
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+  
   def run([], %{node: node_name}) do
     case :rabbit_misc.rpc_call(node_name, :os, :getpid, []) do
       pid when is_list(pid) ->

--- a/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
@@ -26,8 +26,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ShutdownCommand do
   def validate([], _), do: :ok
   def validate([_|_], _), do: {:validation_failure, :too_many_args}
 
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-  
   def run([], %{node: node_name}) do
     case :rabbit_misc.rpc_call(node_name, :os, :getpid, []) do
       pid when is_list(pid) ->

--- a/lib/rabbitmq/cli/ctl/commands/start_app_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/start_app_command.ex
@@ -29,6 +29,5 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StartAppCommand do
 
   def usage, do: "start_app"
 
-
   def banner(_, %{node: node_name}), do: "Starting node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/status_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/status_command.ex
@@ -18,11 +18,12 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def scopes(), do: [:ctl, :diagnostics]
 
   def merge_defaults(args, opts), do: {args, opts}
+
   def validate([_|_] = args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
   def validate([], _), do: :ok
-  def scopes(), do: [:ctl, :diagnostics]
 
   def run([], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit, :status, [])
@@ -31,7 +32,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
   def usage, do: "status"
-
 
   def banner(_, %{node: node_name}), do: "Status of node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/stop_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/stop_command.ex
@@ -41,7 +41,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StopCommand do
         OsPid.wait_for_os_process_death(pid)
         {:ok, "process #{pid} (take from pid file #{pidfile_path}) is no longer running"}
     end
-
   end
 
   def usage, do: "stop [<pidfile>]"

--- a/lib/rabbitmq/cli/ctl/commands/sync_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/sync_queue_command.ex
@@ -17,15 +17,17 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SyncQueueCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  defp default_opts, do: %{vhost: "/"}
+
   def merge_defaults(args, opts) do
     {args, Map.merge(default_opts(), opts)}
   end
 
-  def usage, do: "sync_queue [-p <vhost>] queue"
-
   def validate([], _),  do: {:validation_failure, :not_enough_args}
   def validate([_], _), do: :ok
   def validate(_, _),   do: {:validation_failure, :too_many_args}
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([queue], %{vhost: vhost, node: node_name}) do
     :rpc.call(node_name,
@@ -36,9 +38,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SyncQueueCommand do
     )
   end
 
+  def usage, do: "sync_queue [-p <vhost>] queue"
+
   def banner([queue], %{vhost: vhost, node: _node}) do
     "Synchronising queue '#{queue}' in vhost '#{vhost}' ..."
   end
-
-  defp default_opts, do: %{vhost: "/"}
 end

--- a/lib/rabbitmq/cli/ctl/commands/trace_off_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/trace_off_command.ex
@@ -18,11 +18,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.TraceOffCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
-  def validate([_|_], _), do: {:validation_failure, :too_many_args}
-  def validate(_, _), do: :ok
   def merge_defaults(_, opts) do
     {[], Map.merge(%{vhost: "/"}, opts)}
   end
+
+  def validate([_|_], _), do: {:validation_failure, :too_many_args}
+  def validate(_, _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, vhost: vhost}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_trace, :stop, [vhost]) do

--- a/lib/rabbitmq/cli/ctl/commands/trace_on_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/trace_on_command.ex
@@ -18,12 +18,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.TraceOnCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
-
-  def validate([_|_], _), do: {:validation_failure, :too_many_args}
-  def validate(_, _), do: :ok
   def merge_defaults(_, opts) do
     {[], Map.merge(%{vhost: "/"}, opts)}
   end
+
+  def validate([_|_], _), do: {:validation_failure, :too_many_args}
+  def validate(_, _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
   def run([], %{node: node_name, vhost: vhost}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_trace, :start, [vhost]) do
       :ok   -> {:ok, "Trace enabled for vhost #{vhost}"};
@@ -32,7 +35,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.TraceOnCommand do
   end
 
   def usage, do: "trace_on [-p <vhost>]"
-
 
   def banner(_, %{vhost: vhost}), do: "Starting tracing for vhost \"#{vhost}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
@@ -27,6 +27,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.UpdateClusterNodesCommand do
   def validate([_], _), do: :ok
   def validate(_, _),   do: {:validation_failure, :too_many_args}
 
+  use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
+
   def run([seed_node], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,
         :rabbit_mnesia,

--- a/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -20,6 +20,12 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   @default_timeout 10_000
 
+  def switches(), do: [pid: :integer]
+
+  def aliases(), do: ['P': :pid]
+
+  def scopes(), do: [:ctl, :diagnostics]
+  
   def merge_defaults(args, opts) do
     timeout = case opts[:timeout] do
       nil       -> @default_timeout;
@@ -34,13 +40,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
   def validate([],  %{pid: _} = opts), do: Validators.rabbit_is_loaded([], opts)
   def validate([],  _), do: {:validation_failure, "No pid or pidfile specified"}
   def validate([_], opts), do: Validators.rabbit_is_loaded([], opts)
-
-  def switches(), do: [pid: :integer]
-
-  def aliases(), do: ['P': :pid]
-
-  def scopes(), do: [:ctl, :diagnostics]
-
 
   def run([pid_file], %{node: node_name, timeout: timeout} = opts) do
     app_names = :rabbit_and_plugins

--- a/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -13,9 +13,10 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-
 defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
+  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+
   @behaviour RabbitMQ.CLI.CommandBehaviour
   @default_timeout 10_000
 
@@ -30,9 +31,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
 
   def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
   def validate([_], %{pid: _}), do: {:validation_failure, "Cannot specify both pid and pidfile"}
-  def validate([],  %{pid: _} = opts), do: RabbitMQ.CLI.Ctl.Validators.rabbit_is_loaded([], opts)
+  def validate([],  %{pid: _} = opts), do: Validators.rabbit_is_loaded([], opts)
   def validate([],  _), do: {:validation_failure, "No pid or pidfile specified"}
-  def validate([_], opts), do: RabbitMQ.CLI.Ctl.Validators.rabbit_is_loaded([], opts)
+  def validate([_], opts), do: Validators.rabbit_is_loaded([], opts)
 
   def switches(), do: [pid: :integer]
 

--- a/lib/rabbitmq/cli/default_output.ex
+++ b/lib/rabbitmq/cli/default_output.ex
@@ -33,7 +33,7 @@ defmodule RabbitMQ.CLI.DefaultOutput do
 
   def mnesia_running_error(node_name) do
     "Mnesia is still running on node #{node_name}.\n" <>
-    "Please stop RabbitMQ with rabbitmqctl stop_app first."
+    "Please stop RabbitMQ with 'rabbitmqctl stop_app' first."
   end
 
   defp normalize_output(:ok), do: :ok

--- a/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_hash_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_hash_command.ex
@@ -24,8 +24,6 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieHashCommand do
   end
   def validate(_, _), do: :ok
 
-  def usage, do: "erlang_cookie_hash"
-
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_nodes_common, :cookie_hash, [], timeout)
   end
@@ -37,6 +35,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieHashCommand do
   def banner([], %{node: node_name}) do
     "Asking node #{node_name} its Erlang cookie hash..."
   end
+
+  def usage, do: "erlang_cookie_hash"
 
   def formatter(), do: RabbitMQ.CLI.Formatters.String
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/erlang_version_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/erlang_version_command.ex
@@ -17,6 +17,8 @@
 defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangVersionCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
+  def switches(), do: [details: :boolean]
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{details: false}, opts)}
   end
@@ -25,10 +27,6 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangVersionCommand do
     {:validation_failure, :too_many_args}
   end
   def validate(_, _), do: :ok
-
-  def switches(), do: [details: :boolean]
-
-  def usage, do: "erlang_version"
 
   def run([], %{node: node_name, timeout: timeout, details: details}) do
     case details do
@@ -47,6 +45,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangVersionCommand do
   def banner([], %{node: node_name}) do
     "Asking node #{node_name} for its Erlang/OTP version..."
   end
+
+  def usage, do: "erlang_version"
 
   def formatter(), do: RabbitMQ.CLI.Formatters.String
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
@@ -18,16 +18,14 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MaybeStuckCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
-  def merge_defaults(args, opts), do: {args, opts}
-
   def switches(), do: []
+  
+  def merge_defaults(args, opts), do: {args, opts}
 
   def validate(args, _) when length(args) > 0 do
     {:validation_failure, :too_many_args}
   end
   def validate(_, _), do: :ok
-
-  def usage, do: "maybe_stuck"
 
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_diagnostics, :maybe_stuck, [], timeout)
@@ -36,4 +34,6 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MaybeStuckCommand do
   def banner(_, %{node: node_name}) do
     "Asking node #{node_name} to detect potentially stuck Erlang processes..."
   end
+
+  def usage, do: "maybe_stuck"  
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -19,11 +19,11 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
+  def switches(), do: [unit: :string]
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{unit: "gb"}, opts)}
   end
-
-  def switches(), do: [unit: :string]
 
   def validate(args, _) when length(args) > 0 do
     {:validation_failure, :too_many_args}
@@ -37,8 +37,6 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
     end
   end
 
-  def usage, do: "memory_breakdown [--unit <unit>]"
-
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vm, :memory, [], timeout)
   end
@@ -46,6 +44,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
   def output(result, _options) do
     {:ok, compute_relative_values(result)}
   end
+
+  def usage, do: "memory_breakdown [--unit <unit>]"
 
   def banner([], %{node: node_name}) do
     "Reporting memory breakdown on node #{node_name}..."

--- a/lib/rabbitmq/cli/diagnostics/commands/server_version_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/server_version_command.ex
@@ -24,8 +24,6 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ServerVersionCommand do
   end
   def validate(_, _), do: :ok
 
-  def usage, do: "server_version"
-
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_misc, :version, [], timeout)
   end
@@ -34,6 +32,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ServerVersionCommand do
     {:ok, result}
   end
   use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "server_version"
 
   def banner([], %{node: node_name}) do
     "Asking node #{node_name} for its RabbitMQ version..."

--- a/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -50,7 +50,8 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
                       &Helpers.require_rabbit_and_plugins/2,
                       &PluginHelpers.enabled_plugins_file/2,
                       &Helpers.plugins_dir/2],
-                     [args, opts])
+                     [args, opts],
+                     :environment_validation_failure)
   end
 
   def usage, do: "disable <plugin>|--all [--offline] [--online]"

--- a/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -15,9 +15,9 @@
 
 
 defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
-
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -45,21 +45,12 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
     :ok
   end
 
-  def validate_execution_environment(_, opts) do
-    :ok
-    |> validate_step(fn() -> Helpers.require_rabbit_and_plugins(opts) end)
-    |> validate_step(fn() -> PluginHelpers.enabled_plugins_file(opts) end)
-    |> validate_step(fn() -> Helpers.plugins_dir(opts) end)
-  end
-
-  def validate_step(:ok, step) do
-    case step.() do
-      {:error, err} -> {:validation_failure, err};
-      _             -> :ok
-    end
-  end
-  def validate_step({:validation_failure, err}, _) do
-    {:validation_failure, err}
+  def validate_execution_environment(args, opts) do
+    Validators.chain([&Validators.rabbit_is_running_or_offline_flag_used/2,
+                      &Helpers.require_rabbit_and_plugins/2,
+                      &PluginHelpers.enabled_plugins_file/2,
+                      &Helpers.plugins_dir/2],
+                     [args, opts])
   end
 
   def usage, do: "disable <plugin>|--all [--offline] [--online]"

--- a/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -41,8 +41,11 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
   def validate(_, %{online: true, offline: true}) do
     {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}
   end
+  def validate(_args, _opts) do
+    :ok
+  end
 
-  def validate(_, opts) do
+  def validate_execution_environment(_, opts) do
     :ok
     |> validate_step(fn() -> Helpers.require_rabbit_and_plugins(opts) end)
     |> validate_step(fn() -> PluginHelpers.enabled_plugins_file(opts) end)

--- a/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -50,8 +50,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
                       &Helpers.require_rabbit_and_plugins/2,
                       &PluginHelpers.enabled_plugins_file/2,
                       &Helpers.plugins_dir/2],
-                     [args, opts],
-                     :environment_validation_failure)
+                     [args, opts])
   end
 
   def usage, do: "disable <plugin>|--all [--offline] [--online]"
@@ -62,7 +61,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
   def banner(plugins, %{node: node_name}) do
     ["Disabling plugins on node #{node_name}:" | plugins]
   end
-
 
   def run(plugin_names, %{all: all_flag, node: node_name} = opts) do
     plugins = case all_flag do

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -50,8 +50,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
                       &Helpers.require_rabbit_and_plugins/2,
                       &PluginHelpers.enabled_plugins_file/2,
                       &Helpers.plugins_dir/2],
-                     [args, opts],
-                     :environment_validation_failure)
+                     [args, opts])
   end
 
   def usage, do: "enable <plugin>|--all [--offline] [--online]"

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -15,10 +15,8 @@
 
 
 defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
-
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -42,8 +40,11 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
   def validate(_, %{online: true, offline: true}) do
     {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}
   end
+  def validate(_, _) do
+    :ok
+  end
 
-  def validate(_plugins, opts) do
+  def validate_execution_environment(_plugins, opts) do
     :ok
     |> Helpers.validate_step(fn() -> Helpers.require_rabbit_and_plugins(opts) end)
     |> Helpers.validate_step(fn() -> PluginHelpers.enabled_plugins_file(opts) end)

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -17,6 +17,7 @@
 defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -44,11 +45,12 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
     :ok
   end
 
-  def validate_execution_environment(_plugins, opts) do
-    :ok
-    |> Helpers.validate_step(fn() -> Helpers.require_rabbit_and_plugins(opts) end)
-    |> Helpers.validate_step(fn() -> PluginHelpers.enabled_plugins_file(opts) end)
-    |> Helpers.validate_step(fn() -> Helpers.plugins_dir(opts) end)
+  def validate_execution_environment(args, opts) do
+    Validators.chain([&Validators.rabbit_is_running_or_offline_flag_used/2,
+                      &Helpers.require_rabbit_and_plugins/2,
+                      &PluginHelpers.enabled_plugins_file/2,
+                      &Helpers.plugins_dir/2],
+                     [args, opts])
   end
 
   def usage, do: "enable <plugin>|--all [--offline] [--online]"

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -50,7 +50,8 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
                       &Helpers.require_rabbit_and_plugins/2,
                       &PluginHelpers.enabled_plugins_file/2,
                       &Helpers.plugins_dir/2],
-                     [args, opts])
+                     [args, opts],
+                     :environment_validation_failure)
   end
 
   def usage, do: "enable <plugin>|--all [--offline] [--online]"

--- a/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -55,8 +55,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
                       &Helpers.require_rabbit_and_plugins/2,
                       &PluginHelpers.enabled_plugins_file/2,
                       &Helpers.plugins_dir/2],
-                     [args, opts],
-                     :environment_validation_failure)
+                     [args, opts])
   end
 
   def usage, do: "list [pattern] [--verbose] [--minimal] [--enabled] [--implicitly-enabled]"

--- a/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -55,7 +55,8 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
                       &Helpers.require_rabbit_and_plugins/2,
                       &PluginHelpers.enabled_plugins_file/2,
                       &Helpers.plugins_dir/2],
-                     [args, opts])
+                     [args, opts],
+                     :environment_validation_failure)
   end
 
   def usage, do: "list [pattern] [--verbose] [--minimal] [--enabled] [--implicitly-enabled]"

--- a/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -15,11 +15,10 @@
 
 
 defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
-
   import RabbitCommon.Records
 
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-
+  alias RabbitMQ.CLI.Core.Validators, as: Validators
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
@@ -47,22 +46,16 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
   def validate(_, %{verbose: true, minimal: true}) do
     {:validation_failure, {:bad_argument, "Cannot set both verbose and minimal"}}
   end
-
-  def validate(_, opts) do
+  def validate(_, _) do
     :ok
-    |> validate_step(fn() -> Helpers.require_rabbit_and_plugins(opts) end)
-    |> validate_step(fn() -> PluginHelpers.enabled_plugins_file(opts) end)
-    |> validate_step(fn() -> Helpers.plugins_dir(opts) end)
   end
 
-  def validate_step(:ok, step) do
-    case step.() do
-      {:error, err} -> {:validation_failure, err};
-      _             -> :ok
-    end
-  end
-  def validate_step({:validation_failure, err}, _) do
-    {:validation_failure, err}
+  def validate_execution_environment(args, opts) do
+    Validators.chain([&Validators.rabbit_is_running_or_offline_flag_used/2,
+                      &Helpers.require_rabbit_and_plugins/2,
+                      &PluginHelpers.enabled_plugins_file/2,
+                      &Helpers.plugins_dir/2],
+                     [args, opts])
   end
 
   def usage, do: "list [pattern] [--verbose] [--minimal] [--enabled] [--implicitly-enabled]"

--- a/lib/rabbitmq/cli/plugins/commands/set_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/set_command.ex
@@ -43,7 +43,8 @@ defmodule RabbitMQ.CLI.Plugins.Commands.SetCommand do
                       &Helpers.require_rabbit_and_plugins/2,
                       &PluginHelpers.enabled_plugins_file/2,
                       &Helpers.plugins_dir/2],
-                     [args, opts])
+                     [args, opts],
+                     :environment_validation_failure)
   end
 
   def usage, do: "set [<plugin>] [--offline] [--online]"

--- a/lib/rabbitmq/cli/plugins/commands/set_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/set_command.ex
@@ -34,8 +34,11 @@ defmodule RabbitMQ.CLI.Plugins.Commands.SetCommand do
   def validate(_, %{online: true, offline: true}) do
     {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}
   end
+  def validate(_, _) do
+    :ok
+  end
 
-  def validate(_plugins, opts) do
+  def validate_execution_environment(_plugins, opts) do
     :ok
     |> validate_step(fn() -> Helpers.require_rabbit_and_plugins(opts) end)
     |> validate_step(fn() -> PluginHelpers.enabled_plugins_file(opts) end)

--- a/lib/rabbitmq/cli/plugins/commands/set_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/set_command.ex
@@ -43,8 +43,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.SetCommand do
                       &Helpers.require_rabbit_and_plugins/2,
                       &PluginHelpers.enabled_plugins_file/2,
                       &Helpers.plugins_dir/2],
-                     [args, opts],
-                     :environment_validation_failure)
+                     [args, opts])
   end
 
   def usage, do: "set [<plugin>] [--offline] [--online]"

--- a/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -42,6 +42,10 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     end
   end
 
+  def enabled_plugins_file(_, opts) do
+    enabled_plugins_file(opts)
+  end
+
   def set_enabled_plugins(plugins, opts) do
     plugin_atoms = :lists.usort(for plugin <- plugins, do: to_atom(plugin))
     CliHelpers.require_rabbit_and_plugins(opts)

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -81,10 +81,14 @@ defmodule RabbitMQCtl do
                   result = proceed_to_execution(command, arguments, options)
                   handle_command_output(result, command, options, output_fun);
                 {:validation_failure, err} ->
-                  environment_validation_error_output(err, command, unparsed_command, options)
+                  environment_validation_error_output(err, command, unparsed_command, options);
+                {:error, _} = err ->
+                  format_error(err, options, command)
               end
             {:validation_failure, err} ->
-              argument_validation_error_output(err, command, unparsed_command, options)
+              argument_validation_error_output(err, command, unparsed_command, options);
+            {:error, _} = err ->
+              format_error(err, options, command)
           end
         end)
     end

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -80,19 +80,20 @@ defmodule RabbitMQCtl do
                 :ok ->
                   # then optionally validate execution environment
                   case maybe_validate_execution_environment(command, arguments, options) do
-                    :ok                            -> proceed_to_execution(command, arguments, options)
-                    {:validation_failure, _} = err -> err
-                    {:error, _}              = err -> err
+                    :ok   -> proceed_to_execution(command, arguments, options)
+                    other -> other
                   end
                 other -> other
               end
             other -> other
+          # handle_command_output will handle all the errors
+          # among other things
           end |> handle_command_output(command, options, unparsed_command, output_fun)
         end)
     end
   end
 
-  defp maybe_validate_rabbit_app_state(command, arguments, %{offline: true} = options) do
+  defp maybe_validate_rabbit_app_state(_command, _arguments, %{offline: true}) do
     :ok
   end
   defp maybe_validate_rabbit_app_state(command, arguments, options) do

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -81,10 +81,10 @@ defmodule RabbitMQCtl do
                   result = proceed_to_execution(command, arguments, options)
                   handle_command_output(result, command, options, output_fun);
                 {:validation_failure, err} ->
-                  argument_validation_error_output(err, command, unparsed_command, options)
+                  environment_validation_error_output(err, command, unparsed_command, options)
               end
             {:validation_failure, err} ->
-              environment_validation_error_output(err, command, unparsed_command, options)
+              argument_validation_error_output(err, command, unparsed_command, options)
           end
         end)
     end

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -283,8 +283,8 @@ defmodule RabbitMQCtl do
     Enum.join([header | for {key, val} <- opts do "#{key} : #{val}" end], "\n")
   end
   defp format_validation_error({:bad_info_key, keys}), do: "Info key(s) #{Enum.join(keys, ",")} are not supported"
-  defp format_validation_error(:rabbit_app_is_stopped), do: "this command requires the 'rabbit' app to be running on the target node. Start it with rabbitmqctl start_app."
-  defp format_validation_error(:rabbit_app_is_running), do: "this command requires the 'rabbit' app to be stopped on the target node. Stop it with rabbitmqctl stop_app."
+  defp format_validation_error(:rabbit_app_is_stopped), do: "this command requires the 'rabbit' app to be running on the target node. Start it with 'rabbitmqctl start_app'."
+  defp format_validation_error(:rabbit_app_is_running), do: "this command requires the 'rabbit' app to be stopped on the target node. Stop it with 'rabbitmqctl stop_app'."
   defp format_validation_error(err), do: inspect err
 
   defp exit_program(code) do

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -75,41 +75,18 @@ defmodule RabbitMQCtl do
           # validate CLI arguments
           case command.validate(arguments, options) do
             :ok ->
-              # then validate RabbitMQ application state (running or not)
-              case maybe_validate_rabbit_app_state(command, arguments, options) do
-                :ok ->
-                  # then optionally validate execution environment
-                  case maybe_validate_execution_environment(command, arguments, options) do
-                    :ok   -> proceed_to_execution(command, arguments, options)
-                    other -> other
-                  end
+              # then optionally validate execution environment
+              case maybe_validate_execution_environment(command, arguments, options) do
+                :ok   -> proceed_to_execution(command, arguments, options)
                 other -> other
               end
             other -> other
-          # handle_command_output will handle all the errors
-          # among other things
+            # handle_command_output will handle all the errors
+            # among other things
           end |> handle_command_output(command, options, unparsed_command, output_fun)
         end)
     end
   end
-
-  defp maybe_validate_rabbit_app_state(_command, _arguments, %{offline: true}) do
-    :ok
-  end
-  defp maybe_validate_rabbit_app_state(command, arguments, options) do
-    required_state = case function_exported?(command, :required_rabbit_app_state, 2) do
-                       false -> :running
-                       true  -> command.required_rabbit_app_state(arguments, options)
-                     end
-
-    compare_rabbit_app_state(Helpers.rabbit_app_running?(options), required_state)
-  end
-
-  defp compare_rabbit_app_state(true, :running),  do: :ok
-  defp compare_rabbit_app_state(false, :stopped), do: :ok
-  defp compare_rabbit_app_state(true, :stopped),  do: {:validation_error, "rabbit app not running"}
-  defp compare_rabbit_app_state(false, :running), do: {:validation_error, "rabbit app running"}
-  defp compare_rabbit_app_state(error, _), do: error
 
   defp maybe_validate_execution_environment(command, arguments, options) do
     case function_exported?(command, :validate_execution_environment, 2) do

--- a/test/forget_cluster_node_command_test.exs
+++ b/test/forget_cluster_node_command_test.exs
@@ -55,42 +55,42 @@ defmodule ForgetClusterNodeCommandTest do
       {:validation_failure, :too_many_args}
   end
 
-  test "validate: offline request to a running node fails", context do
+  test "validate_execution_environment: offline request to a running node fails", context do
     assert match?(
      {:validation_failure, :node_running},
-     @command.validate(["other_node@localhost"],
+     @command.validate_execution_environment(["other_node@localhost"],
                        Map.merge(context[:opts], %{offline: true})))
   end
 
-  test "validate: offline forget without mnesia dir fails", context do
+  test "validate_execution_environment: offline forget without mnesia dir fails", context do
     offline_opts = Map.merge(context[:opts],
                              %{offline: true, node: :non_exist@localhost})
     opts_without_mnesia = Map.delete(offline_opts, :mnesia_dir)
     assert match?(
       {:validation_failure, :mnesia_dir_not_found},
-      @command.validate(["other_node@localhost"], opts_without_mnesia))
+      @command.validate_execution_environment(["other_node@localhost"], opts_without_mnesia))
     Application.put_env(:mnesia, :dir, "/tmp")
     on_exit(fn -> Application.delete_env(:mnesia, :dir) end)
     assert match?(
       :ok,
-      @command.validate(["other_node@localhost"], opts_without_mnesia))
+      @command.validate_execution_environment(["other_node@localhost"], opts_without_mnesia))
     Application.delete_env(:mnesia, :dir)
     System.put_env("RABBITMQ_MNESIA_DIR", "/tmp")
     on_exit(fn -> System.delete_env("RABBITMQ_MNESIA_DIR") end)
     assert match?(
       :ok,
-      @command.validate(["other_node@localhost"], opts_without_mnesia))
+      @command.validate_execution_environment(["other_node@localhost"], opts_without_mnesia))
     System.delete_env("RABBITMQ_MNESIA_DIR")
     assert match?(
       :ok,
-      @command.validate(["other_node@localhost"], offline_opts))
+      @command.validate_execution_environment(["other_node@localhost"], offline_opts))
   end
 
-  test "validate: online mode does not fail is mnesia is not loaded", context do
+  test "validate_execution_environment: online mode does not fail is mnesia is not loaded", context do
     opts_without_mnesia = Map.delete(context[:opts], :mnesia_dir)
     assert match?(
       :ok,
-      @command.validate(["other_node@localhost"], opts_without_mnesia))
+      @command.validate_execution_environment(["other_node@localhost"], opts_without_mnesia))
   end
 
   test "run: online request to a non-existent node returns nodedown", context do

--- a/test/plugins/disable_plugins_command_test.exs
+++ b/test/plugins/disable_plugins_command_test.exs
@@ -60,6 +60,7 @@ defmodule DisablePluginsCommandTest do
       :ok,
       opts: Map.merge(context[:opts], %{
               node: get_rabbit_hostname(),
+              timeout: 1000
             })
     }
   end

--- a/test/plugins/disable_plugins_command_test.exs
+++ b/test/plugins/disable_plugins_command_test.exs
@@ -79,28 +79,28 @@ defmodule DisablePluginsCommandTest do
   end
 
   test "validate: not specifying an enabled_plugins_file is reported as an error", context do
-    assert @command.validate(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
+    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
       {:validation_failure, :no_plugins_file}
   end
 
   test "validate: not specifying a plugins_dir is reported as an error", context do
-    assert @command.validate(["a"], Map.delete(context[:opts], :plugins_dir)) ==
+    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
       {:validation_failure, :no_plugins_dir}
   end
 
 
   test "validate: specifying a non-existent enabled_plugins_file is fine", context do
-    assert @command.validate(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
+    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
   end
 
   test "validate: specifying a non-existent plugins_dir is reported as an error", context do
-    assert @command.validate(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
+    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
       {:validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "validate: failure to load the rabbit application is reported as an error", context do
     assert {:validation_failure, {:unable_to_load_rabbit, _}} =
-      @command.validate(["a"], Map.delete(context[:opts], :rabbitmq_home))
+      @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 
   test "node is unaccessible, writes out enabled plugins file and returns implicitly enabled plugin list", context do

--- a/test/plugins/disable_plugins_command_test.exs
+++ b/test/plugins/disable_plugins_command_test.exs
@@ -43,17 +43,14 @@ defmodule DisablePluginsCommandTest do
       set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(), opts)
     end)
 
-
     {:ok, opts: opts}
   end
 
   setup context do
-
     set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation],
                         :online,
                         get_rabbit_hostname(),
                         context[:opts])
-
 
 
     {
@@ -81,12 +78,12 @@ defmodule DisablePluginsCommandTest do
 
   test "validate_execution_environment: not specifying an enabled_plugins_file is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:validation_failure, :no_plugins_file}
+      {:environment_validation_failure, :no_plugins_file}
   end
 
   test "validate_execution_environment: not specifying a plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
-      {:validation_failure, :no_plugins_dir}
+      {:environment_validation_failure, :no_plugins_dir}
   end
 
 
@@ -96,11 +93,11 @@ defmodule DisablePluginsCommandTest do
 
   test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:validation_failure, :plugins_dir_does_not_exist}
+      {:environment_validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "validate_execution_environment: failure to load the rabbit application is reported as an error", context do
-    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
+    assert {:environment_validation_failure, {:unable_to_load_rabbit, _}} =
       @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 

--- a/test/plugins/disable_plugins_command_test.exs
+++ b/test/plugins/disable_plugins_command_test.exs
@@ -78,12 +78,12 @@ defmodule DisablePluginsCommandTest do
 
   test "validate_execution_environment: not specifying an enabled_plugins_file is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:environment_validation_failure, :no_plugins_file}
+      {:validation_failure, :no_plugins_file}
   end
 
   test "validate_execution_environment: not specifying a plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
-      {:environment_validation_failure, :no_plugins_dir}
+      {:validation_failure, :no_plugins_dir}
   end
 
 
@@ -93,11 +93,11 @@ defmodule DisablePluginsCommandTest do
 
   test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:environment_validation_failure, :plugins_dir_does_not_exist}
+      {:validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "validate_execution_environment: failure to load the rabbit application is reported as an error", context do
-    assert {:environment_validation_failure, {:unable_to_load_rabbit, _}} =
+    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
       @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 

--- a/test/plugins/disable_plugins_command_test.exs
+++ b/test/plugins/disable_plugins_command_test.exs
@@ -78,27 +78,27 @@ defmodule DisablePluginsCommandTest do
     )
   end
 
-  test "validate: not specifying an enabled_plugins_file is reported as an error", context do
+  test "validate_execution_environment: not specifying an enabled_plugins_file is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
       {:validation_failure, :no_plugins_file}
   end
 
-  test "validate: not specifying a plugins_dir is reported as an error", context do
+  test "validate_execution_environment: not specifying a plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
       {:validation_failure, :no_plugins_dir}
   end
 
 
-  test "validate: specifying a non-existent enabled_plugins_file is fine", context do
+  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
   end
 
-  test "validate: specifying a non-existent plugins_dir is reported as an error", context do
+  test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
       {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "validate: failure to load the rabbit application is reported as an error", context do
+  test "validate_execution_environment: failure to load the rabbit application is reported as an error", context do
     assert {:validation_failure, {:unable_to_load_rabbit, _}} =
       @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end

--- a/test/plugins/enable_plugins_command_test.exs
+++ b/test/plugins/enable_plugins_command_test.exs
@@ -78,12 +78,12 @@ defmodule EnablePluginsCommandTest do
 
   test "validate_execution_environment: not specifying an enabled_plugins_file is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:validation_failure, :no_plugins_file}
+      {:environment_validation_failure, :no_plugins_file}
   end
 
   test "validate_execution_environment: not specifying a plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
-      {:validation_failure, :no_plugins_dir}
+      {:environment_validation_failure, :no_plugins_dir}
   end
 
 
@@ -93,11 +93,11 @@ defmodule EnablePluginsCommandTest do
 
   test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:validation_failure, :plugins_dir_does_not_exist}
+      {:environment_validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "validate: failure to load the rabbit application is reported as an error", context do
-    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
+    assert {:environment_validation_failure, {:unable_to_load_rabbit, _}} =
       @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 

--- a/test/plugins/enable_plugins_command_test.exs
+++ b/test/plugins/enable_plugins_command_test.exs
@@ -57,6 +57,7 @@ defmodule EnablePluginsCommandTest do
       :ok,
       opts: Map.merge(context[:opts], %{
               node: get_rabbit_hostname(),
+              timeout: 1000
             })
     }
   end

--- a/test/plugins/enable_plugins_command_test.exs
+++ b/test/plugins/enable_plugins_command_test.exs
@@ -48,13 +48,10 @@ defmodule EnablePluginsCommandTest do
   end
 
   setup context do
-
     set_enabled_plugins([:rabbitmq_stomp, :rabbitmq_federation],
                         :online,
                         get_rabbit_hostname(),
                         context[:opts])
-
-
 
     {
       :ok,
@@ -71,36 +68,36 @@ defmodule EnablePluginsCommandTest do
     )
   end
 
-  test "validate: not specifying a plugins to enable is reported as invalid", context do
+  test "validate: not specifying any plugins to enable is reported as invalid", context do
     assert match?(
       {:validation_failure, :not_enough_arguments},
       @command.validate([], Map.merge(context[:opts], %{online: true, offline: false}))
     )
   end
 
-  test "validate: not specifying an enabled_plugins_file is reported as an error", context do
-    assert @command.validate(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
+  test "validate_execution_environment: not specifying an enabled_plugins_file is reported as an error", context do
+    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
       {:validation_failure, :no_plugins_file}
   end
 
-  test "validate: not specifying a plugins_dir is reported as an error", context do
-    assert @command.validate(["a"], Map.delete(context[:opts], :plugins_dir)) ==
+  test "validate_execution_environment: not specifying a plugins_dir is reported as an error", context do
+    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
       {:validation_failure, :no_plugins_dir}
   end
 
 
-  test "validate: specifying a non-existent enabled_plugins_file is fine", context do
-    assert @command.validate(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
+  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
+    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
   end
 
-  test "validate: specifying a non-existent plugins_dir is reported as an error", context do
-    assert @command.validate(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
+  test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
+    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
       {:validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "validate: failure to load the rabbit application is reported as an error", context do
     assert {:validation_failure, {:unable_to_load_rabbit, _}} =
-      @command.validate(["a"], Map.delete(context[:opts], :rabbitmq_home))
+      @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 
   test "if node is unaccessible, writes enabled plugins file and reports implicitly enabled plugin list", context do

--- a/test/plugins/enable_plugins_command_test.exs
+++ b/test/plugins/enable_plugins_command_test.exs
@@ -78,12 +78,12 @@ defmodule EnablePluginsCommandTest do
 
   test "validate_execution_environment: not specifying an enabled_plugins_file is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:environment_validation_failure, :no_plugins_file}
+      {:validation_failure, :no_plugins_file}
   end
 
   test "validate_execution_environment: not specifying a plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
-      {:environment_validation_failure, :no_plugins_dir}
+      {:validation_failure, :no_plugins_dir}
   end
 
 
@@ -93,11 +93,11 @@ defmodule EnablePluginsCommandTest do
 
   test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:environment_validation_failure, :plugins_dir_does_not_exist}
+      {:validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "validate: failure to load the rabbit application is reported as an error", context do
-    assert {:environment_validation_failure, {:unable_to_load_rabbit, _}} =
+    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
       @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 

--- a/test/plugins/list_plugins_command_test.exs
+++ b/test/plugins/list_plugins_command_test.exs
@@ -63,6 +63,7 @@ defmodule ListPluginsCommandTest do
       :ok,
       opts: Map.merge(context[:opts], %{
               node: get_rabbit_hostname(),
+              timeout: 1000
             })
     }
   end
@@ -79,29 +80,29 @@ defmodule ListPluginsCommandTest do
       {:validation_failure, :too_many_args}
   end
 
-  test "validate: not specifying enabled_plugins_file is reported as an error", context do
-    assert @command.validate(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
+  test "validate_execution_environment: not specifying enabled_plugins_file is reported as an error", context do
+    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
       {:validation_failure, :no_plugins_file}
   end
 
-  test "validate: not specifying plugins_dir is reported as an error", context do
-    assert @command.validate(["a"], Map.delete(context[:opts], :plugins_dir)) ==
+  test "validate_execution_environment: not specifying plugins_dir is reported as an error", context do
+    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
       {:validation_failure, :no_plugins_dir}
   end
 
 
-  test "validate: specifying non existent enabled_plugins_file is fine", context do
-    assert @command.validate(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
+  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
+    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
   end
 
-  test "validate: specifying non existent plugins_dir is reported as an error", context do
-    assert @command.validate(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
+  test "validate_execution_environment: specifying non existent plugins_dir is reported as an error", context do
+    assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
       {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "validate: failure to load rabbit application is reported as an error", context do
+  test "validate_execution_environment: failure to load rabbit application is reported as an error", context do
     assert {:validation_failure, {:unable_to_load_rabbit, _}} =
-      @command.validate(["a"], Map.delete(context[:opts], :rabbitmq_home))
+      @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 
   test "will report list of plugins from file for stopped node", context do

--- a/test/plugins/list_plugins_command_test.exs
+++ b/test/plugins/list_plugins_command_test.exs
@@ -82,12 +82,12 @@ defmodule ListPluginsCommandTest do
 
   test "validate_execution_environment: not specifying enabled_plugins_file is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:validation_failure, :no_plugins_file}
+      {:environment_validation_failure, :no_plugins_file}
   end
 
   test "validate_execution_environment: not specifying plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
-      {:validation_failure, :no_plugins_dir}
+      {:environment_validation_failure, :no_plugins_dir}
   end
 
 
@@ -97,11 +97,11 @@ defmodule ListPluginsCommandTest do
 
   test "validate_execution_environment: specifying non existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:validation_failure, :plugins_dir_does_not_exist}
+      {:environment_validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "validate_execution_environment: failure to load rabbit application is reported as an error", context do
-    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
+    assert {:environment_validation_failure, {:unable_to_load_rabbit, _}} =
       @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 

--- a/test/plugins/list_plugins_command_test.exs
+++ b/test/plugins/list_plugins_command_test.exs
@@ -82,12 +82,12 @@ defmodule ListPluginsCommandTest do
 
   test "validate_execution_environment: not specifying enabled_plugins_file is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:environment_validation_failure, :no_plugins_file}
+      {:validation_failure, :no_plugins_file}
   end
 
   test "validate_execution_environment: not specifying plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
-      {:environment_validation_failure, :no_plugins_dir}
+      {:validation_failure, :no_plugins_dir}
   end
 
 
@@ -97,11 +97,11 @@ defmodule ListPluginsCommandTest do
 
   test "validate_execution_environment: specifying non existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:environment_validation_failure, :plugins_dir_does_not_exist}
+      {:validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "validate_execution_environment: failure to load rabbit application is reported as an error", context do
-    assert {:environment_validation_failure, {:unable_to_load_rabbit, _}} =
+    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
       @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 

--- a/test/plugins/set_plugins_command_test.exs
+++ b/test/plugins/set_plugins_command_test.exs
@@ -68,30 +68,29 @@ defmodule SetPluginsCommandTest do
     )
   end
 
-  test "validate: not specifying enabled_plugins_file is reported as an error", context do
-    assert @command.validate([], Map.delete(context[:opts], :enabled_plugins_file)) ==
+  test "validate_execution_environment: not specifying enabled_plugins_file is reported as an error", context do
+    assert @command.validate_execution_environment([], Map.delete(context[:opts], :enabled_plugins_file)) ==
       {:validation_failure, :no_plugins_file}
   end
 
-  test "validate: not specifying plugins_dir is reported as an error", context do
-    assert @command.validate([], Map.delete(context[:opts], :plugins_dir)) ==
+  test "validate_execution_environment: not specifying plugins_dir is reported as an error", context do
+    assert @command.validate_execution_environment([], Map.delete(context[:opts], :plugins_dir)) ==
       {:validation_failure, :no_plugins_dir}
   end
 
-
-  test "validate: specifying non existent enabled_plugins_file is fine", context do
-    assert @command.validate([], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) ==
+  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
+    assert @command.validate_execution_environment([], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) ==
       :ok
   end
 
-  test "validate: specifying non existent plugins_dir is reported as an error", context do
-    assert @command.validate([], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
+  test "validate_execution_environment: specifying non existent plugins_dir is reported as an error", context do
+    assert @command.validate_execution_environment([], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
       {:validation_failure, :plugins_dir_does_not_exist}
   end
 
-  test "validate: failure to load rabbit application is reported as an error", context do
+  test "validate_execution_environment: failure to load rabbit application is reported as an error", context do
     assert {:validation_failure, {:unable_to_load_rabbit, _}} =
-      @command.validate([], Map.delete(context[:opts], :rabbitmq_home))
+      @command.validate_execution_environment([], Map.delete(context[:opts], :rabbitmq_home))
   end
 
   test "will write enabled plugins file if node is unaccessible and report implicitly enabled list", context do

--- a/test/plugins/set_plugins_command_test.exs
+++ b/test/plugins/set_plugins_command_test.exs
@@ -71,12 +71,12 @@ defmodule SetPluginsCommandTest do
 
   test "validate_execution_environment: not specifying enabled_plugins_file is reported as an error", context do
     assert @command.validate_execution_environment([], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:validation_failure, :no_plugins_file}
+      {:environment_validation_failure, :no_plugins_file}
   end
 
   test "validate_execution_environment: not specifying plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment([], Map.delete(context[:opts], :plugins_dir)) ==
-      {:validation_failure, :no_plugins_dir}
+      {:environment_validation_failure, :no_plugins_dir}
   end
 
   test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
@@ -86,11 +86,11 @@ defmodule SetPluginsCommandTest do
 
   test "validate_execution_environment: specifying non existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment([], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:validation_failure, :plugins_dir_does_not_exist}
+      {:environment_validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "validate_execution_environment: failure to load rabbit application is reported as an error", context do
-    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
+    assert {:environment_validation_failure, {:unable_to_load_rabbit, _}} =
       @command.validate_execution_environment([], Map.delete(context[:opts], :rabbitmq_home))
   end
 

--- a/test/plugins/set_plugins_command_test.exs
+++ b/test/plugins/set_plugins_command_test.exs
@@ -71,12 +71,12 @@ defmodule SetPluginsCommandTest do
 
   test "validate_execution_environment: not specifying enabled_plugins_file is reported as an error", context do
     assert @command.validate_execution_environment([], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:environment_validation_failure, :no_plugins_file}
+      {:validation_failure, :no_plugins_file}
   end
 
   test "validate_execution_environment: not specifying plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment([], Map.delete(context[:opts], :plugins_dir)) ==
-      {:environment_validation_failure, :no_plugins_dir}
+      {:validation_failure, :no_plugins_dir}
   end
 
   test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
@@ -86,11 +86,11 @@ defmodule SetPluginsCommandTest do
 
   test "validate_execution_environment: specifying non existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment([], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
-      {:environment_validation_failure, :plugins_dir_does_not_exist}
+      {:validation_failure, :plugins_dir_does_not_exist}
   end
 
   test "validate_execution_environment: failure to load rabbit application is reported as an error", context do
-    assert {:environment_validation_failure, {:unable_to_load_rabbit, _}} =
+    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
       @command.validate_execution_environment([], Map.delete(context[:opts], :rabbitmq_home))
   end
 

--- a/test/plugins/set_plugins_command_test.exs
+++ b/test/plugins/set_plugins_command_test.exs
@@ -57,6 +57,7 @@ defmodule SetPluginsCommandTest do
       :ok,
       opts: Map.merge(context[:opts], %{
               node: get_rabbit_hostname(),
+              timeout: 1000
             })
     }
   end

--- a/test/rabbitmqctl_test.exs
+++ b/test/rabbitmqctl_test.exs
@@ -85,14 +85,14 @@ defmodule RabbitMQCtlTest do
     command = ["status", "extra"]
     assert capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/Given:\n\t.*\nUsage:\n.* status/
+    end) =~ ~r/given:\n\t.*\nUsage:\n.* status/
   end
 
   test "Insufficient arguments return a usage error" do
     command = ["list_user_permissions"]
     assert capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/Given:\n\t.*\nUsage:\n.* list_user_permissions/
+    end) =~ ~r/given:\n\t.*\nUsage:\n.* list_user_permissions/
   end
 
   test "A bad argument returns a data error" do
@@ -109,17 +109,17 @@ defmodule RabbitMQCtlTest do
     command1 = ["--invalid=true", "list_permissions", "-p", "/"]
     assert capture_io(:stderr, fn ->
       error_check(command1, exit_usage())
-    end) =~ ~r/Error: Invalid options for this command/
+    end) =~ ~r/Invalid options for this command/
 
     command2 = ["--node", "rabbit", "status", "quack"]
     assert capture_io(:stderr, fn ->
       error_check(command2, exit_usage())
-    end) =~ ~r/Error: too many arguments./
+    end) =~ ~r/too many arguments./
 
     command3 = ["--node", "rabbit", "add_user", "quack"]
     assert capture_io(:stderr, fn ->
       error_check(command3, exit_usage())
-    end) =~ ~r/Error: not enough arguments./
+    end) =~ ~r/not enough arguments./
   end
 
 ## ------------------------- Default Flags ------------------------------------
@@ -150,12 +150,12 @@ defmodule RabbitMQCtlTest do
     command1 = ["status", "--nod=rabbit"]
     assert capture_io(:stderr, fn ->
       error_check(command1, exit_usage())
-    end) =~ ~r/Error: Invalid options for this command/
+    end) =~ ~r/Invalid options for this command/
 
     command2 = ["list_permissions", "-o", "/"]
     assert capture_io(:stderr, fn ->
       error_check(command2, exit_usage())
-    end) =~ ~r/Error: Invalid options for this command/
+    end) =~ ~r/Invalid options for this command/
   end
 
 ## ------------------------- Auto-complete ------------------------------------

--- a/test/rabbitmqctl_test.exs
+++ b/test/rabbitmqctl_test.exs
@@ -188,7 +188,7 @@ defmodule RabbitMQCtlTest do
     {:error, ^exit_code, message} =
         RabbitMQCtl.handle_command_output(
           {:error, {:badrpc, :nodedown}},
-          :no_command, %{node: node}, [],
+          :no_command, %{node: node},
           fn(output, _, _) -> output end)
 
     assert message =~ ~r/Error: unable to perform an operation on node/
@@ -199,7 +199,7 @@ defmodule RabbitMQCtlTest do
     {:error, ^exit_code, message} =
         RabbitMQCtl.handle_command_output(
           {:error, {:badrpc, :nodedown}},
-          :no_command, %{node: localnode}, [],
+          :no_command, %{node: localnode},
           fn(output, _, _) -> output end)
     assert message =~ ~r/DIAGNOSTICS/
     assert message =~ ~r/attempted to contact/
@@ -214,7 +214,7 @@ defmodule RabbitMQCtlTest do
     {:error, ^exit_code, ^err_msg} =
       RabbitMQCtl.handle_command_output(
           {:error, {:badrpc, :timeout}},
-          ExampleCommand,%{timeout: timeout, node: nodename}, ["example"],
+          ExampleCommand, %{timeout: timeout, node: nodename},
           fn(output, _, _) -> output end)
   end
 
@@ -223,7 +223,7 @@ defmodule RabbitMQCtlTest do
     {:error, ^exit_code, "Error:\nerror message"} =
       RabbitMQCtl.handle_command_output(
         {:error, "error message"},
-        :no_command, %{}, [],
+        :no_command, %{},
         fn(output, _, _) -> output end)
   end
 
@@ -234,7 +234,7 @@ defmodule RabbitMQCtlTest do
     {:error, ^exit_code, "Error:\n" <> ^inspected} =
       RabbitMQCtl.handle_command_output(
         {:error, error},
-        :no_command, %{}, [],
+        :no_command, %{},
         fn(output, _, _) -> output end)
   end
 
@@ -243,7 +243,7 @@ defmodule RabbitMQCtlTest do
     {:error, ^exit_code, "Error:\nerror_message"} =
       RabbitMQCtl.handle_command_output(
         {:error, :error_message},
-        :no_command, %{}, [],
+        :no_command, %{},
         fn(output, _, _) -> output end)
   end
 

--- a/test/rename_cluster_node_command_test.exs
+++ b/test/rename_cluster_node_command_test.exs
@@ -47,12 +47,6 @@ defmodule RenameClusterNodeCommandTest do
     }
   end
 
-  test "validate: specifying an uneven number of arguments fails validation", context do
-    assert match?(
-      {:validation_failure, {:bad_argument, _}},
-      @command.validate(["a", "b", "c"], context[:opts]))
-  end
-
   test "validate: specifying no nodes fails validation", context do
     assert @command.validate([], context[:opts]) ==
       {:validation_failure, :not_enough_args}
@@ -63,16 +57,22 @@ defmodule RenameClusterNodeCommandTest do
       {:validation_failure, :not_enough_args}
   end
 
-  test "validate: request to a running node fails", _context do
-    node = get_rabbit_hostname()
-    assert match?({:validation_failure, :node_running},
-      @command.validate([to_string(node), "other_node@localhost"], %{node: node}))
+  test "validate_execution_environment: specifying an uneven number of arguments fails validation", context do
+    assert match?(
+      {:validation_failure, {:bad_argument, _}},
+      @command.validate_execution_environment(["a", "b", "c"], context[:opts]))
   end
 
-  test "validate: not providing node mnesia dir fails validation", context do
+  test "validate_execution_environment: request to a running node fails", _context do
+    node = get_rabbit_hostname()
+    assert match?({:validation_failure, :node_running},
+      @command.validate_execution_environment([to_string(node), "other_node@localhost"], %{node: node}))
+  end
+
+  test "validate_execution_environment: not providing node mnesia dir fails validation", context do
     opts_without_mnesia = Map.delete(context[:opts], :mnesia_dir)
     assert match?({:validation_failure, :mnesia_dir_not_found},
-      @command.validate(["some_node@localhost", "other_node@localhost"], opts_without_mnesia))
+      @command.validate_execution_environment(["some_node@localhost", "other_node@localhost"], opts_without_mnesia))
     Application.put_env(:mnesia, :dir, "/tmp")
     on_exit(fn -> Application.delete_env(:mnesia, :dir) end)
     assert :ok == @command.validate(["some_node@localhost", "other_node@localhost"], opts_without_mnesia)


### PR DESCRIPTION
This is a follow-up attempt after #215 was considered to be an experiment that did not work out.

In this attempt we [will] introduce

 * More fine grained command execution steps
 * `validate_execution_environment/2`: an optional callback that can be used by commands to check that, say, files are readable or something else is acceptable, separately from CLI argument validation in `validate/2`

Fixes #214.