### PR TITLE
The command to restart a vhost.

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
@@ -1,0 +1,49 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+
+alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
+
+defmodule RabbitMQ.CLI.Ctl.Commands.RestartVhostCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def validate([], _),  do: :ok
+  def validate(_, _),   do: {:validation_failure, :too_many_args}
+
+  def merge_defaults(args, opts), do: {args, Map.merge(%{vhost: "/"}, opts)}
+
+  def run([], %{node: node_name, vhost: vhost, timeout: timeout}) do
+    :rabbit_misc.rpc_call(node_name, :rabbit_vhost_sup_sup, :start_vhost, [vhost], timeout)
+  end
+
+  def usage, do: "restart_vhost"
+
+  def banner(_,%{node: node_name, vhost: vhost}) do
+    "Trying to restart vhost '#{vhost}' on node '#{node_name}' ..."
+  end
+
+  def output({:ok, _pid}, %{vhost: vhost, node: node_name}) do
+    {:ok, "Successfully restarted vhost '#{vhost}' on node '#{node_name}'"}
+  end
+  def output({:error, {:already_started, _pid}}, %{vhost: vhost, node: node_name}) do
+    {:ok, "Vhost '#{vhost}' is already running on node '#{node_name}'"}
+  end
+  def output({:error, err}, %{vhost: vhost, node: node_name}) do
+    {:error, ExitCodes.exit_software(),
+     ["Failed to start vhost '#{vhost}' on node '#{node_name}'",
+      "Reason: #{inspect(err)}"]}
+  end
+  use RabbitMQ.CLI.DefaultOutput
+
+end

--- a/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
@@ -27,7 +27,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RestartVhostCommand do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost_sup_sup, :start_vhost, [vhost], timeout)
   end
 
-  def usage, do: "restart_vhost"
+  def usage, do: "restart_vhost [-p <vhost>]"
 
   def banner(_,%{node: node_name, vhost: vhost}) do
     "Trying to restart vhost '#{vhost}' on node '#{node_name}' ..."

--- a/lib/rabbitmq/cli/default_output.ex
+++ b/lib/rabbitmq/cli/default_output.ex
@@ -42,7 +42,7 @@ defmodule RabbitMQ.CLI.DefaultOutput do
   defp normalize_output({:badrpc_multi, _, _} = input), do: {:error, input}
   defp normalize_output({:badrpc, :nodedown} = input), do: {:error, input}
   defp normalize_output({:badrpc, :timeout} = input), do: {:error, input}
-  defp normalize_output({:badrpc, {:EXIT, reason}} = input), do: {:error, reason}
+  defp normalize_output({:badrpc, {:EXIT, reason}}), do: {:error, reason}
   defp normalize_output({:error, format, args})
     when (is_list(format) or is_binary(format)) and is_list(args) do
       {:error, to_string(:rabbit_misc.format(format, args))}

--- a/lib/rabbitmq/cli/default_output.ex
+++ b/lib/rabbitmq/cli/default_output.ex
@@ -42,6 +42,7 @@ defmodule RabbitMQ.CLI.DefaultOutput do
   defp normalize_output({:badrpc_multi, _, _} = input), do: {:error, input}
   defp normalize_output({:badrpc, :nodedown} = input), do: {:error, input}
   defp normalize_output({:badrpc, :timeout} = input), do: {:error, input}
+  defp normalize_output({:badrpc, {:EXIT, reason}} = input), do: {:error, reason}
   defp normalize_output({:error, format, args})
     when (is_list(format) or is_binary(format)) and is_list(args) do
       {:error, to_string(:rabbit_misc.format(format, args))}

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -18,7 +18,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
 
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
   alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 

--- a/test/decode_command_test.exs
+++ b/test/decode_command_test.exs
@@ -82,7 +82,6 @@ defmodule DecodeCommandTest do
   end
 
   defp encrypt_decrypt(secret) do
-    secret_as_erlang_term = format_as_erlang_term(secret)
     passphrase = "passphrase"
     cipher = :rabbit_pbe.default_cipher()
     hash = :rabbit_pbe.default_hash()

--- a/test/list_vhost_limits_command_test.exs
+++ b/test/list_vhost_limits_command_test.exs
@@ -114,8 +114,6 @@ defmodule ListVhostLimitsCommandTest do
   end
 
   test "banner", context do
-    vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
-
     assert @command.banner([], %{vhost: context[:vhost]})
       == "Listing limits for vhost \"#{context[:vhost]}\" ..."
     assert @command.banner([], %{global: true})

--- a/test/restart_vhost_command_test.exs
+++ b/test/restart_vhost_command_test.exs
@@ -69,8 +69,10 @@ defmodule RestartVhostCommandTest do
   end
 
   test "run: restarting an failed vhost returns ok", context do
-    force_vhost_failure(context[:opts][:node], context[:opts][:vhost])
+    vhost = context[:opts][:vhost]
+    force_vhost_failure(context[:opts][:node], vhost)
     {:ok, _} = @command.run([], context[:opts])
+    {:ok, _} = :rpc.call(node_name, :rabbit_vhost_sup_sup, :get_vhost_sup, [vhost])
   end
 
   def force_vhost_failure(node_name, vhost) do

--- a/test/restart_vhost_command_test.exs
+++ b/test/restart_vhost_command_test.exs
@@ -1,0 +1,88 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is Pivotal Software, Inc.
+## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule RestartVhostCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Ctl.Commands.RestartVhostCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+    :ok
+  end
+
+  @vhost "vhost_to_restart"
+  @timeout 10000
+
+  setup do
+    add_vhost @vhost
+    on_exit(fn ->
+      delete_vhost @vhost
+    end)
+    {:ok, opts: %{
+      node: get_rabbit_hostname(),
+      vhost: @vhost,
+      timeout: @timeout
+    }}
+  end
+
+  test "validate: specifying arguments is reported as an error", context do
+    assert @command.validate(["a"], context[:opts]) ==
+      {:validation_failure, :too_many_args}
+    assert @command.validate(["a", "b"], context[:opts]) ==
+      {:validation_failure, :too_many_args}
+    assert @command.validate(["a", "b", "c"], context[:opts]) ==
+      {:validation_failure, :too_many_args}
+  end
+
+  test "run: request to a non-existent node returns nodedown", context do
+    target = :jake@thedog
+
+    opts = %{node: target, vhost: @vhost, timeout: @timeout}
+    # We use "self" node as the target. It's enough to trigger the error.
+    assert match?(
+      {:badrpc, :nodedown},
+      @command.run([], opts))
+  end
+
+  test "banner", context do
+    expected = "Trying to restart vhost '#{@vhost}' on node '#{get_rabbit_hostname()}' ..."
+    expected = @command.banner([], context[:opts])
+  end
+
+  test "run: restarting an existing vhost returns already_started", context do
+    {:error, {:already_started, _}} = @command.run([], context[:opts])
+  end
+
+  test "run: restarting an failed vhost returns ok", context do
+    force_vhost_failure(context[:opts][:node], context[:opts][:vhost])
+    {:ok, _} = @command.run([], context[:opts])
+  end
+
+  def force_vhost_failure(node_name, vhost) do
+    case :rpc.call(node_name, :rabbit_vhost_sup_sup, :get_vhost_sup, [vhost]) do
+      {:ok, sup} ->
+        {_, pid, _, _} = :lists.keyfind(:msg_store_persistent, 1, :supervisor.which_children(sup))
+        Process.exit(pid, :foo)
+        :timer.sleep(100)
+        force_vhost_failure(node_name, vhost);
+      {:error, {:vhost_supervisor_not_running, _}} ->
+        :ok
+    end
+  end
+
+end

--- a/test/restart_vhost_command_test.exs
+++ b/test/restart_vhost_command_test.exs
@@ -49,7 +49,7 @@ defmodule RestartVhostCommandTest do
       {:validation_failure, :too_many_args}
   end
 
-  test "run: request to a non-existent node returns nodedown", context do
+  test "run: request to a non-existent node returns nodedown", _context do
     target = :jake@thedog
 
     opts = %{node: target, vhost: @vhost, timeout: @timeout}
@@ -61,7 +61,7 @@ defmodule RestartVhostCommandTest do
 
   test "banner", context do
     expected = "Trying to restart vhost '#{@vhost}' on node '#{get_rabbit_hostname()}' ..."
-    expected = @command.banner([], context[:opts])
+    ^expected = @command.banner([], context[:opts])
   end
 
   test "run: restarting an existing vhost returns already_started", context do
@@ -70,7 +70,8 @@ defmodule RestartVhostCommandTest do
 
   test "run: restarting an failed vhost returns ok", context do
     vhost = context[:opts][:vhost]
-    force_vhost_failure(context[:opts][:node], vhost)
+    node_name = context[:opts][:node]
+    force_vhost_failure(node_name, vhost)
     {:ok, _} = @command.run([], context[:opts])
     {:ok, _} = :rpc.call(node_name, :rabbit_vhost_sup_sup, :get_vhost_sup, [vhost])
   end


### PR DESCRIPTION
The command will attempt to restart a vhost.
If restarted successfully, return exit code 0
If the vhost is already started, return exit code 0 and notify that it's already started.
If there is an error restarting, return exit code 70 and the error
Part of rabbitmq/rabbitmq-server#1321
[#149484305]