### PR TITLE
Don't require RabbitMQ node to be running for `rabbitmq-plugins list'

### DIFF
--- a/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -48,8 +48,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
   end
 
   def validate_execution_environment(args, opts) do
-    Validators.chain([&Validators.rabbit_is_running_or_offline_flag_used/2,
-                      &Helpers.require_rabbit_and_plugins/2,
+    Validators.chain([&Helpers.require_rabbit_and_plugins/2,
                       &PluginHelpers.enabled_plugins_file/2,
                       &Helpers.plugins_dir/2],
                      [args, opts])


### PR DESCRIPTION
This extra validation wasn't intentional and turns out to be inconvenient
for provisioning and automation projects such as BOSH releases and Docker images.

An easy way to test this is by building the CLI and the server first:

 * `cd umbrella/deps/rabbitmq_cli; gmake`
 * `cd umbrella/deps/rabbit; gmake`

then running `scripts/rabbitmq-plugins` from `umbrella/rabbit` while providing it a plugins directory to use,
e.g. one from [a 3.7.0 milestone release](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v3.7.0-beta.19):

```
RABBITMQ_PLUGINS_DIR=~/Tools/rabbitmq/3.7.0.M19/plugins ./scripts/rabbitmq-plugins list
 Configured: E = explicitly enabled; e = implicitly enabled
 | Status: [failed to contact rabbit@mercurio - status not shown]
 |/
[  ] rabbitmq_amqp1_0                  3.7.0-beta.19
[  ] rabbitmq_auth_backend_ldap        3.7.0-beta.19
[  ] rabbitmq_auth_mechanism_ssl       3.7.0-beta.19
[  ] rabbitmq_consistent_hash_exchange 3.7.0-beta.19
[  ] rabbitmq_event_exchange           3.7.0-beta.19
[  ] rabbitmq_federation               3.7.0-beta.19
[  ] rabbitmq_federation_management    3.7.0-beta.19
[  ] rabbitmq_jms_topic_exchange       3.7.0-beta.19
[  ] rabbitmq_management               3.7.0-beta.19
[  ] rabbitmq_management_agent         3.7.0-beta.19
[  ] rabbitmq_mqtt                     3.7.0-beta.19
[  ] rabbitmq_recent_history_exchange  3.7.0-beta.19
[  ] rabbitmq_sharding                 3.7.0-beta.19
[  ] rabbitmq_shovel                   3.7.0-beta.19
[  ] rabbitmq_shovel_management        3.7.0-beta.19
[  ] rabbitmq_stomp                    3.7.0-beta.19
[  ] rabbitmq_top                      3.7.0-beta.19
[  ] rabbitmq_tracing                  3.7.0-beta.19
[  ] rabbitmq_trust_store              3.7.0-beta.19
[  ] rabbitmq_web_dispatch             3.7.0-beta.19
[  ] rabbitmq_web_mqtt                 3.7.0-beta.19
[  ] rabbitmq_web_mqtt_examples        3.7.0-beta.19
[  ] rabbitmq_web_stomp                3.7.0-beta.19
[  ] rabbitmq_web_stomp_examples       3.7.0-beta.19
```

The above assumes there are no enabled plugins because we haven't set `RABBITMQ_ENABLED_PLUGINS_FILE`:

```
RABBITMQ_ENABLED_PLUGINS_FILE=~/Tools/rabbitmq/3.7.0.M19/etc/rabbitmq/enabled_plugins RABBITMQ_PLUGINS_DIR=~/Tools/rabbitmq/3.7.0.M19/plugins ./scripts/rabbitmq-plugins list
 Configured: E = explicitly enabled; e = implicitly enabled
 | Status: [failed to contact rabbit@mercurio - status not shown]
 |/
[e ] rabbitmq_amqp1_0                  3.7.0-beta.19
[  ] rabbitmq_auth_backend_ldap        3.7.0-beta.19
[E ] rabbitmq_auth_mechanism_ssl       3.7.0-beta.19
[E ] rabbitmq_consistent_hash_exchange 3.7.0-beta.19
[  ] rabbitmq_event_exchange           3.7.0-beta.19
[  ] rabbitmq_federation               3.7.0-beta.19
[  ] rabbitmq_federation_management    3.7.0-beta.19
[E ] rabbitmq_jms_topic_exchange       3.7.0-beta.19
[E ] rabbitmq_management               3.7.0-beta.19
[E ] rabbitmq_management_agent         3.7.0-beta.19
[E ] rabbitmq_mqtt                     3.7.0-beta.19
[  ] rabbitmq_recent_history_exchange  3.7.0-beta.19
[  ] rabbitmq_sharding                 3.7.0-beta.19
[E ] rabbitmq_shovel                   3.7.0-beta.19
[E ] rabbitmq_shovel_management        3.7.0-beta.19
[E ] rabbitmq_stomp                    3.7.0-beta.19
[  ] rabbitmq_top                      3.7.0-beta.19
[  ] rabbitmq_tracing                  3.7.0-beta.19
[  ] rabbitmq_trust_store              3.7.0-beta.19
[e ] rabbitmq_web_dispatch             3.7.0-beta.19
[E ] rabbitmq_web_mqtt                 3.7.0-beta.19
[  ] rabbitmq_web_mqtt_examples        3.7.0-beta.19
[  ] rabbitmq_web_stomp                3.7.0-beta.19
[  ] rabbitmq_web_stomp_examples       3.7.0-beta.19
```

Closes #219.