### PR TITLE
Ensure that exit code 0 is used for "stop" command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,13 @@ you can simply run `make tests` within the project root directory.
 To run a single test case, use `make test` like so:
 
 ```
-make TEST_FILE=test/help_command_test.exs test
+make test TEST_FILE=test/help_command_test.exs
 ```
 
 And if you want to run in verbose mode, set the `V` make variable:
 
 ```
-make TEST_FILE=test/help_command_test.exs V=1 test
+make test TEST_FILE=test/help_command_test.exs V=1
 ```
 
 NOTE: You may see the following message several times:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,15 +48,14 @@ you can simply run `make tests` within the project root directory.
 To run a single test case, use `make test` like so:
 
 ```
-make test TEST_FILE=test/help_command_test.exs
+make TEST_FILE=test/help_command_test.exs test
 ```
 
 And if you want to run in verbose mode, set the `V` make variable:
 
 ```
-make test TEST_FILE=test/help_command_test.exs V=1
+make TEST_FILE=test/help_command_test.exs V=1 test
 ```
-
 
 NOTE: You may see the following message several times:
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT = rabbitmq_cli
 
 BUILD_DEPS = rabbit_common
-TEST_DEPS = amqp_client
+TEST_DEPS = amqp_client rabbit
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -269,7 +269,7 @@ defmodule RabbitMQCtl do
   defp validation_error_output(err_detail, base_error, command, options) do
     usage = HelpCommand.base_usage(command, options)
     message = base_error <> "\n" <> usage
-    {:error, ExitCodes.exit_code_for({:validation_failure, err_detail}), message}
+    {:error, ExitCodes.exit_code_for(command, {:validation_failure, err_detail}), message}
   end
 
   defp format_validation_error(:not_enough_args), do: "not enough arguments."
@@ -292,53 +292,53 @@ defmodule RabbitMQCtl do
     exit({:shutdown, code})
   end
 
-  defp format_error({:error, {:badrpc_multi, :nodedown, [node | _]} = result}, opts, _) do
+  defp format_error({:error, {:badrpc_multi, :nodedown, [node | _]} = result}, opts, command) do
     diagnostics = get_node_diagnostics(node)
-    {:error, ExitCodes.exit_code_for(result),
+    {:error, ExitCodes.exit_code_for(command, result),
      badrpc_error_message_header(node, opts) <> diagnostics}
   end
   defp format_error({:error, {:badrpc_multi, :timeout, [node | _]} = result}, opts, module) do
     op = CommandModules.module_to_command(module)
-    {:error, ExitCodes.exit_code_for(result),
+    {:error, ExitCodes.exit_code_for(op, result),
      "Error: operation #{op} on node #{node} timed out. Timeout value used: #{opts[:timeout]}"}
   end
-  defp format_error({:error, {:badrpc, :nodedown} = result}, opts, _) do
+  defp format_error({:error, {:badrpc, :nodedown} = result}, opts, command) do
     diagnostics = get_node_diagnostics(opts[:node])
-    {:error, ExitCodes.exit_code_for(result),
+    {:error, ExitCodes.exit_code_for(command, result),
      badrpc_error_message_header(opts[:node], opts) <> diagnostics}
   end
   defp format_error({:error, {:badrpc, :timeout} = result}, opts, module) do
     op = CommandModules.module_to_command(module)
-    {:error, ExitCodes.exit_code_for(result),
+    {:error, ExitCodes.exit_code_for(op, result),
      "Error: operation #{op} on node #{opts[:node]} timed out. Timeout value used: #{opts[:timeout]}"}
   end
   defp format_error({:error, {:badrpc, {:timeout, to}} = result}, opts, module) do
     op = CommandModules.module_to_command(module)
-    {:error, ExitCodes.exit_code_for(result),
+    {:error, ExitCodes.exit_code_for(op, result),
      "Error: operation #{op} on node #{opts[:node]} timed out. Timeout value used: #{to}"}
   end
   defp format_error({:error, {:badrpc, {:timeout, to, warning}}}, opts, module) do
     op = CommandModules.module_to_command(module)
-    {:error, ExitCodes.exit_code_for({:timeout, to}),
+    {:error, ExitCodes.exit_code_for(op, {:timeout, to}),
      "Error: operation #{op} on node #{opts[:node]} timed out. Timeout value used: #{to}. #{warning}"}
   end
-  defp format_error({:error, {:no_such_vhost, vhost} = result}, _opts, _) do
-    {:error, ExitCodes.exit_code_for(result),
+  defp format_error({:error, {:no_such_vhost, vhost} = result}, _opts, command) do
+    {:error, ExitCodes.exit_code_for(command, result),
      "Virtual host '#{vhost}' does not exist"}
   end
   defp format_error({:error, {:timeout, to} = result}, opts, module) do
     op = CommandModules.module_to_command(module)
-    {:error, ExitCodes.exit_code_for(result),
+    {:error, ExitCodes.exit_code_for(op, result),
      "Error: operation #{op} on node #{opts[:node]} timed out. Timeout value used: #{to}"}
   end
   defp format_error({:error, :timeout = result}, opts, module) do
     op = CommandModules.module_to_command(module)
-    {:error, ExitCodes.exit_code_for(result),
+    {:error, ExitCodes.exit_code_for(op, result),
      "Error: operation #{op} on node #{opts[:node]} timed out. Timeout value used: #{opts[:timeout]}"}
   end
-  defp format_error({:error, err} = result, _, _) do
+  defp format_error({:error, err} = result, _, command) do
     string_err = Helpers.string_or_inspect(err)
-    {:error, ExitCodes.exit_code_for(result), "Error:\n#{string_err}"}
+    {:error, ExitCodes.exit_code_for(command, result), "Error:\n#{string_err}"}
   end
 
   defp get_node_diagnostics(nil) do

--- a/test/rabbitmqctl_test.exs
+++ b/test/rabbitmqctl_test.exs
@@ -22,9 +22,7 @@ defmodule RabbitMQCtlTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-
     set_scope(:all)
-
     :ok
   end
 

--- a/test/rabbitmqctl_test.exs
+++ b/test/rabbitmqctl_test.exs
@@ -20,7 +20,6 @@ defmodule RabbitMQCtlTest do
   import RabbitMQ.CLI.Core.ExitCodes
   import TestHelper
 
-
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
@@ -29,7 +28,15 @@ defmodule RabbitMQCtlTest do
     :ok
   end
 
+## ------------------------ Exit Codes ------------------------------------
+
+  test "stop on a bad connection exits OK" do
+    command = ["stop", "-n", "sandwich@croque-monsieur"]
+    error_check(command, exit_ok())
+  end
+
 ## ------------------------ Error Messages ------------------------------------
+
   test "print error message on a bad connection" do
     command = ["status", "-n", "sandwich@pastrami"]
     assert capture_io(:stderr, fn ->
@@ -178,7 +185,6 @@ defmodule RabbitMQCtlTest do
       error_check(cmd, exit_ok())
     end) == out
   end
-
 
 ## ------------------------- Error formatting ---------------------------------
 

--- a/test/stop_command_test.exs
+++ b/test/stop_command_test.exs
@@ -22,8 +22,6 @@ defmodule StopCommandTest do
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-
-
     :ok
   end
 


### PR DESCRIPTION
Part of the fix to rabbitmq/rabbitmq-server#1362

Add test that validates exit code 0 when a stop command is issued to a non-running node