### PR TITLE
Fix rabbitmq-plugins enable/disable/set behavior for --online flag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ else
 endif
 
 dialyzer:: $(ESCRIPTS)
-	$(MIX_TEST) dialyzer
+	MIX_ENV=test mix dialyzer
 
 .PHONY: install
 

--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -22,11 +22,11 @@ defmodule RabbitMQ.CLI.Core.Parser do
   # the English language is 5.
   @levenshtein_distance_limit 5
 
-  @spec parse(String.t) :: {command :: :no_command | atom() | {:suggest, String.t},
-                            command_name :: String.t,
-                            arguments :: [String.t],
-                            options :: map(),
-                            invalid :: [{String.t, String.t | nil}]}
+  @spec parse([String.t]) :: {command :: :no_command | atom() | {:suggest, String.t},
+                              command_name :: String.t,
+                              arguments :: [String.t],
+                              options :: map(),
+                              invalid :: [{String.t, String.t | nil}]}
 
   def parse(input) do
     {parsed_args, options, invalid} = parse_global(input)

--- a/lib/rabbitmq/cli/core/validators.ex
+++ b/lib/rabbitmq/cli/core/validators.ex
@@ -36,6 +36,13 @@ defmodule RabbitMQ.CLI.Core.Validators do
     end
   end
 
+  def node_is_running(_, %{node: node_name}) do
+    case Helpers.node_running?(node_name) do
+      false -> {:validation_failure, :node_not_running};
+      true  -> :ok
+    end
+  end
+
   def mnesia_dir_is_set(_, opts) do
     case Helpers.require_mnesia_dir(opts) do
       :ok           -> :ok;

--- a/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -32,11 +32,11 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
   def can_set_plugins_with_mode(args, opts) do
     mode = mode(opts)
     case mode(opts) do
-      ## Can always set offline plugins list
+      # can always set offline plugins list
       :offline -> :ok;
-      ## It should fall back to offline mode in case of errors
+      # assume online mode, fall back to offline mode in case of errors
       :best_effort -> :ok;
-      ## The running node is required
+      # a running node is required
       :online ->
         Validators.chain([&Validators.node_is_running/2,
                           &Validators.rabbit_is_running/2],

--- a/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -14,10 +14,35 @@
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 alias RabbitMQ.CLI.Core.Helpers, as: CliHelpers
 alias RabbitMQ.CLI.Core.Config, as: Config
+alias RabbitMQ.CLI.Core.Validators, as: Validators
 
 defmodule RabbitMQ.CLI.Plugins.Helpers do
   import Rabbitmq.Atom.Coerce
   import RabbitCommon.Records
+
+  def mode(opts) do
+    %{online: online, offline: offline} = opts
+    case {online, offline} do
+      {true, false}  -> :online;
+      {false, true}  -> :offline;
+      {false, false} -> :best_effort
+    end
+  end
+
+  def can_set_plugins_with_mode(args, opts) do
+    mode = mode(opts)
+    case mode(opts) do
+      ## Can always set offline plugins list
+      :offline -> :ok;
+      ## It should fall back to offline mode in case of errors
+      :best_effort -> :ok;
+      ## The running node is required
+      :online ->
+        Validators.chain([&Validators.node_is_running/2,
+                          &Validators.rabbit_is_running/2],
+                          [args, opts])
+    end
+  end
 
   def list(opts) do
     {:ok, dir} = CliHelpers.plugins_dir(opts)
@@ -53,10 +78,23 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     write_enabled_plugins(plugin_atoms, plugins_file, opts)
   end
 
+  @spec update_enabled_plugins([atom()],
+                               :online | :offline | :best_effort,
+                               node(),
+                               map()) :: map() | {:error, any()}
   def update_enabled_plugins(enabled_plugins, mode, node_name, opts) do
     {:ok, plugins_file} = enabled_plugins_file(opts)
     case mode do
-      :online  ->
+      :online ->
+        case update_enabled_plugins(node_name, plugins_file) do
+          {:ok, started, stopped} ->
+            %{mode: :online,
+              started: Enum.sort(started),
+              stopped: Enum.sort(stopped),
+              set: Enum.sort(enabled_plugins)};
+          {:error, _} = err -> err
+        end;
+      :best_effort  ->
         case update_enabled_plugins(node_name, plugins_file) do
           {:ok, started, stopped} ->
             %{mode: :online,
@@ -137,7 +175,8 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
   defp update_enabled_plugins(node_name, plugins_file) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_plugins,
                                           :ensure, [to_list(plugins_file)]) do
-      {:badrpc, :nodedown} -> {:error, :offline};
+      {:badrpc, :nodedown}          -> {:error, :offline};
+      {:error, :rabbit_not_running} -> {:error, :offline};
       {:ok, start, stop}   -> {:ok, start, stop};
       {:error, _} = err    -> err
     end

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -285,6 +285,8 @@ defmodule RabbitMQCtl do
   defp format_validation_error({:bad_info_key, keys}), do: "Info key(s) #{Enum.join(keys, ",")} are not supported"
   defp format_validation_error(:rabbit_app_is_stopped), do: "this command requires the 'rabbit' app to be running on the target node. Start it with 'rabbitmqctl start_app'."
   defp format_validation_error(:rabbit_app_is_running), do: "this command requires the 'rabbit' app to be stopped on the target node. Stop it with 'rabbitmqctl stop_app'."
+  defp format_validation_error(:node_running), do: "this command requires the target node to be stopped."
+  defp format_validation_error(:node_not_running), do: "this command requires the target node to be running."
   defp format_validation_error(err), do: inspect err
 
   defp exit_program(code) do

--- a/test/plugins/disable_plugins_command_test.exs
+++ b/test/plugins/disable_plugins_command_test.exs
@@ -36,7 +36,7 @@ defmodule DisablePluginsCommandTest do
     opts = %{enabled_plugins_file: plugins_file,
              plugins_dir: plugins_dir,
              rabbitmq_home: rabbitmq_home,
-             online: true, offline: false,
+             online: false, offline: false,
              all: false}
 
     on_exit(fn ->

--- a/test/plugins/enable_plugins_command_test.exs
+++ b/test/plugins/enable_plugins_command_test.exs
@@ -36,7 +36,7 @@ defmodule EnablePluginsCommandTest do
     opts = %{enabled_plugins_file: plugins_file,
              plugins_dir: plugins_dir,
              rabbitmq_home: rabbitmq_home,
-             online: true, offline: false,
+             online: false, offline: false,
              all: false}
 
     on_exit(fn ->

--- a/test/plugins/set_plugins_command_test.exs
+++ b/test/plugins/set_plugins_command_test.exs
@@ -37,7 +37,7 @@ defmodule SetPluginsCommandTest do
     opts = %{enabled_plugins_file: plugins_file,
              plugins_dir: plugins_dir,
              rabbitmq_home: rabbitmq_home,
-             online: true, offline: false}
+             online: false, offline: false}
 
     on_exit(fn ->
       set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(),opts)


### PR DESCRIPTION
If flag is set to `--online` the commands should fail if node is not
running.
If flag is not set, they should fallback to offline mode if the
node is not running.
This corresponds to the rabbitmq-plugins.8 manpage.

Made validation aware of online flag.
Define best_effort mode to fallback if node is not running.
Requires rabbitmq/rabbitmq-server#1433

Fixes #226
[#153184802]