### PR TITLE
Adapt rabbitmq-diagnostics memory_breakdown to server master

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -83,14 +83,14 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
   defp compute_relative_values(all_pairs) do
     strategy  = Keyword.get(all_pairs, :strategy)
     num_pairs = Keyword.delete(all_pairs, :strategy)
-    # Includes RSS, allocated and runtime-used ("erlang") values
+    # Includes RSS, allocated and runtime-used ("erlang") values.
     # See https://github.com/rabbitmq/rabbitmq-server/pull/1404.
     totals    = Keyword.get(num_pairs, :total)
     pairs     = Keyword.delete(num_pairs, :total)
     total     = Keyword.get(totals, strategy) ||
-                # should not be necessary but be more defensive
-                # the list of totals depends on the strategy, so
-                # we have multiple fallback options
+                # Should not be necessary but be more defensive.
+                # The list of totals depends on the strategy, so
+                # we have multiple fallback options.
                 Keyword.get(totals, :rss) ||
                 Keyword.get(totals, :allocated) ||
                 Keyword.get(totals, :erlang)

--- a/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -87,10 +87,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
     # See https://github.com/rabbitmq/rabbitmq-server/pull/1404.
     totals    = Keyword.get(num_pairs, :total)
     pairs     = Keyword.delete(num_pairs, :total)
-    total     = Keyword.get(totals, strategy) ||
+    total     = max_of(totals) ||
                 # Should not be necessary but be more defensive.
-                # The list of totals depends on the strategy, so
-                # we have multiple fallback options.
                 Keyword.get(totals, :rss) ||
                 Keyword.get(totals, :allocated) ||
                 Keyword.get(totals, :erlang)
@@ -105,5 +103,9 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
 
   defp fraction_to_percent(x) do
     Float.round(x * 100, 2)
+  end
+
+  defp max_of(m) do
+    Keyword.values(m) |> Enum.max
   end
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -81,7 +81,6 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
   #
 
   defp compute_relative_values(all_pairs) do
-    strategy  = Keyword.get(all_pairs, :strategy)
     num_pairs = Keyword.delete(all_pairs, :strategy)
     # Includes RSS, allocated and runtime-used ("erlang") values.
     # See https://github.com/rabbitmq/rabbitmq-server/pull/1404.


### PR DESCRIPTION
Specifically to https://github.com/rabbitmq/rabbitmq-server/pull/1404.

Closes #228.

[#153217000]