### PR TITLE
 Add an optional callback to control erlang distribution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ There are also a number of optional callbacks:
    to provide additional command-specific documentation.
  * `scopes`: what scopes this command appears in. Scopes associate
    tools (e.g. `rabbitmqctl`, `rabbitmq-diagnostics`) with commands.
+ * `distribution`: control erlang distribution.
+   Can be `:cli` (default), `:none` or `{:fun, fun}`
 
 ### Tutorial
 

--- a/lib/rabbitmq/cli/command_behaviour.ex
+++ b/lib/rabbitmq/cli/command_behaviour.ex
@@ -33,7 +33,8 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
                       aliases: 0,
                       # validates execution environment, e.g. file presence,
                       # whether RabbitMQ is in an expected state on a node, etc
-                      validate_execution_environment: 2
+                      validate_execution_environment: 2,
+                      distribution: 1
 
   @callback validate_execution_environment(list(), map()) :: :ok | {:validation_failure, atom() | {atom(), any}}
   @callback switches() :: Keyword.t
@@ -42,4 +43,9 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
   @callback formatter() :: atom()
   @callback scopes() :: [atom()]
   @callback usage_additional() :: String.t | [String.t]
+  ## Erlang distribution control
+  ## :cli - default rabbitmqctl generated node name
+  ## :none - disable erlang distribution
+  ## {:fun, fun} - use a custom function to start distribution
+  @callback distribution(map()) :: :cli | :none | {:fun, ((map()) -> :ok | {:error, any()})}
 end

--- a/lib/rabbitmq/cli/ctl/commands/decode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/decode_command.ex
@@ -27,6 +27,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
       ]
   end
 
+  def distribution(_), do: :none
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{
         cipher:       :rabbit_pbe.default_cipher(),

--- a/lib/rabbitmq/cli/ctl/commands/encode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/encode_command.ex
@@ -27,6 +27,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
     ]
   end
 
+  def distribution(_), do: :none
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{
         cipher:       :rabbit_pbe.default_cipher(),

--- a/lib/rabbitmq/cli/ctl/commands/exec_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/exec_command.ex
@@ -60,7 +60,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExecCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Inspect
 
-  def usage, do: "exec <expr>"
+  def usage, do: "exec <expr> [--offline]"
 
   def banner(_, _), do: nil
 end

--- a/lib/rabbitmq/cli/ctl/commands/exec_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/exec_command.ex
@@ -20,6 +20,11 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExecCommand do
 
   def merge_defaults(args, opts), do: {args, opts}
 
+  def switches(), do: [offline: :boolean]
+
+  def distribution(%{offline: true}), do: :none
+  def distribution(%{}), do: :cli
+
   def validate([], _) do
     {:validation_failure, :not_enough_args}
   end

--- a/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -24,6 +24,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
 
   def validate(_, _), do: :ok
 
+  def distribution(_), do: :none
+
   def merge_defaults(args, opts), do: {args, opts}
 
   def scopes(), do: [:ctl, :diagnostics, :plugins]

--- a/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
@@ -23,6 +23,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HipeCompileCommand do
   # API
   #
 
+  def distribution(_), do: :none
+
   def merge_defaults(args, opts) do
     {args, opts}
   end

--- a/lib/rabbitmq/cli/ctl/commands/list_ciphers_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_ciphers_command.ex
@@ -26,6 +26,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListCiphersCommand do
   end
   def validate(_, _), do: :ok
 
+  def distribution(_), do: :none
+
   def run(_, _) do
     {:ok, :rabbit_pbe.supported_ciphers()}
   end

--- a/lib/rabbitmq/cli/ctl/commands/list_hashes_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_hashes_command.ex
@@ -26,6 +26,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListHashesCommand do
   end
   def validate(_, _), do: :ok
 
+  def distribution(_), do: :none
+
   def run(_, _) do
     {:ok, :rabbit_pbe.supported_hashes()}
   end

--- a/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -27,6 +27,9 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
     {args, Map.merge(%{online: false, offline: false, all: false}, opts)}
   end
 
+  def distribution(%{offline: true}),  do: :none
+  def distribution(%{offline: false}), do: :cli
+
   def switches(), do: [online: :boolean,
                        offline: :boolean,
                        all: :boolean]

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -27,6 +27,9 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
     {args, Map.merge(%{online: false, offline: false, all: false}, opts)}
   end
 
+  def distribution(%{offline: true}),  do: :none
+  def distribution(%{offline: false}), do: :cli
+
   def switches(), do: [online: :boolean,
                        offline: :boolean,
                        all: :boolean]

--- a/lib/rabbitmq/cli/plugins/commands/set_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/set_command.ex
@@ -28,6 +28,9 @@ defmodule RabbitMQ.CLI.Plugins.Commands.SetCommand do
     {args, Map.merge(%{online: false, offline: false}, opts)}
   end
 
+  def distribution(%{offline: true}),  do: :none
+  def distribution(%{offline: false}), do: :cli
+
   def switches(), do: [online: :boolean,
                        offline: :boolean]
 

--- a/rabbitmq-components.mk
+++ b/rabbitmq-components.mk
@@ -115,7 +115,7 @@ dep_cowlib = hex 2.0.0
 dep_jsx = hex 2.8.2
 dep_lager = hex 3.5.1
 dep_ranch = hex 1.4.0
-dep_ranch_proxy_protocol = hex 1.4.2
+dep_ranch_proxy_protocol = hex 1.4.4
 dep_recon = hex 2.3.2
 
 dep_sockjs = git https://github.com/rabbitmq/sockjs-erlang.git 405990ea62353d98d36dbf5e1e64942d9b0a1daf
@@ -326,11 +326,16 @@ endif
 
 UPSTREAM_RMQ_COMPONENTS_MK = $(DEPS_DIR)/rabbit_common/mk/rabbitmq-components.mk
 
+ifeq ($(PROJECT),rabbit_common)
+check-rabbitmq-components.mk:
+	@:
+else
 check-rabbitmq-components.mk:
 	$(verbose) cmp -s rabbitmq-components.mk \
 		$(UPSTREAM_RMQ_COMPONENTS_MK) || \
 		(echo "error: rabbitmq-components.mk must be updated!" 1>&2; \
 		  false)
+endif
 
 ifeq ($(PROJECT),rabbit_common)
 rabbitmq-components-mk:


### PR DESCRIPTION
The callback can be used to disable erlang distribution (offline commands)
or to have command-specific node name and distribution parameters.