### PR TITLE
Specify dist port range

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule RabbitMQCtl.MixfileBase do
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       escript: [main_module: RabbitMQCtl,
-                emu_args: "-hidden -kernel inet_dist_listen_min 55672 -kernel inet_dist_listen_max 55672",
+                emu_args: "-hidden -kernel inet_dist_listen_min 35672 -kernel inet_dist_listen_max 35672",
                 path: "escript/rabbitmqctl"],
       deps: deps(),
       aliases: aliases()

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule RabbitMQCtl.MixfileBase do
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       escript: [main_module: RabbitMQCtl,
-                emu_args: "-hidden",
+                emu_args: "-hidden -kernel inet_dist_listen_min 55672 -kernel inet_dist_listen_max 55672",
                 path: "escript/rabbitmqctl"],
       deps: deps(),
       aliases: aliases()


### PR DESCRIPTION
Fixes #237 

Question: do we want to use a different port?

Also, as of version 3.7.3 we won't be using `escript` to run these commands anymore (rabbitmq/rabbitmq-server#1462) so I will have to add the `-kernel` argument to those scripts / batch files.