### PR TITLE
Ensure another string case is taken care of

### DIFF
--- a/lib/rabbitmq/cli/core/config.ex
+++ b/lib/rabbitmq/cli/core/config.ex
@@ -29,10 +29,11 @@ defmodule RabbitMQ.CLI.Core.Config do
   def normalize(:erlang_cookie, c) when not is_atom(c) do
     Rabbitmq.Atom.Coerce.to_atom(c)
   end
-  def normalize(:longnames, true),   do: :longnames
-  def normalize(:longnames, "true"), do: :longnames
-  def normalize(:longnames, 'true'), do: :longnames
-  def normalize(:longnames, _),      do: :shortnames
+  def normalize(:longnames, true),       do: :longnames
+  def normalize(:longnames, "true"),     do: :longnames
+  def normalize(:longnames, 'true'),     do: :longnames
+  def normalize(:longnames, "\"true\""), do: :longnames
+  def normalize(:longnames, val),        do: :shortnames
   def normalize(_, value),           do: value
 
   def get_system_option(:script_name) do


### PR DESCRIPTION
If a user happens to set the following in `rabbitmq-env-conf.bat`, it will be matched:

```
set USE_LONGNAME="true"
```

Fixes rabbitmq/rabbitmq-server#1508