### PR TITLE
Timeout in help messages

### DIFF
--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -167,7 +167,6 @@ defmodule RabbitMQ.CLI.Core.Parser do
     [node: :atom,
      quiet: :boolean,
      dry_run: :boolean,
-     # timeout: :integer,
      vhost: :string,
      longnames: :boolean,
      formatter: :string,
@@ -187,7 +186,6 @@ defmodule RabbitMQ.CLI.Core.Parser do
     [p: :vhost,
      n: :node,
      q: :quiet,
-     # t: :timeout,
      l: :longnames]
   end
 

--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -167,7 +167,7 @@ defmodule RabbitMQ.CLI.Core.Parser do
     [node: :atom,
      quiet: :boolean,
      dry_run: :boolean,
-     timeout: :integer,
+     # timeout: :integer,
      vhost: :string,
      longnames: :boolean,
      formatter: :string,
@@ -187,7 +187,7 @@ defmodule RabbitMQ.CLI.Core.Parser do
     [p: :vhost,
      n: :node,
      q: :quiet,
-     t: :timeout,
+     # t: :timeout,
      l: :longnames]
   end
 

--- a/lib/rabbitmq/cli/ctl/commands/delete_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/delete_queue_command.ex
@@ -17,8 +17,8 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.DeleteQueueCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  def switches(), do: [if_empty: :boolean, if_unused: :boolean]
-  def aliases(), do: [e: :if_empty, u: :is_unused]
+  def switches(), do: [if_empty: :boolean, if_unused: :boolean, timeout: :integer]
+  def aliases(), do: [e: :if_empty, u: :is_unused, t: :timeout]
 
   def usage(), do: "delete_queue queue_name [--if_empty|-e] [--if_unused|-u]"
 

--- a/lib/rabbitmq/cli/ctl/commands/list_bindings_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_bindings_command.ex
@@ -29,6 +29,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListBindingsCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
+
   def merge_defaults([], opts) do
     {~w(source_name source_kind
              destination_name destination_kind

--- a/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
@@ -25,6 +25,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConnectionsCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   @info_keys ~w(pid name port host peer_port peer_host ssl ssl_protocol
                 ssl_key_exchange ssl_cipher ssl_hash peer_cert_subject

--- a/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
@@ -25,6 +25,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   @info_keys ~w(queue_name channel_pid consumer_tag
                 ack_required prefetch_count arguments)a

--- a/lib/rabbitmq/cli/ctl/commands/list_exchanges_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_exchanges_command.ex
@@ -28,6 +28,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListExchangesCommand do
   def info_keys(), do: @info_keys
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults([], opts) do
     merge_defaults(~w(name type), opts)
@@ -36,7 +38,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListExchangesCommand do
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}
   end
-  
+
   def validate(args, _) do
       case InfoKeys.validate_info_keys(args, @info_keys) do
         {:ok, _} -> :ok
@@ -45,7 +47,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListExchangesCommand do
   end
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-  
+
   def run([_|_] = args, %{node: node_name, timeout: timeout, vhost: vhost}) do
       info_keys = InfoKeys.prepare_info_keys(args)
       RpcStream.receive_list_items(node_name, :rabbit_exchange, :info_all,
@@ -62,6 +64,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListExchangesCommand do
       "<exchangeinfoitem> must be a member of the list [" <>
       Enum.join(@info_keys, ", ") <> "]."
   end
-  
+
   def banner(_,%{vhost: vhost}), do: "Listing exchanges for vhost #{vhost} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_global_parameters_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_global_parameters_command.ex
@@ -25,6 +25,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListGlobalParametersCommand do
   end
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def validate([_|_], _) do
     {:validation_failure, :too_many_args}
@@ -32,7 +34,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListGlobalParametersCommand do
   def validate([], _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-  
+
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_runtime_parameters,

--- a/lib/rabbitmq/cli/ctl/commands/list_operator_policies_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_operator_policies_command.ex
@@ -22,6 +22,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListOperatorPoliciesCommand do
 
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/list_parameters_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_parameters_command.ex
@@ -22,6 +22,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListParametersCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/list_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_permissions_command.ex
@@ -21,6 +21,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListPermissionsCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/list_policies_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_policies_command.ex
@@ -21,6 +21,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListPoliciesCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
@@ -41,7 +41,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def switches(), do: [offline: :boolean, online: :boolean, local: :boolean]
+  def switches(), do: [offline: :boolean, online: :boolean, local: :boolean, timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   defp default_opts() do
     %{vhost: "/", offline: false, online: false, local: false}
@@ -103,8 +104,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
   end
 
   def usage_additional() do
-    "<queueinfoitem> must be a member of the list [" <>
-      Enum.join(@info_keys, ", ") <> "]."
+    ["<queueinfoitem> must be a member of the list [" <> Enum.join(@info_keys, ", ") <> "]."]
   end
 
   def banner(_,%{vhost: vhost, timeout: timeout}) do

--- a/lib/rabbitmq/cli/ctl/commands/list_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_topic_permissions_command.ex
@@ -21,6 +21,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListTopicPermissionsCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}

--- a/lib/rabbitmq/cli/ctl/commands/list_unresponsive_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_unresponsive_queues_command.ex
@@ -34,7 +34,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUnresponsiveQueuesCommand do
 
   def scopes(), do: [:ctl, :diagnostics]
 
-  def switches(), do: [queue_timeout: :integer, local: :boolean]
+  def switches(), do: [queue_timeout: :integer, local: :boolean, timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   defp default_opts() do
     %{vhost: "/", local: false, queue_timeout: 15}

--- a/lib/rabbitmq/cli/ctl/commands/list_user_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_user_permissions_command.ex
@@ -21,6 +21,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserPermissionsCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/ctl/commands/list_user_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_user_topic_permissions_command.ex
@@ -21,6 +21,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserTopicPermissionsCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
@@ -21,6 +21,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUsersCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
@@ -27,6 +27,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostsCommand do
   def info_keys(), do: @info_keys
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults([], opts), do: {["name"], opts}
   def merge_defaults(args, opts), do: {args, opts}

--- a/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
@@ -19,6 +19,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand do
   @default_timeout 70_000
 
   def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts) do
     timeout = case opts[:timeout] do

--- a/lib/rabbitmq/cli/ctl/commands/purge_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/purge_queue_command.ex
@@ -18,6 +18,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.PurgeQueueCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/"}, opts)}
   end

--- a/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
@@ -18,6 +18,9 @@ alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
 defmodule RabbitMQ.CLI.Ctl.Commands.RestartVhostCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
+
   def merge_defaults(args, opts), do: {args, Map.merge(%{vhost: "/"}, opts)}
 
   def validate([], _),  do: :ok

--- a/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -20,12 +20,12 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   @default_timeout 10_000
 
-  def switches(), do: [pid: :integer]
+  def switches(), do: [pid: :integer, timeout: :integer]
 
-  def aliases(), do: ['P': :pid]
+  def aliases(), do: ['P': :pid, t: :timeout]
 
   def scopes(), do: [:ctl, :diagnostics]
-  
+
   def merge_defaults(args, opts) do
     timeout = case opts[:timeout] do
       nil       -> @default_timeout;

--- a/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -20,7 +20,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
 
   def merge_defaults(args, opts), do: {args, Map.merge(%{openssl_format: false}, opts)}
 
-  def switches(), do: [openssl_format: :boolean]
+  def switches(), do: [openssl_format: :boolean, timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def validate(args, _) when length(args) > 0 do
     {:validation_failure, :too_many_args}

--- a/lib/rabbitmq/cli/diagnostics/commands/discover_peers_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/discover_peers_command.ex
@@ -17,6 +17,9 @@
 defmodule RabbitMQ.CLI.Diagnostics.Commands.DiscoverPeersCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
+
   def merge_defaults(args, opts), do: {args, opts}
 
   def validate([_|_], _) do

--- a/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_hash_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_hash_command.ex
@@ -17,6 +17,9 @@
 defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieHashCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
+
   def merge_defaults(args, opts), do: {args, opts}
 
   def validate(args, _) when length(args) > 0 do

--- a/lib/rabbitmq/cli/diagnostics/commands/erlang_version_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/erlang_version_command.ex
@@ -17,7 +17,8 @@
 defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangVersionCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  def switches(), do: [details: :boolean]
+  def switches(), do: [details: :boolean, timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{details: false}, opts)}

--- a/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
@@ -18,8 +18,9 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MaybeStuckCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
-  def switches(), do: []
-  
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
+
   def merge_defaults(args, opts), do: {args, opts}
 
   def validate(args, _) when length(args) > 0 do
@@ -35,5 +36,5 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MaybeStuckCommand do
     "Asking node #{node_name} to detect potentially stuck Erlang processes..."
   end
 
-  def usage, do: "maybe_stuck"  
+  def usage, do: "maybe_stuck"
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -19,7 +19,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  def switches(), do: [unit: :string]
+  def switches(), do: [unit: :string, timeout: :integer]
+  def aliases(), do: [t: :timeout]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{unit: "gb"}, opts)}

--- a/lib/rabbitmq/cli/diagnostics/commands/server_version_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/server_version_command.ex
@@ -17,6 +17,9 @@
 defmodule RabbitMQ.CLI.Diagnostics.Commands.ServerVersionCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
+
   def merge_defaults(args, opts), do: {args, opts}
 
   def validate(args, _) when length(args) > 0 do

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -113,30 +113,6 @@ defmodule ParserTest do
     assert @subject.parse_global(["--node=rabbitmq@localhost"]) == {[], %{node: :"rabbitmq@localhost"}, []}
   end
 
-  test "no commands, one integer --timeout value" do
-    assert @subject.parse_global(["--timeout=600"]) == {[], %{timeout: 600}, []}
-  end
-
-  test "no commands, one string --timeout value is invalid" do
-    assert @subject.parse_global(["--timeout=sandwich"]) == {[], %{}, [{"--timeout", "sandwich"}]}
-  end
-
-  test "no commands, one float --timeout value is invalid" do
-    assert @subject.parse_global(["--timeout=60.5"]) == {[], %{}, [{"--timeout", "60.5"}]}
-  end
-
-  test "no commands, one integer -t value" do
-    assert @subject.parse_global(["-t", "600"]) == {[], %{timeout: 600}, []}
-  end
-
-  test "no commands, one string -t value is invalid" do
-    assert @subject.parse_global(["-t", "sandwich"]) == {[], %{}, [{"-t", "sandwich"}]}
-  end
-
-  test "no commands, one float -t value is invalid" do
-    assert @subject.parse_global(["-t", "60.5"]) == {[], %{}, [{"-t", "60.5"}]}
-  end
-
   test "no commands, one single-dash -p option" do
     assert @subject.parse_global(["-p", "sandwich"]) == {[], %{vhost: "sandwich"}, []}
   end

--- a/test/rabbitmqctl_test.exs
+++ b/test/rabbitmqctl_test.exs
@@ -59,14 +59,14 @@ defmodule RabbitMQCtlTest do
     command = []
     assert capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/Usage:\n/
+    end) =~ ~r/\nUsage:\n/
   end
 
   test "Empty command with options shows usage, and exit with usage exit code" do
     command = ["-n", "sandwich@pastrami"]
     assert capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/Usage:\n/
+    end) =~ ~r/\nUsage:\n/
   end
 
   test "Short names without host connect properly" do
@@ -78,21 +78,21 @@ defmodule RabbitMQCtlTest do
     command = ["not_real"]
     assert capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/Usage\:/
+    end) =~ ~r/\nUsage\:/
   end
 
   test "Extraneous arguments return a usage error" do
     command = ["status", "extra"]
     assert capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/given:\n\t.*\nUsage:\n.* status/
+    end) =~ ~r/given:\n\t.*\n\nUsage:\n.* status/
   end
 
   test "Insufficient arguments return a usage error" do
     command = ["list_user_permissions"]
     assert capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/given:\n\t.*\nUsage:\n.* list_user_permissions/
+    end) =~ ~r/given:\n\t.*\n\nUsage:\n.* list_user_permissions/
   end
 
   test "A bad argument returns a data error" do


### PR DESCRIPTION
Addresses #236
 
Only show timeout help for commands, which support it.
Removed timeout from global switches.
Each command supporting timeout argument should have it in it's own switches.
Help for timeout is shown for each command, supporting timeout.
Reworked timeout message.

This PR addresses the help message only. And only for commands, which currently respect the timeout argument. In future it might be required to revisit remaining commands and make them respect the argument.
Also some commands have default timeout, which is not infinity, they don't have a separate help message, so the message can be confusing.