### PR TITLE
Accept -t/--timeout before command name [again]

### DIFF
--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -168,6 +168,8 @@ defmodule RabbitMQ.CLI.Core.Parser do
      quiet: :boolean,
      dry_run: :boolean,
      vhost: :string,
+     # for backwards compatibility,
+     # not all commands support timeouts
      timeout: :integer,
      longnames: :boolean,
      formatter: :string,
@@ -188,6 +190,8 @@ defmodule RabbitMQ.CLI.Core.Parser do
      n: :node,
      q: :quiet,
      l: :longnames,
+     # for backwards compatibility,
+     # not all commands support timeouts
      t: :timeout]
   end
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -152,6 +152,18 @@ defmodule ParserTest do
       {["seagull"], %{vhost: "my_vhost"}, []}
   end
 
+  test "--timeout can be specified before command" do
+    # for backwards compatibility
+    assert @subject.parse_global(["-n", "rabbitmq@localhost", "--timeout", "5", "sandwich", "pastrami"]) ==
+      {["sandwich", "pastrami"], %{node: :"rabbitmq@localhost", timeout: 5}, []}
+  end
+
+  test "-t can be specified before command" do
+    # for backwards compatibility
+    assert @subject.parse_global(["-n", "rabbitmq@localhost", "-t", "5", "sandwich", "pastrami"]) ==
+      {["sandwich", "pastrami"], %{node: :"rabbitmq@localhost", timeout: 5}, []}
+  end
+
   test "parse/1 returns command name" do
     command_line = ["pacific_gull", "fly", "-p", "my_vhost"]
     command = RabbitMQ.CLI.Seagull.Commands.PacificGullCommand


### PR DESCRIPTION
There are existing users (including RabbitMQ core tests) that
use that sequence because it was previously in the docs.

This relaxes command validation so that if a command-specific
flag overrides a global, we accept it as long as their types match.

Per discussion with @hairyhum.