### PR TITLE
Re-include policies and parameters in rabbitmqctl report & reduce code footprint on aliases

### DIFF
--- a/lib/rabbitmq/cli/auto_complete.ex
+++ b/lib/rabbitmq/cli/auto_complete.ex
@@ -15,8 +15,7 @@
 
 
 defmodule Rabbitmq.CLI.AutoComplete do
-  alias RabbitMQ.CLI.Core.Parser, as: Parser
-  alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
+  alias RabbitMQ.CLI.Core.{CommandModules, Parser}
 
   @spec complete(String.t, [String.t]) :: [String.t]
   def complete(_, []) do

--- a/lib/rabbitmq/cli/core/command_modules.ex
+++ b/lib/rabbitmq/cli/core/command_modules.ex
@@ -13,9 +13,8 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.Config, as: Config
+alias RabbitMQ.CLI.Core.{Config, Helpers}
 alias RabbitMQ.CLI.Plugins.Helpers, as: PluginsHelpers
-alias RabbitMQ.CLI.Core.Helpers, as: Helpers
 
 defmodule RabbitMQ.CLI.Core.CommandModules do
   @commands_ns ~r/RabbitMQ.CLI.(.*).Commands/

--- a/lib/rabbitmq/cli/core/distribution.ex
+++ b/lib/rabbitmq/cli/core/distribution.ex
@@ -13,7 +13,7 @@
 ## The Initial Developer of the Original Code is Pivotal Software, Inc.
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.Config, as: Config
+alias RabbitMQ.CLI.Core.Config
 
 defmodule RabbitMQ.CLI.Core.Distribution do
 

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -16,7 +16,7 @@
 
 # Small helper functions, mostly related to connecting to RabbitMQ and
 # handling memory units.
-alias RabbitMQ.CLI.Core.Config, as: Config
+alias RabbitMQ.CLI.Core.Config
 
 defmodule RabbitMQ.CLI.Core.Helpers do
   require Record

--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -13,8 +13,7 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
-alias RabbitMQ.CLI.Core.Config, as: Config
+alias RabbitMQ.CLI.Core.{CommandModules, Config}
 
 defmodule RabbitMQ.CLI.Core.Parser do
 
@@ -210,7 +209,7 @@ defmodule RabbitMQ.CLI.Core.Parser do
                         {command, {:redefining_global_aliases,
                                    command_aliases}}})
   end
-  
+
   defp apply_if_exported(mod, fun, args, default) do
     case function_exported?(mod, fun, length(args)) do
       true  -> apply(mod, fun, args);

--- a/lib/rabbitmq/cli/core/validators.ex
+++ b/lib/rabbitmq/cli/core/validators.ex
@@ -15,7 +15,7 @@
 
 # Provides common validation functions.
 defmodule RabbitMQ.CLI.Core.Validators do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   def chain([validator | rest], args) do
     case apply(validator, args) do

--- a/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -16,8 +16,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
 
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
+  alias RabbitMQ.CLI.Core.{ExitCodes, Helpers}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 

--- a/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_vhost_command.ex
@@ -16,7 +16,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
 
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
@@ -16,7 +16,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ChangePasswordCommand do
 
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/clear_global_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_global_parameter_command.ex
@@ -16,7 +16,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearGlobalParameterCommand do
 
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
@@ -16,7 +16,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearOperatorPolicyCommand do
 
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/clear_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_parameter_command.ex
@@ -16,7 +16,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearParameterCommand do
 
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/clear_password_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_password_command.ex
@@ -16,7 +16,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearPasswordCommand do
 
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearPermissionsCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/clear_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_policy_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearPolicyCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/clear_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_topic_permissions_command.ex
@@ -16,7 +16,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearTopicPermissionsCommand do
 
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/clear_vhost_limits_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_vhost_limits_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ClearVhostLimitsCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/decode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/decode_command.ex
@@ -13,7 +13,7 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+alias RabbitMQ.CLI.Core.Helpers
 
 defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/ctl/commands/delete_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/delete_user_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.DeleteUserCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/delete_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/delete_vhost_command.ex
@@ -15,19 +15,19 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.DeleteVhostCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
   def merge_defaults(args, opts), do: {args, opts}
-  
+
   def validate([], _), do: {:validation_failure, :not_enough_args}
   def validate([_|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
   def validate([_], _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-  
+
   def run([arg], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :delete, [arg, Helpers.cli_acting_user()])
   end
@@ -36,4 +36,3 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteVhostCommand do
 
   def banner([arg], _), do: "Deleting vhost \"#{arg}\" ..."
 end
-

--- a/lib/rabbitmq/cli/ctl/commands/encode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/encode_command.ex
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
@@ -13,7 +13,7 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.Config, as: Config
+alias RabbitMQ.CLI.Core.Config
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ForceBootCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
@@ -14,8 +14,7 @@
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
-  alias RabbitMQ.CLI.Core.Validators, as: Validators
-  alias RabbitMQ.CLI.Core.Distribution, as: Distribution
+  alias RabbitMQ.CLI.Core.{Distribution, Validators}
   import Rabbitmq.Atom.Coerce
 
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -16,9 +16,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
 
-  alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
-  alias RabbitMQ.CLI.Core.ExitCodes,      as: ExitCodes
-  alias RabbitMQ.CLI.Core.Config,         as: Config
+  alias RabbitMQ.CLI.Core.{CommandModules, Config, ExitCodes}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 

--- a/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
@@ -14,7 +14,7 @@
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.HipeCompileCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 

--- a/lib/rabbitmq/cli/ctl/commands/list_bindings_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_bindings_command.ex
@@ -15,8 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ListBindingsCommand do
-  alias RabbitMQ.CLI.Ctl.InfoKeys, as: InfoKeys
-  alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
+  alias RabbitMQ.CLI.Ctl.{InfoKeys, RpcStream}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/list_channels_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_channels_command.ex
@@ -16,9 +16,8 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ListChannelsCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
-  alias RabbitMQ.CLI.Ctl.InfoKeys, as: InfoKeys
+  alias RabbitMQ.CLI.Core.Helpers
+  alias RabbitMQ.CLI.Ctl.{InfoKeys, RpcStream}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
@@ -15,9 +15,8 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ListConnectionsCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Ctl.InfoKeys, as: InfoKeys
-  alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
+  alias RabbitMQ.CLI.Core.Helpers
+  alias RabbitMQ.CLI.Ctl.{InfoKeys, RpcStream}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
@@ -15,9 +15,8 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Ctl.InfoKeys, as: InfoKeys
-  alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
+  alias RabbitMQ.CLI.Core.Helpers
+  alias RabbitMQ.CLI.Ctl.{InfoKeys, RpcStream}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/list_exchanges_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_exchanges_command.ex
@@ -15,8 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ListExchangesCommand do
-  alias RabbitMQ.CLI.Ctl.InfoKeys, as: InfoKeys
-  alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
+  alias RabbitMQ.CLI.Ctl.{InfoKeys, RpcStream}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
@@ -18,9 +18,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
   require RabbitMQ.CLI.Ctl.InfoKeys
   require RabbitMQ.CLI.Ctl.RpcStream
 
-  alias RabbitMQ.CLI.Ctl.InfoKeys, as: InfoKeys
-  alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Ctl.{InfoKeys, RpcStream}
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/list_unresponsive_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_unresponsive_queues_command.ex
@@ -18,9 +18,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUnresponsiveQueuesCommand do
   require RabbitMQ.CLI.Ctl.InfoKeys
   require RabbitMQ.CLI.Ctl.RpcStream
 
-  alias RabbitMQ.CLI.Ctl.InfoKeys, as: InfoKeys
-  alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Ctl.{InfoKeys, RpcStream}
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostsCommand do
-  alias RabbitMQ.CLI.Ctl.InfoKeys, as: InfoKeys
+  alias RabbitMQ.CLI.Ctl.InfoKeys
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
@@ -16,7 +16,7 @@
 require Integer
 
 defmodule RabbitMQ.CLI.Ctl.Commands.RenameClusterNodeCommand do
-  alias RabbitMQ.CLI.Core.Validators, as: Validators
+  alias RabbitMQ.CLI.Core.Validators
   import Rabbitmq.Atom.Coerce
 
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/ctl/commands/report_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/report_command.ex
@@ -15,17 +15,10 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
-  alias RabbitMQ.CLI.Ctl.Commands.StatusCommand,          as: StatusCommand
-  alias RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand,   as: ClusterStatusCommand
-  alias RabbitMQ.CLI.Ctl.Commands.EnvironmentCommand,     as: EnvironmentCommand
-  alias RabbitMQ.CLI.Ctl.Commands.ListConnectionsCommand, as: ListConnectionsCommand
-  alias RabbitMQ.CLI.Ctl.Commands.ListChannelsCommand,    as: ListChannelsCommand
-  alias RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand,      as: ListQueuesCommand
-  alias RabbitMQ.CLI.Ctl.Commands.ListExchangesCommand,   as: ListExchangesCommand
-  alias RabbitMQ.CLI.Ctl.Commands.ListBindingsCommand,    as: ListBindingsCommand
-  alias RabbitMQ.CLI.Ctl.Commands.ListPermissionsCommand, as: ListPermissionsCommand
-  alias RabbitMQ.CLI.Ctl.Commands.ListPoliciesCommand,    as: ListPoliciesCommand
-  alias RabbitMQ.CLI.Ctl.Commands.ListParametersCommand,  as: ListParametersCommand
+  alias RabbitMQ.CLI.Ctl.Commands.{ClusterStatusCommand, EnvironmentCommand,
+    ListBindingsCommand, ListChannelsCommand, ListConnectionsCommand,
+    ListExchangesCommand, ListParametersCommand, ListPermissionsCommand,
+    ListPoliciesCommand, ListQueuesCommand, StatusCommand}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/report_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/report_command.ex
@@ -24,6 +24,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
   alias RabbitMQ.CLI.Ctl.Commands.ListExchangesCommand,   as: ListExchangesCommand
   alias RabbitMQ.CLI.Ctl.Commands.ListBindingsCommand,    as: ListBindingsCommand
   alias RabbitMQ.CLI.Ctl.Commands.ListPermissionsCommand, as: ListPermissionsCommand
+  alias RabbitMQ.CLI.Ctl.Commands.ListPoliciesCommand,    as: ListPoliciesCommand
+  alias RabbitMQ.CLI.Ctl.Commands.ListParametersCommand,  as: ListParametersCommand
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
@@ -64,7 +66,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
               [run_command(ListQueuesCommand, info_keys(ListQueuesCommand), opts),
                run_command(ListExchangesCommand, info_keys(ListExchangesCommand), opts),
                run_command(ListBindingsCommand, info_keys(ListBindingsCommand), opts),
-               run_command(ListPermissionsCommand, [], opts)]
+               run_command(ListPermissionsCommand, [], opts),
+               run_command(ListPoliciesCommand, [], opts),
+               run_command(ListParametersCommand, [], opts)]
             end)
         data ++ vhost_data
     end

--- a/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
@@ -13,7 +13,7 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
+alias RabbitMQ.CLI.Core.ExitCodes
 
 defmodule RabbitMQ.CLI.Ctl.Commands.RestartVhostCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/ctl/commands/set_cluster_name_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_cluster_name_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetClusterNameCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/set_disk_free_limit_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_disk_free_limit_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetDiskFreeLimitCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/set_global_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_global_parameter_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetGlobalParameterCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/set_operator_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_operator_policy_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetOperatorPolicyCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetParameterCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetPermissionsCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
@@ -38,7 +38,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPermissionsCommand do
   def validate(_, _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-  
+
   def run([user, conf, write, read], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_auth_backend_internal,

--- a/lib/rabbitmq/cli/ctl/commands/set_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_policy_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetPolicyCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/set_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_topic_permissions_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetTopicPermissionsCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetUserTagsCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
@@ -26,7 +26,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetUserTagsCommand do
   def validate(_, _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-  
+
   def run([user | tags], %{node: node_name}) do
     :rabbit_misc.rpc_call(node_name,
       :rabbit_auth_backend_internal,

--- a/lib/rabbitmq/cli/ctl/commands/set_vhost_limits_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_vhost_limits_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetVhostLimitsCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
@@ -35,7 +35,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetVhostLimitsCommand do
   def validate(_, _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-  
+
   def run([definition], %{node: node_name, vhost: vhost}) do
     :rabbit_misc.rpc_call(node_name,
                           :rabbit_vhost_limit, :parse_set, [vhost, definition, Helpers.cli_acting_user()])

--- a/lib/rabbitmq/cli/ctl/commands/set_vm_memory_high_watermark_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_vm_memory_high_watermark_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.SetVmMemoryHighWatermarkCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
@@ -68,7 +68,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetVmMemoryHighWatermarkCommand do
   def validate(_, _), do: :ok
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-  
+
   def run(["absolute", arg], opts) do
     case Integer.parse(arg) do
       {num, rest}   ->  valid_units = rest in Helpers.memory_units

--- a/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
@@ -17,7 +17,7 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.ShutdownCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
-  alias RabbitMQ.CLI.Core.OsPid, as: OsPid
+  alias RabbitMQ.CLI.Core.OsPid
 
   def formatter(), do: RabbitMQ.CLI.Formatters.String
 

--- a/lib/rabbitmq/cli/ctl/commands/stop_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/stop_command.ex
@@ -17,7 +17,7 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.StopCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
-  alias RabbitMQ.CLI.Core.OsPid, as: OsPid
+  alias RabbitMQ.CLI.Core.OsPid
 
   def merge_defaults(args, opts), do: {args, opts}
 

--- a/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.UpdateClusterNodesCommand do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 

--- a/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -14,8 +14,7 @@
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
-  alias RabbitMQ.CLI.Core.Validators, as: Validators
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.{Helpers, Validators}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
   @default_timeout 10_000

--- a/lib/rabbitmq/cli/ctl/rpc_stream.ex
+++ b/lib/rabbitmq/cli/ctl/rpc_stream.ex
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.RpcStream do
-  alias RabbitMQ.CLI.Ctl.InfoKeys, as: InfoKeys
+  alias RabbitMQ.CLI.Ctl.InfoKeys
 
   def receive_list_items(node, mod, fun, args, timeout, info_keys) do
     receive_list_items(node, [{mod, fun, args}], timeout, info_keys, 1)

--- a/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -53,7 +53,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
   end
 
   defmodule Formatter do
-    alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
+    alias RabbitMQ.CLI.Formatters.FormatterHelpers
     alias RabbitMQ.CLI.InformationUnit, as: IU
 
     @behaviour RabbitMQ.CLI.FormatterBehaviour

--- a/lib/rabbitmq/cli/formatters/csv.ex
+++ b/lib/rabbitmq/cli/formatters/csv.ex
@@ -13,7 +13,7 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
+alias RabbitMQ.CLI.Formatters.FormatterHelpers
 
 defmodule RabbitMQ.CLI.Formatters.Csv do
 
@@ -117,4 +117,3 @@ defimpl CSV.Encode, for: Map do
     |> CSV.Encode.encode(env)
   end
 end
-

--- a/lib/rabbitmq/cli/formatters/inspect.ex
+++ b/lib/rabbitmq/cli/formatters/inspect.ex
@@ -12,7 +12,7 @@
 ##
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
-alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
+alias RabbitMQ.CLI.Formatters.FormatterHelpers
 
 defmodule RabbitMQ.CLI.Formatters.Inspect do
   @behaviour RabbitMQ.CLI.FormatterBehaviour

--- a/lib/rabbitmq/cli/formatters/json.ex
+++ b/lib/rabbitmq/cli/formatters/json.ex
@@ -17,7 +17,7 @@
 # collection using start/finish_collection.
 # Primary purpose is to translate stream from CTL,
 # so there is no need for multiple collection levels
-alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
+alias RabbitMQ.CLI.Formatters.FormatterHelpers
 
 defmodule RabbitMQ.CLI.Formatters.Json do
   @behaviour RabbitMQ.CLI.FormatterBehaviour

--- a/lib/rabbitmq/cli/formatters/plugins.ex
+++ b/lib/rabbitmq/cli/formatters/plugins.ex
@@ -12,7 +12,7 @@
 ##
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
-alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
+alias RabbitMQ.CLI.Formatters.FormatterHelpers
 
 defmodule RabbitMQ.CLI.Formatters.Plugins do
   @behaviour RabbitMQ.CLI.FormatterBehaviour

--- a/lib/rabbitmq/cli/formatters/report.ex
+++ b/lib/rabbitmq/cli/formatters/report.ex
@@ -13,8 +13,8 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
-alias RabbitMQ.CLI.Core.Output, as: Output
+alias RabbitMQ.CLI.Formatters.FormatterHelpers
+alias RabbitMQ.CLI.Core.Output
 
 defmodule RabbitMQ.CLI.Formatters.Report do
   @behaviour RabbitMQ.CLI.FormatterBehaviour

--- a/lib/rabbitmq/cli/formatters/string.ex
+++ b/lib/rabbitmq/cli/formatters/string.ex
@@ -15,8 +15,8 @@
 
 ## Prints values from a command as strings(if possible)
 defmodule RabbitMQ.CLI.Formatters.String do
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
+  alias RabbitMQ.CLI.Core.Helpers
+  alias RabbitMQ.CLI.Formatters.FormatterHelpers
 
   @behaviour RabbitMQ.CLI.FormatterBehaviour
 

--- a/lib/rabbitmq/cli/formatters/table.ex
+++ b/lib/rabbitmq/cli/formatters/table.ex
@@ -13,7 +13,7 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Formatters.FormatterHelpers, as: FormatterHelpers
+alias RabbitMQ.CLI.Formatters.FormatterHelpers
 
 defmodule RabbitMQ.CLI.Formatters.Table do
 

--- a/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -16,8 +16,7 @@
 
 defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Core.Validators, as: Validators
+  alias RabbitMQ.CLI.Core.{Helpers, Validators}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -16,8 +16,7 @@
 
 defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Core.Validators, as: Validators
+  alias RabbitMQ.CLI.Core.{Helpers, Validators}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 

--- a/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -17,8 +17,7 @@
 defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
   import RabbitCommon.Records
 
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Core.Validators, as: Validators
+  alias RabbitMQ.CLI.Core.{Helpers, Validators}
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
 
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/plugins/commands/set_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/set_command.ex
@@ -16,9 +16,7 @@
 
 defmodule RabbitMQ.CLI.Plugins.Commands.SetCommand do
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Core.Validators, as: Validators
-  alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
+  alias RabbitMQ.CLI.Core.{ExitCodes, Helpers, Validators}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 

--- a/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -13,8 +13,7 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 alias RabbitMQ.CLI.Core.Helpers, as: CliHelpers
-alias RabbitMQ.CLI.Core.Config, as: Config
-alias RabbitMQ.CLI.Core.Validators, as: Validators
+alias RabbitMQ.CLI.Core.{Config, Validators}
 
 defmodule RabbitMQ.CLI.Plugins.Helpers do
   import Rabbitmq.Atom.Coerce

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -15,16 +15,9 @@
 
 
 defmodule RabbitMQCtl do
-  alias RabbitMQ.CLI.Core.Distribution,  as: Distribution
+  alias RabbitMQ.CLI.Core.{CommandModules, Distribution, ExitCodes, Helpers, Output, Parser}
+  alias RabbitMQ.CLI.Ctl.Commands.HelpCommand
 
-  alias RabbitMQ.CLI.Ctl.Commands.HelpCommand, as: HelpCommand
-  alias RabbitMQ.CLI.Core.Output, as: Output
-  alias RabbitMQ.CLI.Core.ExitCodes, as: ExitCodes
-
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
-  alias RabbitMQ.CLI.Core.Parser, as: Parser
-
-  alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
 
   # Enable unit tests for private functions
   @compile if Mix.env == :test, do: :export_all

--- a/test/close_all_connections_command_test.exs
+++ b/test/close_all_connections_command_test.exs
@@ -18,7 +18,7 @@ defmodule CloseAllConnectionsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
+  alias RabbitMQ.CLI.Ctl.RpcStream
 
   @helpers RabbitMQ.CLI.Core.Helpers
 

--- a/test/close_connection_command_test.exs
+++ b/test/close_connection_command_test.exs
@@ -18,7 +18,7 @@ defmodule CloseConnectionCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
+  alias RabbitMQ.CLI.Ctl.RpcStream
 
   @helpers RabbitMQ.CLI.Core.Helpers
 

--- a/test/distribution_test.exs
+++ b/test/distribution_test.exs
@@ -13,7 +13,7 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Core.Distribution, as: Distribution
+alias RabbitMQ.CLI.Core.Distribution
 
 defmodule DistributionTest do
   use ExUnit.Case, async: false

--- a/test/help_command_test.exs
+++ b/test/help_command_test.exs
@@ -18,8 +18,7 @@ defmodule HelpCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
-  alias RabbitMQ.CLI.Core.ExitCodes,   as: ExitCodes
+  alias RabbitMQ.CLI.Core.{CommandModules, ExitCodes}
 
   @command RabbitMQ.CLI.Ctl.Commands.HelpCommand
 

--- a/test/rpc_stream_test.exs
+++ b/test/rpc_stream_test.exs
@@ -2,7 +2,7 @@ defmodule RpcStreamTest do
   use ExUnit.Case, async: false
 
   require RabbitMQ.CLI.Ctl.RpcStream
-  alias RabbitMQ.CLI.Ctl.RpcStream, as: RpcStream
+  alias RabbitMQ.CLI.Ctl.RpcStream
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()

--- a/test/set_vm_memory_high_watermark_command_test.exs
+++ b/test/set_vm_memory_high_watermark_command_test.exs
@@ -17,7 +17,7 @@ defmodule SetVmMemoryHighWatermarkCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.Helpers
 
   @command RabbitMQ.CLI.Ctl.Commands.SetVmMemoryHighWatermarkCommand
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -19,9 +19,7 @@ ExUnit.start()
 defmodule TestHelper do
   import ExUnit.Assertions
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
-  alias RabbitMQ.CLI.Core.Config, as: Config
-  alias RabbitMQ.CLI.Core.CommandModules, as: CommandModules
-  alias RabbitMQ.CLI.Core.Helpers, as: Helpers
+  alias RabbitMQ.CLI.Core.{CommandModules, Config, Helpers}
 
   def get_rabbit_hostname() do
     RabbitMQ.CLI.Core.Helpers.get_rabbit_hostname()


### PR DESCRIPTION
Policies and parameters have always been part of the `report` command in prior major releases.
We still need them in captured `3.7.x` reports.

(Side note, elixir aliases fall to last part of trailing module name, without need for `as:`. Just left this for consistency with entire CLI implementation, although unnecessary).