### PR TITLE
Require Elixir 1.6.6+, adding support for Elixir 1.7.x at the same time

### DIFF
--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -141,7 +141,12 @@ defmodule RabbitMQ.CLI.Core.Parser do
     switches = default_switches()
     aliases = default_aliases()
     {options, tail, invalid} =
-      OptionParser.parse_head(input, strict: switches, aliases: aliases)
+      OptionParser.parse_head(
+        input,
+        strict: switches,
+        aliases: aliases,
+        allow_nonexistent_atoms: true,
+      )
     norm_options = normalize_options(options, switches) |> Map.new
     {norm_options, tail, invalid}
   end
@@ -156,7 +161,8 @@ defmodule RabbitMQ.CLI.Core.Parser do
     {options, args, invalid} = OptionParser.parse(
       input,
       strict: switches,
-      aliases: aliases
+      aliases: aliases,
+      allow_nonexistent_atoms: true,
     )
     norm_options = normalize_options(options, switches) |> Map.new
     {args, norm_options, invalid}

--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,7 @@ defmodule RabbitMQCtl.MixfileBase do
     [
       app: :rabbitmqctl,
       version: "3.8.0-dev",
-      elixir: "~> 1.6.0",
+      elixir: ">= 1.6.6 and < 1.8.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       escript: [main_module: RabbitMQCtl,


### PR DESCRIPTION
Elixir 1.6.6 is the first version to support Erlang 21.0. Bumping the minimum to this version eases packaging: packagers don't have to think about Erlang/Elixir combinations which work.

The upper limit is set to 1.8.0 (not included) because 1.7.x should work fine. However, 1.8.0 will probably drop Erlang 19.x support, at which point we should review this version pinning.

[#159500280]