### PR TITLE
New command: rabbitmq-plugins directories

### DIFF
--- a/lib/rabbitmq/cli/core/config.ex
+++ b/lib/rabbitmq/cli/core/config.ex
@@ -36,24 +36,28 @@ defmodule RabbitMQ.CLI.Core.Config do
   def normalize(:longnames, _val),       do: :shortnames
   def normalize(_, value),           do: value
 
-  def get_system_option(:script_name) do
-    Path.basename(:escript.script_name())
-    |> Path.rootname
-    |> String.to_atom
-  end
-  def get_system_option(name) do
-    system_env_option = case name do
+  def system_env_variable(name) do
+    case name do
       :longnames            -> "RABBITMQ_USE_LONGNAME";
       :rabbitmq_home        -> "RABBITMQ_HOME";
       :mnesia_dir           -> "RABBITMQ_MNESIA_DIR";
       :plugins_dir          -> "RABBITMQ_PLUGINS_DIR";
+      :plugins_expand_dir   -> "RABBITMQ_PLUGINS_EXPAND_DIR";
       :enabled_plugins_file -> "RABBITMQ_ENABLED_PLUGINS_FILE";
       :node                 -> "RABBITMQ_NODENAME";
       :aliases_file         -> "RABBITMQ_CLI_ALIASES_FILE";
       :erlang_cookie        -> "RABBITMQ_ERLANG_COOKIE";
       _ -> ""
     end
-    System.get_env(system_env_option)
+  end
+
+  def get_system_option(:script_name) do
+    Path.basename(:escript.script_name())
+    |> Path.rootname
+    |> String.to_atom
+  end
+  def get_system_option(name) do
+    System.get_env(system_env_variable(name))
   end
 
   def default(:script_name), do: :rabbitmqctl

--- a/lib/rabbitmq/cli/plugins/commands/directories_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/directories_command.ex
@@ -61,7 +61,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
   def usage, do: "directories [--offline] [--online]"
 
   def banner([], %{online: false, offline: true}) do
-    "Listing plugin directories..."
+    "Listing plugin directories inferred from environment..."
   end
 
   def banner([], %{online: true, offline: false, node: node}) do

--- a/lib/rabbitmq/cli/plugins/commands/directories_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/directories_command.ex
@@ -16,7 +16,7 @@
 
 defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
   alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
-  alias RabbitMQ.CLI.Core.{Helpers, Validators}
+  alias RabbitMQ.CLI.Core.{Helpers, Validators, Config}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -73,9 +73,9 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
       :rabbit_misc.rpc_call(node_name, :rabbit_plugins, key, [])
     end
   end
-  def run([], %{offline: true}) do
+  def run([], %{offline: true} = opts) do
     do_run fn(key) ->
-      apply(:rabbit_plugins, key, [])
+      Config.get_option(key, opts)
     end
   end
 
@@ -100,7 +100,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
 
   defp do_run(fun) do
     # return an error or an {:ok, map} tuple
-    Enum.reduce([:plugins_dist_dir, :plugins_expand_dir, :enabled_plugins_file], {:ok, %{}},
+    Enum.reduce([:plugins_dir, :plugins_expand_dir, :enabled_plugins_file], {:ok, %{}},
                 fn _,   {:error, err} -> {:error, err}
                    key, {:ok, acc}    ->
                     case fun.(key) do

--- a/lib/rabbitmq/cli/plugins/commands/directories_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/directories_command.ex
@@ -85,7 +85,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
 
   def output({:ok, map}, _opts) do
     s = """
-        Plugin archives directory: #{Map.get(map, :plugins_dist_dir)}
+        Plugin archives directory: #{Map.get(map, :plugins_dir)}
         Plugin expansion directory: #{Map.get(map, :plugins_expand_dir)}
         Enabled plugins file: #{Map.get(map, :enabled_plugins_file)}
         """

--- a/lib/rabbitmq/cli/plugins/commands/directories_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/directories_command.ex
@@ -22,6 +22,9 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.String
 
+  def merge_defaults(args, %{offline: true} = opts) do
+    {args, opts}
+  end
   def merge_defaults(args, opts) do
     {args, Map.merge(%{online: true, offline: false}, opts)}
   end
@@ -51,20 +54,17 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
                       &Helpers.plugins_dir/2],
                      [args, opts])
   end
-  def validate_execution_environment(args, %{offline: false} = opts) do
-    Validators.node_is_running(args, opts)
-  end
   def validate_execution_environment(args, %{online: true} = opts) do
     Validators.node_is_running(args, opts)
   end
 
   def usage, do: "directories [--offline] [--online]"
 
-  def banner([], %{online: false, offline: true}) do
+  def banner([], %{offline: true}) do
     "Listing plugin directories inferred from local environment..."
   end
 
-  def banner([], %{online: true, offline: false, node: node}) do
+  def banner([], %{online: true, node: node}) do
     "Listing plugin directories used by node #{node}"
   end
 
@@ -73,13 +73,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
       :rabbit_misc.rpc_call(node_name, :rabbit_plugins, key, [])
     end
   end
-
-  def run([], %{offline: false, node: node_name}) do
-    do_run fn(key) ->
-      :rabbit_misc.rpc_call(node_name, :rabbit_plugins, key, [])
-    end
-  end
-
   def run([], %{offline: true}) do
     do_run fn(key) ->
       apply(:rabbit_plugins, key, [])

--- a/lib/rabbitmq/cli/plugins/commands/directories_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/directories_command.ex
@@ -1,0 +1,119 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is Pivotal Software, Inc.
+## Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
+  alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
+  alias RabbitMQ.CLI.Core.{Helpers, Validators}
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.String
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{online: true, offline: false}, opts)}
+  end
+
+  def distribution(%{offline: true}),  do: :none
+  def distribution(%{offline: false}), do: :cli
+
+  def switches(), do: [online: :boolean,
+                       offline: :boolean]
+
+  def validate(_, %{online: true, offline: true}) do
+   {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}
+  end
+  def validate(_, %{online: false, offline: false}) do
+   {:validation_failure, {:bad_argument, "Cannot set online and offline to false"}}
+  end
+  def validate([_ | _], _) do
+    {:validation_failure, :too_many_args}
+  end
+  def validate([], _) do
+    :ok
+  end
+
+  def validate_execution_environment(args, %{offline: true} = opts) do
+    Validators.chain([&Helpers.require_rabbit_and_plugins/2,
+                      &PluginHelpers.enabled_plugins_file/2,
+                      &Helpers.plugins_dir/2],
+                     [args, opts])
+  end
+  def validate_execution_environment(args, %{offline: false} = opts) do
+    Validators.node_is_running(args, opts)
+  end
+  def validate_execution_environment(args, %{online: true} = opts) do
+    Validators.node_is_running(args, opts)
+  end
+
+  def usage, do: "directories [--offline] [--online]"
+
+  def banner([], %{online: false, offline: true}) do
+    "Listing plugin directories..."
+  end
+
+  def banner([], %{online: true, offline: false, node: node}) do
+    "Listing plugin directories used by node #{node}"
+  end
+
+  def run([], %{online: true, node: node_name}) do
+    do_run fn(key) ->
+      :rabbit_misc.rpc_call(node_name, :rabbit_plugins, key, [])
+    end
+  end
+
+  def run([], %{offline: false, node: node_name}) do
+    do_run fn(key) ->
+      :rabbit_misc.rpc_call(node_name, :rabbit_plugins, key, [])
+    end
+  end
+
+  def run([], %{offline: true}) do
+    do_run fn(key) ->
+      apply(:rabbit_plugins, key, [])
+    end
+  end
+
+  def output({:ok, _map} = res, %{formatter: "json"}) do
+    res
+  end
+
+  def output({:ok, map}, _opts) do
+    s = """
+        Plugin archives directory: #{Map.get(map, :plugins_dist_dir)}
+        Plugin expansion directory: #{Map.get(map, :plugins_expand_dir)}
+        Enabled plugins file: #{Map.get(map, :enabled_plugins_file)}
+        """
+    {:ok, String.trim_trailing(s)}
+  end
+
+  def output({:error, err}, _opts) do
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software, err}
+  end
+  use RabbitMQ.CLI.DefaultOutput
+
+
+  defp do_run(fun) do
+    # return an error or an {:ok, map} tuple
+    Enum.reduce([:plugins_dist_dir, :plugins_expand_dir, :enabled_plugins_file], {:ok, %{}},
+                fn _,   {:error, err} -> {:error, err}
+                   key, {:ok, acc}    ->
+                    case fun.(key) do
+                      {:error, err} -> {:error, err}
+                      val           -> {:ok, Map.put(acc, key, :rabbit_data_coercion.to_binary(val))}
+                    end
+                end)
+  end
+end

--- a/lib/rabbitmq/cli/plugins/commands/directories_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/directories_command.ex
@@ -61,7 +61,7 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
   def usage, do: "directories [--offline] [--online]"
 
   def banner([], %{online: false, offline: true}) do
-    "Listing plugin directories inferred from environment..."
+    "Listing plugin directories inferred from local environment..."
   end
 
   def banner([], %{online: true, offline: false, node: node}) do

--- a/test/plugins/directories_command_test.exs
+++ b/test/plugins/directories_command_test.exs
@@ -1,0 +1,130 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+
+defmodule DirectoriesCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+    node = get_rabbit_hostname()
+
+    {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
+                                                :application, :get_env,
+                                                [:rabbit, :enabled_plugins_file])
+    {:ok, plugins_dir} = :rabbit_misc.rpc_call(node,
+                                               :application, :get_env,
+                                               [:rabbit, :plugins_dir])
+    {:ok, plugins_expand_dir} = :rabbit_misc.rpc_call(node,
+                                               :application, :get_env,
+                                               [:rabbit, :plugins_expand_dir])
+
+    rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
+
+    {:ok, opts: %{
+        plugins_file: plugins_file,
+        plugins_dir: plugins_dir,
+        plugins_expand_dir: plugins_expand_dir,
+        rabbitmq_home: rabbitmq_home,
+     }}
+  end
+
+  setup context do
+    {
+      :ok,
+      opts: Map.merge(context[:opts], %{
+              node: get_rabbit_hostname(),
+              timeout: 1000
+            })
+    }
+  end
+
+  test "validate: providing no arguments passes validation", context do
+    assert @command.validate([], context[:opts]) == :ok
+  end
+
+  test "validate: providing --online passes validation", context do
+    assert @command.validate([], Map.merge(%{online: true}, context[:opts])) == :ok
+  end
+
+  test "validate: providing --offline passes validation", context do
+    assert @command.validate([], Map.merge(%{offline: true}, context[:opts])) == :ok
+  end
+
+  test "validate: providing any arguments fails validation", context do
+    assert @command.validate(["a", "b", "c"], context[:opts]) ==
+      {:validation_failure, :too_many_args}
+  end
+
+  test "validate: setting both --online and --offline to false fails validation", context do
+    assert @command.validate([], Map.merge(context[:opts], %{online: false, offline: false})) ==
+      {:validation_failure, {:bad_argument, "Cannot set online and offline to false"}}
+  end
+
+  test "validate: setting both --online and --offline to true fails validation", context do
+    assert @command.validate([], Map.merge(context[:opts], %{online: true, offline: true})) ==
+      {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}
+  end
+
+  test "validate_execution_environment: when --offline is used, not specifying an enabled_plugins_file fails validation", context do
+    opts = context[:opts] |> Map.merge(%{offline: true}) |> Map.delete(:enabled_plugins_file)
+    assert @command.validate_execution_environment([], opts) == {:validation_failure, :no_plugins_file}
+  end
+
+  test "validate_execution_environment: when --offline is used, not specifying a plugins_dir fails validation", context do
+    opts = context[:opts] |> Map.merge(%{offline: true}) |> Map.delete(:plugins_dir)
+    assert @command.validate_execution_environment([], opts) == {:validation_failure, :no_plugins_dir}
+  end
+
+  test "validate_execution_environment: when --offline is used, specifying a non-existent enabled_plugins_file passes validation", context do
+    opts = context[:opts] |> Map.merge(%{offline: true, enabled_plugins_file: "none"})
+    assert @command.validate_execution_environment([], opts) == :ok
+  end
+
+  test "validate_execution_environment: when --offline is used, specifying a non-existent plugins_dir fails validation", context do
+    opts = context[:opts] |> Map.merge(%{offline: true, plugins_dir: "none"})
+    assert @command.validate_execution_environment([], opts) == {:validation_failure, :plugins_dir_does_not_exist}
+  end
+
+  test "validate_execution_environment: when --online is used, not specifying an enabled_plugins_file passes validation", context do
+    opts = context[:opts] |> Map.merge(%{online: true}) |> Map.delete(:enabled_plugins_file)
+    assert @command.validate_execution_environment([], opts) == :ok
+  end
+
+  test "validate_execution_environment: when --online is used, not specifying a plugins_dir passes validation", context do
+    opts = context[:opts] |> Map.merge(%{online: true}) |> Map.delete(:plugins_dir)
+    assert @command.validate_execution_environment([], opts) == :ok
+  end
+
+  test "validate_execution_environment: when --online is used, specifying a non-existent enabled_plugins_file passes validation", context do
+    opts = context[:opts] |> Map.merge(%{online: true, enabled_plugins_file: "none"})
+    assert @command.validate_execution_environment([], opts) == :ok
+  end
+
+  test "validate_execution_environment: when --online is used, specifying a non-existent plugins_dir passes validation", context do
+    opts = context[:opts] |> Map.merge(%{online: true, plugins_dir: "none"})
+    assert @command.validate_execution_environment([], opts) == :ok
+  end
+
+
+  test "run: when --online is used, lists plugin directories", context do
+    opts = Map.merge(context[:opts], %{online: true})
+    assert @command.run([], opts) == {:ok, %{plugins_dist_dir: to_string(Map.get(opts, :plugins_dir)),
+                                             plugins_expand_dir: to_string(Map.get(opts, :plugins_expand_dir)),
+                                             enabled_plugins_file: to_string(Map.get(opts, :plugins_file))}}
+  end
+end

--- a/test/plugins/directories_command_test.exs
+++ b/test/plugins/directories_command_test.exs
@@ -123,8 +123,10 @@ defmodule DirectoriesCommandTest do
 
   test "run: when --online is used, lists plugin directories", context do
     opts = Map.merge(context[:opts], %{online: true})
-    assert @command.run([], opts) == {:ok, %{plugins_dist_dir: to_string(Map.get(opts, :plugins_dir)),
-                                             plugins_expand_dir: to_string(Map.get(opts, :plugins_expand_dir)),
-                                             enabled_plugins_file: to_string(Map.get(opts, :plugins_file))}}
+    dirs = %{plugins_dir: to_string(Map.get(opts, :plugins_dir)),
+             plugins_expand_dir: to_string(Map.get(opts, :plugins_expand_dir)),
+             enabled_plugins_file: to_string(Map.get(opts, :plugins_file))}
+
+    assert @command.run([], opts) == {:ok, dirs}
   end
 end

--- a/test/plugins/disable_plugins_command_test.exs
+++ b/test/plugins/disable_plugins_command_test.exs
@@ -86,7 +86,6 @@ defmodule DisablePluginsCommandTest do
       {:validation_failure, :no_plugins_dir}
   end
 
-
   test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
   end

--- a/test/plugins/list_plugins_command_test.exs
+++ b/test/plugins/list_plugins_command_test.exs
@@ -54,10 +54,7 @@ defmodule ListPluginsCommandTest do
   end
 
   setup context do
-
     reset_enabled_plugins_to_preconfigured_defaults(context)
-
-
 
     {
       :ok,


### PR DESCRIPTION
This introduces a new command, `rabbitmq-plugins directories`, which displays plugin directories and enabled plugins file path.

Closes #261.

[#160792758]