### PR TITLE
Add headers to the table formatter.

### DIFF
--- a/test/table_formatter_test.exs
+++ b/test/table_formatter_test.exs
@@ -20,16 +20,36 @@ defmodule TableFormatterTest do
   @formatter RabbitMQ.CLI.Formatters.Table
 
   test "format_output tab-separates map values" do
-    assert @formatter.format_output(%{a: :apple, b: :beer}, %{}) == "apple\tbeer"
-    assert @formatter.format_output(%{a: :apple, b: :beer, c: 1}, %{}) == "apple\tbeer\t1"
-    assert @formatter.format_output(%{a: "apple", b: 'beer', c: 1}, %{}) == "apple\t\"beer\"\t1"
+    assert @formatter.format_output(%{a: :apple, b: :beer}, %{}) == ["a\tb", "apple\tbeer"]
+    assert @formatter.format_output(%{a: :apple, b: :beer, c: 1}, %{}) == ["a\tb\tc", "apple\tbeer\t1"]
+    assert @formatter.format_output(%{a: "apple", b: 'beer', c: 1}, %{}) == ["a\tb\tc", "apple\t\"beer\"\t1"]
+  end
+
+  test "format_output tab-separates keyword values" do
+    assert @formatter.format_output([a: :apple, b: :beer], %{}) == ["a\tb", "apple\tbeer"]
+    assert @formatter.format_output([a: :apple, b: :beer, c: 1], %{}) == ["a\tb\tc", "apple\tbeer\t1"]
+    assert @formatter.format_output([a: "apple", b: 'beer', c: 1], %{}) == ["a\tb\tc", "apple\t\"beer\"\t1"]
+  end
+
+  test "format_stream tab-separates map values" do
+    assert @formatter.format_stream([%{a: :apple, b: :beer, c: 1},
+                                     %{a: "aadvark", b: 'bee', c: 2}], %{})
+           |> Enum.to_list ==
+           ["a\tb\tc", "apple\tbeer\t1", "aadvark\t\"bee\"\t2"]
+  end
+
+  test "format_stream tab-separates keyword values" do
+    assert @formatter.format_stream([[a: :apple, b: :beer, c: 1],
+                                     [a: "aadvark", b: 'bee', c: 2]], %{})
+           |> Enum.to_list ==
+           ["a\tb\tc", "apple\tbeer\t1", "aadvark\t\"bee\"\t2"]
   end
 
   test "format_output formats non-string values with inspect recursively" do
     assert @formatter.format_output(%{a: :apple, b: "beer", c: {:carp, "fish"}, d: [door: :way], e: %{elk: "horn", for: :you}}, %{}) ==
-        "apple\tbeer\t{carp, fish}\t[{door, way}]\t\#{elk => horn, for => you}"
+        ["a\tb\tc\td\te", "apple\tbeer\t{carp, fish}\t[{door, way}]\t\#{elk => horn, for => you}"]
 
     assert @formatter.format_output(%{a: :apple, b: "beer", c: {:carp, {:small, :fish}}, d: [door: {:way, "big"}], e: %{elk: [horn: :big]}}, %{}) ==
-        "apple\tbeer\t{carp, {small, fish}}\t[{door, {way, big}}]\t\#{elk => [{horn, big}]}"
+        ["a\tb\tc\td\te", "apple\tbeer\t{carp, {small, fish}}\t[{door, {way, big}}]\t\#{elk => [{horn, big}]}"]
   end
 end


### PR DESCRIPTION
There were headers in 3.6 CLI which were not implemented when moving
to the new one.

Fixes #264
[#161326468]