### PR TITLE
Output cipher suites one by one

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -41,5 +41,5 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
   def banner([], %{openssl_format: true}),  do: "Listing available cipher suites in the OpenSSL format"
   def banner([], %{openssl_format: false}), do: "Listing available cipher suites in the Erlang term format"
 
-  def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
+  def formatter(), do: RabbitMQ.CLI.Formatters.String
 end


### PR DESCRIPTION
This is more useful to the users of the new config format.

References rabbitmq/rabbitmq-server#1712.

[#160792113]