### PR TITLE
New diagnostics command: runtime_thread_stats

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/discover_peers_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/discover_peers_command.ex
@@ -25,7 +25,9 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.DiscoverPeersCommand do
   def validate([_|_], _) do
     {:validation_failure, :too_many_args}
   end
+
   def validate(_, _), do: :ok
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_peer_discovery, :discover_cluster_nodes, [], timeout)
@@ -48,6 +50,4 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.DiscoverPeersCommand do
   def usage, do: "discover_peers"
 
   def banner(_,_), do: "Discovering peers nodes ..."
-
-
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
@@ -27,6 +27,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MaybeStuckCommand do
     {:validation_failure, :too_many_args}
   end
   def validate(_, _), do: :ok
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_diagnostics, :maybe_stuck, [], timeout)

--- a/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -37,6 +37,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
         {:validation_failure, "unit '#{unit}' is not supported. Please use one of: bytes, mb, gb"}
     end
   end
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vm, :memory, [], timeout)

--- a/lib/rabbitmq/cli/diagnostics/commands/runtime_thread_stats.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/runtime_thread_stats.ex
@@ -1,0 +1,60 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.RuntimeThreadStatsCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def switches(), do: [sample_interval: :integer]
+  def aliases(), do: [i: :sample_interval]
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{sample_interval: 5}, opts)}
+  end
+
+  def validate(args, _) when length(args) > 0 do
+    {:validation_failure, :too_many_args}
+  end
+  def validate(_, _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, timeout: timeout, sample_interval: interval}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_runtime, :msacc_stats, [interval * 1000], timeout) do
+      {:ok, stats} -> stats;
+      other        -> other
+    end
+  end
+
+  def output(result, %{formatter: :json}) when is_list(result) do
+    {:error, "JSON formatter is not supported by this command"}
+  end
+
+  def output(result, %{formatter: :csv}) when is_list(result) do
+    {:error, "CSV formatter is not supported by this command"}
+  end
+
+  def output(result, _options) when is_list(result) do
+    {:ok, result}
+  end
+
+  def banner([], %{node: node_name, sample_interval: interval}) do
+    "Will collect runtime thread stats on #{node_name} for #{interval} seconds..."
+  end
+
+  def usage, do: "runtime_thread_stats [--sample-interval <interval>]"
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.Msacc
+end

--- a/lib/rabbitmq/cli/formatters/msacc.ex
+++ b/lib/rabbitmq/cli/formatters/msacc.ex
@@ -1,0 +1,28 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Formatters.Msacc do
+  @behaviour RabbitMQ.CLI.FormatterBehaviour
+
+  def format_output(output, _) do
+    {:ok, io} = StringIO.open("")
+    :msacc.print(io, output, %{})
+    StringIO.flush(io)
+  end
+
+  def format_stream(stream, options) do
+    [format_output(Enum.to_list(stream), options)]
+  end
+end

--- a/test/diagnostics/cipher_suites_command_test.exs
+++ b/test/diagnostics/cipher_suites_command_test.exs
@@ -23,7 +23,6 @@ defmodule CipherSuitesCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-
     :ok
   end
 


### PR DESCRIPTION
Uses Erlang's microstate accounting data to produce
high level thread state/activity breakdown.

Usage:

``` shell
# sample for 5 seconds
rabbitmq-diagnostics runtime_thread_stats -i 5
```

Per discussion with @gerhard.

Depends on https://github.com/rabbitmq/rabbitmq-common/pull/286.