### PR TITLE
Improve error message formatting for rabbitmq-plugins commands

### DIFF
--- a/lib/rabbitmq/cli/core/exit_codes.ex
+++ b/lib/rabbitmq/cli/core/exit_codes.ex
@@ -13,6 +13,11 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
+# Lists predefined error exit codes used by RabbitMQ CLI tools.
+# The codes are adopted from [1], which (according to our team's research)
+# is possibly the most standardized set of codes there is.
+#
+# 1. https://www.freebsd.org/cgi/man.cgi?query=sysexits&apropos=0&sektion=0&manpath=FreeBSD+12.0-RELEASE&arch=default&format=html
 defmodule RabbitMQ.CLI.Core.ExitCodes do
   @exit_ok 0
   @exit_usage 64

--- a/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -110,11 +110,5 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
     end
   end
 
-  def output({:error, err}, _opts) do
-    {:error, err}
-  end
-  def output({:stream, stream}, _opts) do
-    {:stream, stream}
-  end
-
+  use RabbitMQ.CLI.Plugins.ErrorOutput
 end

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -120,10 +120,5 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
     end
   end
 
-  def output({:error, err}, _opts) do
-    {:error, err}
-  end
-  def output({:stream, stream}, _opts) do
-    {:stream, stream}
-  end
+  use RabbitMQ.CLI.Plugins.ErrorOutput
 end

--- a/lib/rabbitmq/cli/plugins/commands/set_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/set_command.ex
@@ -102,13 +102,8 @@ defmodule RabbitMQ.CLI.Plugins.Commands.SetCommand do
   end
 
   def output({:error, {:plugins_not_found, missing}}, _opts) do
-    {:error, ExitCodes.exit_dataerr(), "The following plugins were not found: #{Enum.join(Enum.to_list(missing), ", ")}"}
+    {:error, ExitCodes.exit_dataerr(),
+     "The following plugins were not found: #{Enum.join(Enum.to_list(missing), ", ")}"}
   end
-  def output({:error, err}, _opts) do
-    {:error, ExitCodes.exit_software(), to_string(err)}
-  end
-  def output({:stream, stream}, _opts) do
-    {:stream, stream}
-  end
-
+  use RabbitMQ.CLI.Plugins.ErrorOutput
 end

--- a/lib/rabbitmq/cli/plugins/error_output.ex
+++ b/lib/rabbitmq/cli/plugins/error_output.ex
@@ -1,0 +1,58 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
+
+# Default output implementation for plugin commands
+defmodule RabbitMQ.CLI.Plugins.ErrorOutput do
+  alias RabbitMQ.CLI.Core.ExitCodes
+
+  defmacro __using__(_) do
+    quote do
+
+      def output({:error, {:enabled_plugins_mismatch, cli_path, node_path}}, opts) do
+        {:error, ExitCodes.exit_dataerr(),
+         "Could not update enabled plugins file at #{cli_path}: target node #{opts[:node]} uses a different path (#{node_path})"}
+      end
+
+      def output({:error, {:cannot_read_enabled_plugins_file, path, :eacces}}, _opts) do
+        {:error, ExitCodes.exit_dataerr(),
+         "Could not read enabled plugins file at #{path}: the file does not exist or permission was denied (EACCES)"}
+      end
+
+      def output({:error, {:cannot_read_enabled_plugins_file, path, :enoent}}, _opts) do
+        {:error, ExitCodes.exit_dataerr(),
+         "Could not read enabled plugins file at #{path}: the file does not exist (ENOENT)"}
+      end
+      
+      def output({:error, {:cannot_write_enabled_plugins_file, path, :eacces}}, _opts) do
+        {:error, ExitCodes.exit_dataerr(),
+         "Could not update enabled plugins file at #{path}: the file does not exist or permission was denied (EACCES)"}
+      end
+
+      def output({:error, {:cannot_write_enabled_plugins_file, path, :enoent}}, _opts) do
+        {:error, ExitCodes.exit_dataerr(),
+         "Could not update enabled plugins file at #{path}: the file does not exist (ENOENT)"}
+      end
+
+      def output({:error, err}, _opts) do
+        {:error, ExitCodes.exit_software(), err}
+      end
+
+      def output({:stream, stream}, _opts) do
+        {:stream, stream}
+      end
+
+    end # quote
+  end # defmacro
+end # defmodule

--- a/test/plugins/disable_plugins_command_test.exs
+++ b/test/plugins/disable_plugins_command_test.exs
@@ -11,11 +11,13 @@
 ## The Original Code is RabbitMQ.
 ##
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
-## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+## Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
 
 defmodule DisablePluginsCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
+
+  alias RabbitMQ.CLI.Core.ExitCodes
 
   @command RabbitMQ.CLI.Plugins.Commands.DisableCommand
 
@@ -185,4 +187,22 @@ defmodule DisablePluginsCommandTest do
     assert Enum.empty?(Enum.sort(:rabbit_misc.rpc_call(context[:opts][:node], :rabbit_plugins, :active, [])))
   end
 
+  test "formats enabled plugins mismatch errors", context do
+    err = {:enabled_plugins_mismatch, '/tmp/a/cli/path', '/tmp/a/server/path'}
+    assert {:error, ExitCodes.exit_dataerr(),
+            "Could not update enabled plugins file at /tmp/a/cli/path: target node #{context[:opts][:node]} uses a different path (/tmp/a/server/path)"}
+      == @command.output({:error, err}, context[:opts])
+  end
+
+  test "formats enabled plugins write errors", context do
+    err1 = {:cannot_write_enabled_plugins_file, "/tmp/a/path", :eacces}
+    assert {:error, ExitCodes.exit_dataerr(),
+            "Could not update enabled plugins file at /tmp/a/path: the file does not exist or permission was denied (EACCES)"} ==
+      @command.output({:error, err1}, context[:opts])
+
+    err2 = {:cannot_write_enabled_plugins_file, "/tmp/a/path", :enoent}
+    assert {:error, ExitCodes.exit_dataerr(),
+            "Could not update enabled plugins file at /tmp/a/path: the file does not exist (ENOENT)"} ==
+      @command.output({:error, err2}, context[:opts])
+  end
 end


### PR DESCRIPTION
There are two main types of errors that I see in practice:

 * Insufficient enabled plugins file permission (or the file does not exist)
 * Enabled plugins file used by CLI tools does not match that of
   the target node

So the test scenarios should use `RABBITMQ_ENABLED_PLUGINS_FILE` files:

 * Owned by `root` without group/world permissions
 * That do not exist
 * That are not readable or writable
 * That are different from those used by the target node (in online mode)

[#162757498]