### PR TITLE
Fix list_consumers command when querying cluster

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
@@ -53,7 +53,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
       Helpers.with_nodes_in_cluster(node_name, fn(nodes) ->
         RpcStream.receive_list_items(node_name,
           :rabbit_amqqueue, :emit_consumers_all,
-          [nodes, vhost], timeout, info_keys)
+          [nodes, vhost], timeout, info_keys, Kernel.length(nodes))
       end)
   end
 

--- a/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
@@ -13,7 +13,6 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
 
-
 defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
   alias RabbitMQ.CLI.Core.Helpers
   alias RabbitMQ.CLI.Ctl.{InfoKeys, RpcStream}
@@ -35,35 +34,42 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
   def merge_defaults([], opts) do
     {Enum.map(@info_keys, &Atom.to_string/1), Map.merge(%{vhost: "/", table_headers: true}, opts)}
   end
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{vhost: "/", table_headers: true}, opts)}
   end
 
   def validate(args, _) do
-      case InfoKeys.validate_info_keys(args, @info_keys) do
-        {:ok, _} -> :ok
-        err -> err
-      end
+    case InfoKeys.validate_info_keys(args, @info_keys) do
+      {:ok, _} -> :ok
+      err -> err
+    end
   end
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
-  def run([_|_] = args, %{node: node_name, timeout: timeout, vhost: vhost}) do
-      info_keys = InfoKeys.prepare_info_keys(args)
-      Helpers.with_nodes_in_cluster(node_name, fn(nodes) ->
-        RpcStream.receive_list_items(node_name,
-          :rabbit_amqqueue, :emit_consumers_all,
-          [nodes, vhost], timeout, info_keys, Kernel.length(nodes))
-      end)
+  def run([_ | _] = args, %{node: node_name, timeout: timeout, vhost: vhost}) do
+    info_keys = InfoKeys.prepare_info_keys(args)
+
+    Helpers.with_nodes_in_cluster(node_name, fn nodes ->
+      RpcStream.receive_list_items(
+        node_name,
+        :rabbit_amqqueue,
+        :emit_consumers_all,
+        [nodes, vhost],
+        timeout,
+        info_keys,
+        Kernel.length(nodes)
+      )
+    end)
   end
 
   def usage() do
-      "list_consumers [-p vhost] [--no-table-headers] [<consumerinfoitem> ...]"
+    "list_consumers [-p vhost] [--no-table-headers] [<consumerinfoitem> ...]"
   end
 
   def usage_additional() do
-      "<consumerinfoitem> must be a member of the list [" <>
-      Enum.join(@info_keys, ", ") <> "]."
+    "<consumerinfoitem> must be a member of the list [" <> Enum.join(@info_keys, ", ") <> "]."
   end
 
   def banner(_, %{vhost: vhost}), do: "Listing consumers on vhost #{vhost} ..."


### PR DESCRIPTION
Fixes #284 

Note that the second commit only contains cosmetic changes after running:

```
mix format lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
```