### PR TITLE
New command: rabbitmq-diagnostics tls_versions

### DIFF
--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -93,7 +93,7 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     case Config.get_option(:plugins_dir, opts) do
       nil -> {:error, :no_plugins_dir};
       dir ->
-        paths = String.split(to_string(dir), separator())
+        paths = String.split(to_string(dir), path_separator())
         case Enum.any?(paths, &File.dir?/1) do
           true  -> {:ok, dir};
           false -> {:error, :plugins_dir_does_not_exist}
@@ -151,7 +151,7 @@ defmodule RabbitMQ.CLI.Core.Helpers do
   def add_plugins_to_load_path(opts) do
     with {:ok, plugins_dir} <- plugins_dir(opts)
     do
-      String.split(to_string(plugins_dir), separator())
+      String.split(to_string(plugins_dir), path_separator())
       |>
       Enum.map(&add_directory_plugins_to_load_path/1)
       :ok
@@ -269,10 +269,17 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     end
   end
 
-  def separator() do
+  def path_separator() do
     case :os.type do
         {:unix, _} ->  ":"
         {:win32, _} -> ";"
+    end
+  end
+
+  def line_separator() do
+    case :os.type do
+        {:unix, _} ->  "\n"
+        {:win32, _} -> "\r\n"
     end
   end
 

--- a/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -11,8 +11,7 @@
 ## The Original Code is RabbitMQ.
 ##
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
-## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
-
+## Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/diagnostics/commands/runtime_thread_stats.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/runtime_thread_stats.ex
@@ -38,11 +38,11 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.RuntimeThreadStatsCommand do
     end
   end
 
-  def output(result, %{formatter: :json}) when is_list(result) do
+  def output(result, %{formatter: "json"}) when is_list(result) do
     {:error, "JSON formatter is not supported by this command"}
   end
 
-  def output(result, %{formatter: :csv}) when is_list(result) do
+  def output(result, %{formatter: "csv"}) when is_list(result) do
     {:error, "CSV formatter is not supported by this command"}
   end
 

--- a/lib/rabbitmq/cli/diagnostics/commands/tls_versions.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/tls_versions.ex
@@ -1,0 +1,51 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.TlsVersionsCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def merge_defaults(args, opts) do
+    {args, opts}
+  end
+
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
+
+  def validate(args, _) when length(args) > 0 do
+    {:validation_failure, :too_many_args}
+  end
+  def validate(_, _), do: :ok
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def usage, do: "tls_versions"
+
+  def run([], %{node: node_name, timeout: timeout} = _opts) do
+    :rabbit_misc.rpc_call(node_name, :ssl, :versions, [], timeout)
+  end
+
+  def banner([], %{}),  do: "Listing all TLS versions supported by the runtime..."
+
+  def output(result, %{formatter: "json"}) do
+    vs = Map.new(result) |> Map.get(:available)
+
+    {:ok, %{versions: vs}}
+  end
+  def output(result, _opts) do
+    vs = Map.new(result) |> Map.get(:available)
+    {:ok, vs}
+  end
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.StringPerLine
+end

--- a/lib/rabbitmq/cli/formatters/string_per_line.ex
+++ b/lib/rabbitmq/cli/formatters/string_per_line.ex
@@ -1,0 +1,46 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Formatters.StringPerLine do
+  @doc """
+  Use this to output one stream (collection) element per line,
+  using the string formatter. Flattens the stream.
+  """
+
+  alias RabbitMQ.CLI.Formatters.FormatterHelpers
+  alias RabbitMQ.CLI.Core.Helpers
+
+  @behaviour RabbitMQ.CLI.FormatterBehaviour
+
+  def format_output(output, _) do
+    Enum.map(output, fn(el) -> Helpers.string_or_inspect(el) end)
+  end
+
+  def format_stream(stream, options) do
+    Stream.scan(stream, :empty,
+                FormatterHelpers.without_errors_2(
+                 fn(element, previous) ->
+                   separator = case previous do
+                     :empty -> "";
+                     _      -> Helpers.line_separator()
+                   end
+                   format_element(element, separator, options)
+                 end))
+  end
+
+  def format_element(val, separator, options) do
+    separator <> format_output(val, options)
+  end
+end

--- a/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -181,7 +181,7 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
   end
 
   defp add_all_to_path(plugins_directories) do
-    directories = String.split(to_string(plugins_directories), CliHelpers.separator())
+    directories = String.split(to_string(plugins_directories), CliHelpers.path_separator())
     Enum.map(directories, fn(directory) ->
         with {:ok, subdirs} <- File.ls(directory)
         do

--- a/test/diagnostics/tls_versions_command_test.exs
+++ b/test/diagnostics/tls_versions_command_test.exs
@@ -1,0 +1,69 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2018 Pivotal Software, Inc.  All rights reserved.
+
+defmodule TlsVersionsCommandTest do
+  use ExUnit.Case
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.TlsVersionsCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000
+      }}
+  end
+
+  test "merge_defaults: is a no-op" do
+    assert @command.merge_defaults([], %{}) == {[], %{}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})) == {:badrpc, :nodedown}
+  end
+
+  test "run when formatter is set to JSON: return a document with a list of supported TLS versions", context do
+    m  = @command.run([], Map.merge(context[:opts], %{formatter: "json"})) |> Map.new
+    xs = Map.get(m, :available)
+
+    # assert that we have a list and tlsv1.2 is included
+    assert length(xs) > 0
+    assert Enum.member?(xs, :"tlsv1.2")
+  end
+
+  test "run and output: return a list of supported TLS versions", context do
+    m          = @command.run([], context[:opts])
+    {:ok, res} = @command.output(m, context[:opts])
+
+    # assert that we have a list and tlsv1.2 is included
+    assert length(res) > 0
+    assert Enum.member?(res, :"tlsv1.2")
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -447,7 +447,7 @@ defmodule TestHelper do
   def get_opts_with_plugins_directories(context, plugins_directories) do
     opts = context[:opts]
     plugins_dir = opts[:plugins_dir]
-    all_directories = Enum.join([to_string(plugins_dir) | plugins_directories], Helpers.separator())
+    all_directories = Enum.join([to_string(plugins_dir) | plugins_directories], Helpers.path_separator())
     %{opts | plugins_dir: to_charlist(all_directories)}
   end
 


### PR DESCRIPTION
Like `rabbitmq-diagnostics cipher_suites` but for supported (available in the runtime)
TLS versions.

[#162832991]