### PR TITLE
Introoduce rabbitmq-diagnostics is_running, is_booting

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/is_booting.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/is_booting.ex
@@ -1,0 +1,48 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.IsBootingCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
+
+  def merge_defaults(args, opts), do: {args, opts}
+
+  def validate(args, _) when length(args) > 0 do
+    {:validation_failure, :too_many_args}
+  end
+  def validate(_, _), do: :ok
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    :rabbit_misc.rpc_call(node_name, :rabbit, :is_booting, [node_name], timeout)
+  end
+
+  def output(true, %{node: node_name} = _options) do
+    {:ok, "RabbitMQ on node #{node_name} is booting"}
+  end
+  def output(false, %{node: node_name} = _options) do
+    {:error, "RabbitMQ on node #{node_name} is fully booted (check with is_running), stopped or has not started booting yet"}
+  end  
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "is_booting"
+
+  def banner([], %{node: node_name}) do
+    "Checking if RabbitMQ on node #{node_name} is currently booting ..."
+  end
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.String
+end

--- a/lib/rabbitmq/cli/diagnostics/commands/is_running.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/is_running.ex
@@ -1,0 +1,50 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.IsRunningCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def switches(), do: [timeout: :integer]
+  def aliases(), do: [t: :timeout]
+
+  def merge_defaults(args, opts), do: {args, opts}
+
+  def validate(args, _) when length(args) > 0 do
+    {:validation_failure, :too_many_args}
+  end
+  def validate(_, _), do: :ok
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    # Note: we use is_booted/1 over is_running/1 to avoid
+    # returning a positive result when the node is still booting
+    :rabbit_misc.rpc_call(node_name, :rabbit, :is_booted, [node_name], timeout)
+  end
+
+  def output(true, %{node: node_name} = _options) do
+    {:ok, "RabbitMQ on node #{node_name} is fully booted and running"}
+  end
+  def output(false, %{node: node_name} = _options) do
+    {:error, "RabbitMQ on node #{node_name} is not running or has not fully booted yet (check with is_booting)"}
+  end  
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "is_running"
+
+  def banner([], %{node: node_name}) do
+    "Checking if RabbitMQ is running on node #{node_name} ..."
+  end
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.String
+end

--- a/test/diagnostics/is_booting_test.exs
+++ b/test/diagnostics/is_booting_test.exs
@@ -1,0 +1,72 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule IsBootingCommandTest do
+  use ExUnit.Case
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.IsBootingCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000
+      }}
+  end
+
+  test "merge_defaults: nothing to do" do
+    assert @command.merge_defaults([], %{}) == {[], %{}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})) == {:badrpc, :nodedown}
+  end
+
+  test "run: when the RabbitMQ app is fully booted and running, returns false", context do
+    await_rabbitmq_startup()
+    
+    refute @command.run([], context[:opts])
+  end
+
+  test "run: when the RabbitMQ app is stopped, returns false", context do
+    stop_rabbitmq_app()
+
+    refute is_rabbitmq_app_running()
+    refute @command.run([], context[:opts])
+
+    start_rabbitmq_app()
+  end
+end

--- a/test/diagnostics/is_running_test.exs
+++ b/test/diagnostics/is_running_test.exs
@@ -1,0 +1,72 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule IsRunningCommandTest do
+  use ExUnit.Case
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.IsRunningCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000
+      }}
+  end
+
+  test "merge_defaults: nothing to do" do
+    assert @command.merge_defaults([], %{}) == {[], %{}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})) == {:badrpc, :nodedown}
+  end
+
+  test "run: when the RabbitMQ app is booted and started, returns true", context do
+    await_rabbitmq_startup()
+    
+    assert @command.run([], context[:opts])
+  end
+
+  test "run: when the RabbitMQ app is stopped, returns false", context do
+    stop_rabbitmq_app()
+
+    refute is_rabbitmq_app_running()
+    refute @command.run([], context[:opts])
+
+    start_rabbitmq_app()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -222,19 +222,35 @@ defmodule TestHelper do
     :rpc.call(get_rabbit_hostname(), :rabbit_disk_monitor, :set_disk_free_limit, [limit])
   end
 
+
+  #
+  # App lifecycle
+  #
+
+  def await_rabbitmq_startup() do
+    :ok = :rabbit_misc.rpc_call(get_rabbit_hostname(), :rabbit, :await_startup, [])
+  end
+
+  def is_rabbitmq_app_running() do
+    :rabbit_misc.rpc_call(node, :rabbit, :is_booted, [])
+  end
+
   def start_rabbitmq_app do
     :rabbit_misc.rpc_call(get_rabbit_hostname(), :rabbit, :start, [])
-    :timer.sleep(1000)
+    await_rabbitmq_startup()
+    :timer.sleep(250)
   end
 
   def stop_rabbitmq_app do
     :rabbit_misc.rpc_call(get_rabbit_hostname(), :rabbit, :stop, [])
-    :timer.sleep(1000)
+    :timer.sleep(1200)
   end
 
   def status do
     :rpc.call(get_rabbit_hostname(), :rabbit, :status, [])
   end
+
+
 
   def error_check(cmd_line, code) do
     assert catch_exit(RabbitMQCtl.main(cmd_line)) == {:shutdown, code}


### PR DESCRIPTION
Part one of #292 introduces

 * `rabbitmq-diagnostics is_running` which returns a success if the node is fully booted and running (as reported by `rabbit:is_booted/1`). This command can be used as/in a health check and meant to be used both interactively and non-interactively.

 *  * `rabbitmq-diagnostics is_booting` which returns a success if the node is currently booting (as reported by `rabbit:is_booting/1`). For full booted (running) and stopped nodes it would report a failure. This command is meant for interactive use only and mostly for completeness/troubleshooting. It is *NOT* a good fit for health checks since it will return a failure the vast majority of the time (unless you are lucky to catch a node booting or booting takes a long time)