### PR TITLE
Introduce rabbitmq-plugins is_enabled [plugin 1] [plugin 2] [...]

### DIFF
--- a/lib/rabbitmq/cli/formatters/json.ex
+++ b/lib/rabbitmq/cli/formatters/json.ex
@@ -22,7 +22,7 @@ alias RabbitMQ.CLI.Formatters.FormatterHelpers
 defmodule RabbitMQ.CLI.Formatters.Json do
   @behaviour RabbitMQ.CLI.FormatterBehaviour
 
-  def format_output(output, _) do
+  def format_output(output, _opts) do
     {:ok, json} = JSON.encode(output)
     json
   end

--- a/lib/rabbitmq/cli/plugins/commands/is_enabled.ex
+++ b/lib/rabbitmq/cli/plugins/commands/is_enabled.ex
@@ -110,10 +110,10 @@ defmodule RabbitMQ.CLI.Plugins.Commands.IsEnabledCommand do
   end
 
   defp positive_result_message(args, %{online: true, node: node_name}) do
-    String.capitalize "#{plugin_or_plugins(args)} enabled on node #{node_name}"
+    String.capitalize("#{plugin_or_plugins(args)} enabled on node #{node_name}")
   end
   defp positive_result_message(args, %{offline: true}) do
-    String.capitalize "#{plugin_or_plugins(args)} enabled"
+    String.capitalize("#{plugin_or_plugins(args)} enabled")
   end
 
   defp negative_result_message(args, %{online: true, node: node_name}, plugins) do

--- a/lib/rabbitmq/cli/plugins/commands/is_enabled.ex
+++ b/lib/rabbitmq/cli/plugins/commands/is_enabled.ex
@@ -92,11 +92,11 @@ defmodule RabbitMQ.CLI.Plugins.Commands.IsEnabledCommand do
     {:ok, %{"result" => "ok", "message" => msg}}
   end
   def output({:error, msg}, %{formatter: "json"}) do
-    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software,
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_unavailable,
      %{"result" => "error", "message" => msg}}
   end
   def output({:error, err}, _opts) do
-    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software, err}
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_unavailable, err}
   end
   use RabbitMQ.CLI.DefaultOutput
 

--- a/lib/rabbitmq/cli/plugins/commands/is_enabled.ex
+++ b/lib/rabbitmq/cli/plugins/commands/is_enabled.ex
@@ -1,0 +1,127 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is Pivotal Software, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Plugins.Commands.IsEnabledCommand do
+  alias RabbitMQ.CLI.Plugins.Helpers, as: PluginHelpers
+  alias RabbitMQ.CLI.Core.{Helpers, Validators}
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.String
+
+  def merge_defaults(args, %{offline: true} = opts) do
+    {args, opts}
+  end
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{online: true, offline: false}, opts)}
+  end
+
+  def distribution(%{offline: true}),  do: :none
+  def distribution(%{offline: false}), do: :cli
+
+  def switches(), do: [online: :boolean,
+                       offline: :boolean]
+
+  def validate(_, %{online: true, offline: true}) do
+   {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}
+  end
+  def validate(_, %{online: false, offline: false}) do
+   {:validation_failure, {:bad_argument, "Cannot set online and offline to false"}}
+  end
+  def validate([], _) do
+    {:validation_failure, :not_enough_arguments}
+  end
+  def validate([_ | _], _) do
+    :ok
+  end
+
+  def validate_execution_environment(args, %{offline: true} = opts) do
+    Validators.chain([&Helpers.require_rabbit_and_plugins/2,
+                      &PluginHelpers.enabled_plugins_file/2,
+                      &Helpers.plugins_dir/2],
+                     [args, opts])
+  end
+  def validate_execution_environment(args, %{online: true} = opts) do
+    Validators.node_is_running(args, opts)
+  end
+
+  def usage, do: "is_enabled <plugin1> [, <plugin2>, ...] [--offline] [--online]"
+
+  def banner(args, %{offline: true}) do
+    "Inferring if #{plugin_or_plugins(args)} from local environment..."
+  end
+
+  def banner(args, %{online: true, node: node}) do
+    "Asking node #{node} if #{plugin_or_plugins(args)} enabled..."
+  end
+
+  def run(args, %{online: true, node: node_name} = opts) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_plugins, :active, []) do
+      {:error, _} = e -> e
+      plugins  ->
+        plugins = Enum.map(plugins, &Atom.to_string/1) |> Enum.sort
+        case Enum.reduce(args, true,
+              fn p, acc -> acc && Enum.member?(plugins, p) end) do
+          true  -> {:ok,    positive_result_message(args, opts)}
+          false -> {:error, negative_result_message(args, opts, plugins)}
+        end
+    end
+  end
+  def run(args, %{offline: true} = opts) do
+    plugins = PluginHelpers.list_names(opts) |> Enum.map(&Atom.to_string/1) |> Enum.sort
+    case Enum.reduce(args, true,
+          fn p, acc -> acc && Enum.member?(plugins, p) end) do
+      true  -> {:ok,    positive_result_message(args, opts)}
+      false -> {:error, negative_result_message(args, opts, plugins)}
+    end
+  end
+
+  def output({:ok, msg}, %{formatter: "json"}) do
+    {:ok, %{"result" => "ok", "message" => msg}}
+  end
+  def output({:error, msg}, %{formatter: "json"}) do
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software,
+     %{"result" => "error", "message" => msg}}
+  end
+  def output({:error, err}, _opts) do
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software, err}
+  end
+  use RabbitMQ.CLI.DefaultOutput
+
+
+
+  def plugin_or_plugins(args) when length(args) == 1 do
+    "plugin #{PluginHelpers.comma_separated_names(args)} is"
+  end
+  def plugin_or_plugins(args) when length(args) > 1 do
+    "plugins #{PluginHelpers.comma_separated_names(args)} are"
+  end
+
+  defp positive_result_message(args, %{online: true, node: node_name}) do
+    String.capitalize "#{plugin_or_plugins(args)} enabled on node #{node_name}"
+  end
+  defp positive_result_message(args, %{offline: true}) do
+    String.capitalize "#{plugin_or_plugins(args)} enabled"
+  end
+
+  defp negative_result_message(args, %{online: true, node: node_name}, plugins) do
+    String.capitalize("#{plugin_or_plugins(args)} not (all) enabled on node #{node_name}. ")
+                      <> "Enabled plugins and dependencies: #{PluginHelpers.comma_separated_names(plugins)}"
+  end
+  defp negative_result_message(args, %{offline: true}, plugins) do
+    String.capitalize("#{plugin_or_plugins(args)} not (all) enabled. ")
+                      <> "Enabled plugins and dependencies: #{PluginHelpers.comma_separated_names(plugins)}"
+  end
+end

--- a/lib/rabbitmq/cli/plugins/plugins_helpers.ex
+++ b/lib/rabbitmq/cli/plugins/plugins_helpers.ex
@@ -48,6 +48,10 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     :lists.usort(:rabbit_plugins.list(to_charlist(dir)))
   end
 
+  def list_names(opts) do
+    list(opts) |> plugin_names
+  end
+
   def read_enabled(opts) do
     case enabled_plugins_file(opts) do
       {:ok, enabled} ->
@@ -131,6 +135,14 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
     end
   end
 
+  def plugin_name(plugin) when is_binary(plugin) do
+    plugin
+  end
+
+  def plugin_name(plugin) when is_atom(plugin) do
+    Atom.to_string(plugin)
+  end
+
   def plugin_name(plugin) do
     plugin(name: name) = plugin
     name
@@ -139,6 +151,15 @@ defmodule RabbitMQ.CLI.Plugins.Helpers do
   def plugin_names(plugins) do
     for plugin <- plugins, do: plugin_name(plugin)
   end
+
+  def comma_separated_names(plugins) do
+    Enum.join(plugin_names(plugins), ", ")
+  end
+
+
+  #
+  # Implementation
+  #
 
   defp to_list(str) when is_binary(str) do
     :erlang.binary_to_list(str)

--- a/test/plugins/is_enabled_command_test.exs
+++ b/test/plugins/is_enabled_command_test.exs
@@ -1,0 +1,135 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+
+defmodule PluginIsEnabledCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Plugins.Commands.IsEnabledCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+    node = get_rabbit_hostname()
+
+    {:ok, plugins_file} = :rabbit_misc.rpc_call(node,
+                                                :application, :get_env,
+                                                [:rabbit, :enabled_plugins_file])
+    {:ok, plugins_dir} = :rabbit_misc.rpc_call(node,
+                                               :application, :get_env,
+                                               [:rabbit, :plugins_dir])
+    rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
+
+    {:ok, [enabled_plugins]} = :file.consult(plugins_file)
+
+    opts = %{enabled_plugins_file: plugins_file,
+             plugins_dir: plugins_dir,
+             rabbitmq_home: rabbitmq_home,
+             online: false, offline: false}
+
+    on_exit(fn ->
+      set_enabled_plugins(enabled_plugins, :online, get_rabbit_hostname(), opts)
+    end)
+
+
+    {:ok, opts: opts}
+  end
+
+  setup context do
+    {
+      :ok,
+      opts: Map.merge(context[:opts], %{
+              node: get_rabbit_hostname(),
+              timeout: 1000
+            })
+    }
+  end
+
+
+
+  test "validate: specifying both --online and --offline is reported as invalid", context do
+    assert match?(
+      {:validation_failure, {:bad_argument, _}},
+      @command.validate(["rabbitmq_stomp"], Map.merge(context[:opts], %{online: true, offline: true}))
+    )
+  end
+
+  test "validate: not specifying any plugins to check is reported as invalid", context do
+    opts = context[:opts] |> Map.merge(%{online: true, offline: false})
+    assert match?({:validation_failure, :not_enough_arguments}, @command.validate([], opts))
+  end
+
+  test "validate_execution_environment: not specifying an enabled_plugins_file is reported as an error", context do
+    opts = context[:opts] |> Map.merge(%{online: false,
+                                         offline: true}) |> Map.delete(:enabled_plugins_file)
+    assert @command.validate_execution_environment(["rabbitmq_stomp"], opts) ==
+      {:validation_failure, :no_plugins_file}
+  end
+
+  test "validate_execution_environment: not specifying a plugins_dir is reported as an error", context do
+    opts = context[:opts] |> Map.merge(%{online: false,
+                                         offline: true}) |> Map.delete(:plugins_dir)
+    assert @command.validate_execution_environment(["rabbitmq_stomp"], opts) ==
+      {:validation_failure, :no_plugins_dir}
+  end
+
+
+  test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
+    assert @command.validate_execution_environment(["rabbitmq_stomp"],
+      Map.merge(context[:opts], %{online: false,
+                                  offline: true,
+                                  enabled_plugins_file: "none"})) == :ok
+  end
+
+  test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
+    opts = context[:opts] |> Map.merge(%{online: false,
+                                         offline: true,
+                                         plugins_dir: "none"})
+
+    assert @command.validate_execution_environment(["rabbitmq_stomp"], opts) ==
+      {:validation_failure, :plugins_dir_does_not_exist}
+  end
+
+  test "validate: failure to load the rabbit application is reported as an error", context do
+    opts = context[:opts] |> Map.merge(%{online: false,
+                                         offline: true}) |> Map.delete(:rabbitmq_home)
+    assert {:validation_failure, {:unable_to_load_rabbit, :rabbitmq_home_is_undefined}} ==
+      @command.validate_execution_environment(["rabbitmq_stomp"], opts)
+  end
+
+
+  test "run: when given a single enabled plugin, reports it as such", context do
+    opts = context[:opts] |> Map.merge(%{online: true, offline: false})
+    assert match?({:ok, _},
+      assert @command.run(["rabbitmq_stomp"], opts))
+  end
+
+  test "run: when given a list of actually enabled plugins, reports them as such", context do
+    opts = context[:opts] |> Map.merge(%{online: true, offline: false})
+    assert match?({:ok, _},
+      assert @command.run(["rabbitmq_stomp", "rabbitmq_federation"], opts))
+  end
+
+  test "run: when given a list of non-existent plugins, reports them as not enabled", context do
+    opts = context[:opts] |> Map.merge(%{online: true, offline: false})
+    assert match?({:error, _},
+      assert @command.run(["rabbitmq_xyz", "abc_xyz"], opts))
+  end
+
+  test "run: when given a list with one non-existent plugin, reports the group as not [all] enabled", context do
+    opts = context[:opts] |> Map.merge(%{online: true, offline: false})
+    assert match?({:error, _},
+      assert @command.run(["rabbitmq_stomp", "abc_xyz"], opts))
+  end
+end


### PR DESCRIPTION
Part of #292.

To QA:

1. Start a node from `umbrella/deps/rabbitmq_server_release` the same was as for running the test suite: `gmake run-broker PLUGINS="rabbitmq_federation rabbitmq_stomp"`

2. Switch to `deps/rabbit`, run `gmake`

3.  Try various combinations

``` bash
./scripts/rabbitmq-plugins -q is_enabled rabbitmq_stomp --offline --formatter=json; echo $?;
./scripts/rabbitmq-plugins -q is_enabled rabbitmq_stomp rabbitmq_local --offline; echo $?;
./scripts/rabbitmq-plugins -q is_enabled rabbitmq_stomp rabbitmq_local; echo $?;
./scripts/rabbitmq-plugins -q is_enabled rabbitmq_local; echo $?;
./scripts/rabbitmq-plugins -q is_enabled rabbitmq_stomp --offline; echo $?;
./scripts/rabbitmq-plugins -q is_enabled rabbitmq_stomp rabbitmq_federation --offline; echo $?;
./scripts/rabbitmq-plugins -q is_enabled rabbitmq_stomp; echo $?;
./scripts/rabbitmq-plugins -q is_enabled rabbitmq_stomp rabbitmq_federation; echo $?;
./scripts/rabbitmq-plugins -q is_enabled rabbitmq_stomp rabbitmq_local; echo $?
```