### PR TITLE
Introduces listener check commands

### DIFF
--- a/lib/rabbitmq/cli/core/accepts_one_positional_argument.ex
+++ b/lib/rabbitmq/cli/core/accepts_one_positional_argument.ex
@@ -1,0 +1,32 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+# Should be used by commands that require rabbit app to be stopped
+# but need no other execution environment validators.
+defmodule RabbitMQ.CLI.Core.AcceptsOnePositionalArgument do
+  defmacro __using__(_) do
+    quote do
+      def validate(args, _) when length(args) == 0 do
+          {:validation_failure, :not_enough_args}
+      end
+      def validate(args, _) when length(args) > 1 do
+          {:validation_failure, :too_many_args}
+      end
+      # Note: this will accept everything, so it must be the
+      # last validation clause defined!
+      def validate(_, _), do: :ok
+    end
+  end
+end

--- a/lib/rabbitmq/cli/core/accepts_one_positive_integer_argument.ex
+++ b/lib/rabbitmq/cli/core/accepts_one_positive_integer_argument.ex
@@ -1,0 +1,40 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+# Should be used by commands that require rabbit app to be stopped
+# but need no other execution environment validators.
+defmodule RabbitMQ.CLI.Core.AcceptsOnePositiveIntegerArgument do
+  defmacro __using__(_) do
+    quote do
+      def validate(args, _) when length(args) == 0 do
+          {:validation_failure, :not_enough_args}
+      end
+      def validate(args, _) when length(args) > 1 do
+          {:validation_failure, :too_many_args}
+      end
+      def validate([value], _) when is_integer(value) do
+        :ok
+      end
+      def validate([value], _) do
+          case Integer.parse(value) do
+            {n, _} when n >= 1 -> :ok
+            :error             -> {:validation_failure,
+                                    {:bad_argument, "Argument must be a positive integer"}}
+          end
+      end
+      def validate(_, _), do: :ok
+    end
+  end
+end

--- a/lib/rabbitmq/cli/ctl/commands/await_online_nodes_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/await_online_nodes_command.ex
@@ -28,21 +28,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AwaitOnlineNodesCommand do
     {args, Map.merge(opts, %{timeout: timeout})}
   end
 
-  def switches(), do: [timeout: :integer]
-  def aliases(), do: [t: :timeout]
-
-  def validate([], _), do: {:validation_failure, :not_enough_args}
-  def validate([_count|_] = args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
-
-  def validate([count], _) do
-    case Integer.parse(count) do
-      {n, _} when n >= 1 ->
-        :ok
-      _                  ->
-        {:validation_failure, {:bad_argument, "Expected online node count must be a positive integer"}}
-    end
-  end
-
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.AcceptsOnePositiveIntegerArgument
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([count], %{node: node_name, timeout: timeout}) do
@@ -65,6 +52,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AwaitOnlineNodesCommand do
   def output({:error, :timeout}, %{node: node_name}) do
     {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software,
      "Error: timed out while waiting. Not enough nodes joined #{node_name}'s cluster."}
-  end  
+  end
   use RabbitMQ.CLI.DefaultOutput
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/check_port_connectivity_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/check_port_connectivity_command.ex
@@ -1,0 +1,105 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
+  @moduledoc """
+  Displays all listeners on a node.
+
+  Returns a code of 0 unless there were connectivity and authentication
+  errors. This command is not meant to be used in health checks.
+  """
+
+  alias RabbitMQ.CLI.Core.Helpers
+  import RabbitMQ.CLI.Diagnostics.Helpers, only: [listeners_on: 2,
+                                                  listener_lines: 1,
+                                                  listener_map: 1,
+                                                  listener_maps: 1,
+                                                  check_listener_connectivity: 3]
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  @default_timeout 30_000
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+
+  def merge_defaults(args, opts) do
+    timeout = case opts[:timeout] do
+      nil       -> @default_timeout;
+      :infinity -> @default_timeout;
+      other     -> other
+    end
+    {args, Map.merge(opts, %{timeout: timeout})}
+  end
+
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node_name,
+      :rabbit_networking, :active_listeners, [], timeout) do
+      {:error, _}    = err -> err
+      {:error, _, _} = err -> err
+      xs when is_list(xs)  ->
+        locals = listeners_on(xs, node_name)
+        case locals do
+          [] -> {true, locals}
+          _  -> check_connectivity_of(locals, node_name, timeout)
+        end;
+      other                -> other
+    end
+  end
+
+  def output({true, listeners}, %{node: node_name, formatter: "json"}) do
+    {:ok, %{"result"    => "ok",
+            "node"      => node_name,
+            "listeners" => listener_maps(listeners)}}
+  end
+  def output({true, listeners}, %{node: node_name}) do
+    ports = listeners |> listener_maps |> Enum.map(fn %{port: p} -> p end)
+            |> Enum.sort  |> Enum.join(", ")
+    {:ok, "Successfully connected to ports #{ports} on node #{node_name}."}
+  end
+  def output({false, failures}, %{formatter: "json", node: node_name}) do
+    {:error, %{"result"   => "error",
+               "node"     => node_name,
+               "failures" => listener_maps(failures)}}
+  end
+  def output({false, failures}, %{node: node_name}) do
+    lines = ["Connection to ports of the following listeners on node #{node_name} failed: "
+              | listener_lines(failures)]
+    {:error, Enum.join(lines, Helpers.line_separator())}
+  end
+
+  def usage, do: "check_port_connectivity"
+
+  def banner([], %{node: node_name}) do
+    "Testing TCP connections to all active listeners on node #{node_name} ..."
+  end
+
+  #
+  # Implementation
+  #
+
+  defp check_connectivity_of(listeners, node_name, timeout) do
+    # per listener timeout
+    t        = Kernel.trunc(timeout / (length(listeners) + 1))
+    failures = Enum.reject(listeners,
+                fn l -> check_listener_connectivity(listener_map(l), node_name, t) end)
+    case failures do
+      [] -> {true, listeners}
+      fs -> {false, fs}
+    end
+  end
+end

--- a/lib/rabbitmq/cli/diagnostics/commands/check_protocol_listener_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/check_protocol_listener_command.ex
@@ -1,0 +1,83 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckProtocolListenerCommand do
+  @moduledoc """
+  Exits with a non-zero code if there is no active listener
+  for the given protocol on the target node.
+
+  This command is meant to be used in health checks.
+  """
+
+  import RabbitMQ.CLI.Diagnostics.Helpers, only: [listeners_on: 2,
+                                                  listener_maps: 1,
+                                                  normalize_protocol: 1]
+
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsOnePositionalArgument
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([proto], %{node: node_name, timeout: timeout}) do
+    proto = normalize_protocol(proto)
+
+    case :rabbit_misc.rpc_call(node_name,
+      :rabbit_networking, :active_listeners, [], timeout) do
+      {:error, _}    = err -> err;
+      {:error, _, _} = err -> err;
+      xs when is_list(xs)  ->
+        locals = listeners_on(xs, node_name) |> listener_maps
+        found  = Enum.any?(locals, fn %{protocol: p} ->
+                  to_string(proto) == to_string(p)
+                 end)
+        case found do
+          true  -> {true,  proto}
+          false -> {false, proto, locals}
+        end;
+      other                -> other
+    end
+  end
+
+  def output({true, proto}, %{node: node_name, formatter: "json"}) do
+    {:ok, %{"result"   => "ok",
+            "node"     => node_name,
+            "protocol" => proto}}
+  end
+  def output({true, proto}, %{node: node_name}) do
+    {:ok, "A listener for protocol #{proto} is running on node #{node_name}."}
+  end
+  def output({false, proto, listeners}, %{formatter: "json"}) do
+    protocols = Enum.map(listeners, fn %{protocol: p} -> p end)
+    {:error, %{"result"    => "error",
+               "missing"   => proto,
+               "protocols" => protocols,
+               "listeners" => listeners}}
+  end
+  def output({false, proto, listeners}, %{node: node_name}) do
+    protocols = Enum.map(listeners, fn %{protocol: p} -> p end)
+                |> Enum.sort |> Enum.join(", ")
+    {:error, "No listener for protocol #{proto} is active on node #{node_name}. "
+             <> "Found listeners for the following protocols: #{protocols}"}
+  end
+
+  def usage, do: "check_protocol_listener <protocol>"
+
+  def banner([proto], %{node: node_name}) do
+    "Asking node #{node_name} if there's an active listener for protocol #{proto} ..."
+  end
+end

--- a/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
+++ b/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
@@ -63,6 +63,59 @@ defmodule RabbitMQ.CLI.Diagnostics.Helpers do
     end
   end
 
+  def normalize_protocol(proto) do
+    val = proto |> to_string |> String.downcase
+    case val do
+      "amqp091"   -> "amqp"
+      "amqp0.9.1" -> "amqp"
+      "amqp0-9-1" -> "amqp"
+      "amqp0_9_1" -> "amqp"
+
+      "amqp10"    -> "amqp"
+      "amqp1.0"   -> "amqp"
+      "amqp1-0"   -> "amqp"
+      "amqp1_0"   -> "amqp"
+
+      "mqtt3.1"   -> "mqtt"
+      "mqtt3.1.1" -> "mqtt"
+      "mqtt31"    -> "mqtt"
+      "mqtt311"   -> "mqtt"
+      "mqtt3_1"   -> "mqtt"
+      "mqtt3_1_1" -> "mqtt"
+
+      "stomp1.0"  -> "stomp"
+      "stomp1.1"  -> "stomp"
+      "stomp1.2"  -> "stomp"
+      "stomp10"   -> "stomp"
+      "stomp11"   -> "stomp"
+      "stomp12"   -> "stomp"
+      "stomp1_0"  -> "stomp"
+      "stomp1_1"  -> "stomp"
+      "stomp1_2"  -> "stomp"
+
+      "https"     -> "http"
+      "http1"     -> "http"
+      "http1.1"    -> "http"
+      "http_api"      -> "http"
+      "management"    -> "http"
+      "management_ui" -> "http"
+      "ui"            -> "http"
+
+      "cli"          -> "clustering"
+      "distribution" -> "clustering"
+
+      "webmqtt"  -> "http/web-mqtt"
+      "web-mqtt" -> "http/web-mqtt"
+      "web_mqtt" -> "http/web-mqtt"
+
+      "webstomp"  -> "http/web-stomp"
+      "web-stomp" -> "http/web-stomp"
+      "web_stomp" -> "http/web-stomp"
+
+      _ -> val
+    end
+  end
+
   #
   # Alarms
   #
@@ -97,7 +150,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Helpers do
       a_node != node_name
     end)
   end
-  
+
   #
   # Implementation
   #

--- a/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
+++ b/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
@@ -88,6 +88,15 @@ defmodule RabbitMQ.CLI.Diagnostics.Helpers do
     check_port_connectivity(port, node_name, timeout)
   end
 
+  def protocol_label(:amqp),  do: "AMQP 0-9-1 and AMQP 1.0"
+  def protocol_label(:mqtt),  do: "MQTT"
+  def protocol_label(:stomp), do: "STOMP"
+  def protocol_label(:http),  do: "HTTP API"
+  def protocol_label(:"http/web-mqtt"),  do: "MQTT over WebSockets"
+  def protocol_label(:"http/web-stomp"), do: "STOMP over WebSockets"
+  def protocol_label(:clustering),       do: "inter-node and CLI tool communication"
+  def protocol_label(other), do: to_string(other)
+
   def normalize_protocol(proto) do
     val = proto |> to_string |> String.downcase
     case val do
@@ -189,14 +198,4 @@ defmodule RabbitMQ.CLI.Diagnostics.Helpers do
       false -> value
     end
   end
-
-  defp protocol_label(:amqp),  do: "AMQP 0-9-1 and AMQP 1.0"
-  defp protocol_label(:mqtt),  do: "STOMP"
-  defp protocol_label(:stomp), do: "MQTT"
-  defp protocol_label(:http),  do: "HTTP API"
-  defp protocol_label(:"http/web-mqtt"),  do: "MQTT over WebSockets"
-  defp protocol_label(:"http/web-stomp"), do: "STOMP over WebSockets"
-  defp protocol_label(:clustering),       do: "inter-node and CLI tool communication"
-  defp protocol_label(other), do: to_string(other)
-
 end

--- a/test/close_all_connections_command_test.exs
+++ b/test/close_all_connections_command_test.exs
@@ -19,9 +19,7 @@ defmodule CloseAllConnectionsCommandTest do
   import TestHelper
 
   alias RabbitMQ.CLI.Ctl.RpcStream
-
   @helpers RabbitMQ.CLI.Core.Helpers
-
   @command RabbitMQ.CLI.Ctl.Commands.CloseAllConnectionsCommand
 
   @vhost "/"
@@ -33,8 +31,6 @@ defmodule CloseAllConnectionsCommandTest do
 
     on_exit([], fn ->
       close_all_connections(get_rabbit_hostname())
-
-
     end)
 
     :ok
@@ -140,7 +136,7 @@ defmodule CloseAllConnectionsCommandTest do
   defp fetch_connection_vhosts(node, nodes) do
     fetch_connection_vhosts(node, nodes, 10)
   end
-  
+
   defp fetch_connection_vhosts(node, nodes, retries) do
       stream = RpcStream.receive_list_items(node,
                                             :rabbit_networking,
@@ -159,7 +155,7 @@ defmodule CloseAllConnectionsCommandTest do
           fetch_connection_vhosts(node, nodes, retries - 1)
         _ ->
           xs
-      end      
+      end
   end
 
 end

--- a/test/diagnostics/check_port_connectivity_command_test.exs
+++ b/test/diagnostics/check_port_connectivity_command_test.exs
@@ -1,0 +1,68 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule CheckPortConnectivityCommandTest do
+  use ExUnit.Case
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000
+      }}
+  end
+
+  test "merge_defaults: provides a default timeout" do
+    assert @command.merge_defaults([], %{}) == {[], %{timeout: 30000}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})) == {:badrpc, :nodedown}
+  end
+
+  test "run: tries to connect to every inferred active listener", context do
+    assert match?({true, _}, @command.run([], context[:opts]))
+  end
+
+
+  test "output: when all connections succeeded, returns a success", context do
+    assert match?({:ok, _}, @command.output({true, []}, context[:opts]))
+  end
+
+  # note: it's run/2 that filters out non-local alarms
+  test "output: when target node has a local alarm in effect, returns a failure", context do
+    failure = {:listener, :rabbit@mercurio, :lolz, 'mercurio',
+                  {0, 0, 0, 0, 0, 0, 0, 0}, 7761613,
+                  [backlog: 128, nodelay: true]}
+    assert match?({:error, _}, @command.output({false, [failure]}, context[:opts]))
+  end
+end

--- a/test/diagnostics/check_port_listener_command_test.exs
+++ b/test/diagnostics/check_port_listener_command_test.exs
@@ -1,0 +1,71 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule CheckPortListenerCommandTest do
+  use ExUnit.Case
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.CheckPortListenerCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000
+      }}
+  end
+
+  test "merge_defaults: nothing to do" do
+    assert @command.merge_defaults([], %{}) == {[], %{}}
+  end
+
+  test "validate: when no arguments are provided, returns a failure" do
+    assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
+  end
+
+  test "validate: when two or more arguments are provided, returns a failure" do
+    assert @command.validate([5672, 61613], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats a single positional argument and default switches as a success" do
+    assert @command.validate([1883], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert @command.run([61613], Map.merge(context[:opts], %{node: :jake@thedog})) == {:badrpc, :nodedown}
+  end
+
+  test "run: when a listener for the protocol is active, returns a success", context do
+    assert match?({true, _}, @command.run([5672], context[:opts]))
+  end
+
+  test "run: when a listener on the port is not active or unknown, returns an error", context do
+    assert match?({false, _, _}, @command.run([47777], context[:opts]))
+  end
+
+  test "output: when a listener for the port is active, returns a success", context do
+    assert match?({:ok, _}, @command.output({true, 5672}, context[:opts]))
+  end
+
+  test "output: when a listener for the port is not active, returns an error", context do
+    assert match?({:error, _}, @command.output({false, 15672, []}, context[:opts]))
+  end
+end

--- a/test/diagnostics/check_protocol_listener_command_test.exs
+++ b/test/diagnostics/check_protocol_listener_command_test.exs
@@ -1,0 +1,77 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule CheckProtocolListenerCommandTest do
+  use ExUnit.Case
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.CheckProtocolListenerCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000
+      }}
+  end
+
+  test "merge_defaults: nothing to do" do
+    assert @command.merge_defaults([], %{}) == {[], %{}}
+  end
+
+  test "validate: when no arguments are provided, returns a failure" do
+    assert @command.validate([], %{}) == {:validation_failure, :not_enough_args}
+  end
+
+  test "validate: when two or more arguments are provided, returns a failure" do
+    assert @command.validate(["amqp", "stomp"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats a single positional argument and default switches as a success" do
+    assert @command.validate(["mqtt"], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert @command.run(["stomp"], Map.merge(context[:opts], %{node: :jake@thedog})) == {:badrpc, :nodedown}
+  end
+
+  test "run: when a listener for the protocol is active, returns a success", context do
+    assert match?({true, _}, @command.run(["amqp"], context[:opts]))
+  end
+
+  test "run: accepts a number of alternative protocol names/spellings", context do
+    for p <- ["amqp", "amqp1.0", "amqp10", "amqp091", "stomp1.2", "distribution"] do
+      assert match?({true, _}, @command.run([p], context[:opts]))
+    end
+  end
+
+  test "run: when a listener for the protocol is not active or unknown, returns an error", context do
+    assert match?({false, _, _}, @command.run(["non-existent-proto"], context[:opts]))
+  end
+
+  test "output: when a listener for the protocol is active, returns a success", context do
+    assert match?({:ok, _}, @command.output({true, "amqp"}, context[:opts]))
+  end
+
+  test "output: when a listener for the protocol is not active, returns an error", context do
+    assert match?({:error, _}, @command.output({false, "http", []}, context[:opts]))
+  end
+end

--- a/test/diagnostics/diagnostics_helpers_test.exs
+++ b/test/diagnostics/diagnostics_helpers_test.exs
@@ -1,0 +1,41 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule DiagnosticsHelpersTest do
+  use ExUnit.Case, async: true
+
+  alias RabbitMQ.CLI.Diagnostics.Helpers, as: DH
+  import RabbitCommon.Records
+
+  test "listener record translation to a map" do
+    assert DH.listener_map(listener(node: :rabbit@mercurio,
+                           protocol: :stomp,
+                           ip_address: {0,0,0,0,0,0,0,0},
+                           port: 61613)) ==
+      %{
+        interface: "[::]",
+        node: :rabbit@mercurio,
+        port: 61613,
+        protocol: :stomp,
+        purpose: "STOMP"
+      }
+  end
+
+  test "[human-readable] protocol labels" do
+    assert DH.protocol_label(:amqp)  == "AMQP 0-9-1 and AMQP 1.0"
+    assert DH.protocol_label(:mqtt)  == "MQTT"
+    assert DH.protocol_label(:stomp) == "STOMP"
+  end
+end


### PR DESCRIPTION
Part of #292, per discussion with @gerhard.

To QA:

1. Start a node for running the tests
2. `gmake`
3. `for i in 5672 25672 61613 123123 15672; do ./escript/rabbitmq-diagnostics -q check_port_listener $i; echo $?; done`
4. `for i in amqp stomp cli clustering amqp091 amqp1.0 lolz; do ./escript/rabbitmq-diagnostics -q check_protocol_listener $i; echo $?; done`