### PR TITLE
Make it possible for formatters to define arguments.

### DIFF
--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -131,7 +131,7 @@ defmodule RabbitMQ.CLI.Core.Parser do
   end
 
   def parse_command_specific(input, command, options \\ %{}) do
-    formatter = RabbitMQCtl.get_formatter(command, options)
+    formatter = Config.get_formatter(command, options)
 
     switches = build_switches(default_switches(), command, formatter)
     aliases = build_aliases(default_aliases(), command, formatter)

--- a/lib/rabbitmq/cli/formatter_behaviour.ex
+++ b/lib/rabbitmq/cli/formatter_behaviour.ex
@@ -17,4 +17,10 @@
 defmodule RabbitMQ.CLI.FormatterBehaviour do
   @callback format_output(any, map()) :: String.t | [String.t]
   @callback format_stream(Enumerable.t, map()) :: Enumerable.t
+
+  @optional_callbacks switches: 0,
+                      aliases: 0
+
+  @callback switches() :: Keyword.t
+  @callback aliases() :: Keyword.t
 end

--- a/lib/rabbitmq/cli/formatters/report.ex
+++ b/lib/rabbitmq/cli/formatters/report.ex
@@ -13,10 +13,10 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2017 Pivotal Software, Inc.  All rights reserved.
 
-alias RabbitMQ.CLI.Formatters.FormatterHelpers
-alias RabbitMQ.CLI.Core.Output
-
 defmodule RabbitMQ.CLI.Formatters.Report do
+  alias RabbitMQ.CLI.Formatters.FormatterHelpers
+  alias RabbitMQ.CLI.Core.{Output, Config}
+
   @behaviour RabbitMQ.CLI.FormatterBehaviour
   def format_output(_, _) do
     raise "format_output is not implemented for report formatter"
@@ -40,7 +40,7 @@ defmodule RabbitMQ.CLI.Formatters.Report do
   end
 
   def format_result(command, output, options) do
-    formatter = RabbitMQCtl.default_formatter(command)
+    formatter = Config.default_formatter(command)
     case Output.format_output(output, formatter, options) do
       :ok               -> [];
       {:ok, val}        -> [val];

--- a/lib/rabbitmq/cli/formatters/table.ex
+++ b/lib/rabbitmq/cli/formatters/table.ex
@@ -18,6 +18,9 @@ alias RabbitMQ.CLI.Formatters.FormatterHelpers
 defmodule RabbitMQ.CLI.Formatters.Table do
   @behaviour RabbitMQ.CLI.FormatterBehaviour
 
+  def switches(), do: [pad_to_header: :boolean]
+
+
   def format_stream(stream, options) do
     # Flatten for list_consumers
     Stream.flat_map(stream,
@@ -57,25 +60,37 @@ defmodule RabbitMQ.CLI.Formatters.Table do
 
   defp format_output_1(output, options) when is_map(output) do
     escaped = escaped?(options)
-    format_line(output, escaped)
+    pad_to_header = pad_to_header?(options)
+    format_line(output, escaped, pad_to_header)
   end
   defp format_output_1([], _) do
     ""
   end
   defp format_output_1(output, options)do
     escaped = escaped?(options)
+    pad_to_header = pad_to_header?(options)
     case Keyword.keyword?(output) do
-        true  -> format_line(output, escaped);
+        true  -> format_line(output, escaped, pad_to_header);
         false -> format_inspect(output)
     end
   end
 
   defp escaped?(_), do: true
 
-  defp format_line(line, escaped) do
+  defp pad_to_header?(%{pad_to_header: pad}), do: pad
+  defp pad_to_header?(_), do: false
+
+  defp format_line(line, escaped, pad_to_header) do
     values = Enum.map(line,
-                      fn({_k, v}) ->
-                        FormatterHelpers.format_info_item(v, escaped)
+                      fn({k, v}) ->
+                        line = FormatterHelpers.format_info_item(v, escaped)
+                        case pad_to_header do
+                          true ->
+                            String.pad_trailing(to_string(line),
+                                                String.length(to_string(k)));
+                          false ->
+                            line
+                        end
                       end)
     Enum.join(values, "\t")
   end

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -124,8 +124,8 @@ defmodule RabbitMQCtl do
   end
 
   defp process_output(output, command, options) do
-    formatter = get_formatter(command, options)
-    printer = get_printer(options)
+    formatter = Config.get_formatter(command, options)
+    printer   = Config.get_printer(options)
 
     output
     |> Output.format_output(formatter, options)
@@ -191,39 +191,6 @@ defmodule RabbitMQCtl do
   end
   defp normalise_timeout(opts) do
     opts
-  end
-
-  def get_formatter(command, %{formatter: formatter}) do
-    module_name = Module.safe_concat("RabbitMQ.CLI.Formatters", Macro.camelize(formatter))
-    case Code.ensure_loaded(module_name) do
-      {:module, _}      -> module_name;
-      {:error, :nofile} -> default_formatter(command)
-    end
-  end
-  def get_formatter(command, _) do
-    default_formatter(command)
-  end
-
-  defp get_printer(%{printer: printer}) do
-    module_name = String.to_atom("RabbitMQ.CLI.Printers." <> Macro.camelize(printer))
-    case Code.ensure_loaded(module_name) do
-      {:module, _}      -> module_name;
-      {:error, :nofile} -> default_printer()
-    end
-  end
-  defp get_printer(_) do
-    default_printer()
-  end
-
-  def default_printer() do
-    RabbitMQ.CLI.Printers.StdIO
-  end
-
-  def default_formatter(command) do
-    case function_exported?(command, :formatter, 0) do
-      true  -> command.formatter;
-      false -> RabbitMQ.CLI.Formatters.String
-    end
   end
 
   # Suppress banner if --quiet option is provided

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -193,14 +193,14 @@ defmodule RabbitMQCtl do
     opts
   end
 
-  defp get_formatter(command, %{formatter: formatter}) do
+  def get_formatter(command, %{formatter: formatter}) do
     module_name = Module.safe_concat("RabbitMQ.CLI.Formatters", Macro.camelize(formatter))
     case Code.ensure_loaded(module_name) do
       {:module, _}      -> module_name;
       {:error, :nofile} -> default_formatter(command)
     end
   end
-  defp get_formatter(command, _) do
+  def get_formatter(command, _) do
     default_formatter(command)
   end
 


### PR DESCRIPTION
Add new callbacks to formatter_behavior: switches/0 and aliases/0
Merge them with command switches and aliases on parsing.

There is an example switch in the table formatter, enabling header padding.