### PR TITLE
New command: `rabbitmqctl await_startup`

### DIFF
--- a/lib/rabbitmq/cli/core/config.ex
+++ b/lib/rabbitmq/cli/core/config.ex
@@ -26,6 +26,10 @@ defmodule RabbitMQ.CLI.Core.Config do
     normalise(name, raw_option)
   end
 
+  def output_less?(opts) do
+    Map.get(opts, :silent, false) || Map.get(opts, :quiet, false)
+  end
+
   def normalise(:node, nil), do: nil
   def normalise(:node, node) when not is_atom(node) do
     Rabbitmq.Atom.Coerce.to_atom(node)

--- a/lib/rabbitmq/cli/ctl/commands/await_startup_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/await_startup_command.ex
@@ -1,0 +1,46 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Ctl.Commands.AwaitStartupCommand do
+  @moduledoc """
+  Waits until target node is fully booted. If the node is already running,
+  returns immediately.
+
+  This command is meant to be used when automating deployments.
+  See also `AwaitOnlineNodes`.
+  """
+
+  import RabbitMQ.CLI.Core.Config, only: [output_less?: 1]
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  @default_timeout 300
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{timeout: @default_timeout}, opts)}
+  end
+
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+
+  def run([], %{node: node_name, timeout: timeout} = opts) do
+    :rabbit_misc.rpc_call(node_name, :rabbit, :await_startup,
+                          [node_name, not output_less?(opts), timeout])
+  end
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "await_startup"
+
+  def banner(_, _), do: nil
+end

--- a/test/ctl/await_startup_command_test.exs
+++ b/test/ctl/await_startup_command_test.exs
@@ -1,0 +1,60 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at http://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule AwaitStartupCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Ctl.Commands.AwaitStartupCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    {:ok, opts: %{node: get_rabbit_hostname(), timeout: 300_000}}
+  end
+
+  setup do
+    {:ok, opts: %{node: get_rabbit_hostname()}}
+  end
+
+  test "merge_defaults: default timeout is 5 minutes" do
+    assert @command.merge_defaults([], %{}) == {[], %{timeout: 300}}
+  end
+
+  test "validate: accepts no arguments", context do
+    assert @command.validate([], context[:opts]) == :ok
+  end
+
+  test "validate: with extra arguments returns an arg count error", context do
+    assert @command.validate(["extra"], context[:opts]) ==
+      {:validation_failure, :too_many_args}
+  end
+
+  test "run: request to a non-existent node returns nodedown" do
+    target = :jake@thedog
+
+    opts = %{node: target, timeout: 5}
+    assert match?({:badrpc, :nodedown}, @command.run([], opts))
+  end
+
+  test "run: request to a fully booted node succeeds", context do
+    assert @command.run([], Map.merge(context[:opts], %{timeout: 5})) == :ok
+  end
+
+  test "empty banner", context do
+    nil = @command.banner([], context[:opts])
+  end
+end

--- a/test/ctl/shutdown_command_test.exs
+++ b/test/ctl/shutdown_command_test.exs
@@ -23,7 +23,6 @@ defmodule ShutdownCommandTest do
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
 
-
     :ok
   end
 
@@ -31,15 +30,13 @@ defmodule ShutdownCommandTest do
     {:ok, opts: %{node: get_rabbit_hostname()}}
   end
 
-  test "validate accepts no arguments", context do
+  test "validate: accepts no arguments", context do
     assert @command.validate([], context[:opts]) == :ok
   end
 
   test "validate: with extra arguments returns an arg count error", context do
     assert @command.validate(["extra"], context[:opts]) == {:validation_failure, :too_many_args}
   end
-
-  # TODO: we don't have integration tests yet.
 
   test "run: request to a non-existent node returns nodedown" do
     target = :jake@thedog


### PR DESCRIPTION
To go with rabbitmq/rabbitmq-server#1848.