### PR TITLE
Make it possible to get command help by typing 'rabbitmqctl mycommand --help'

### DIFF
--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -218,7 +218,8 @@ defmodule RabbitMQ.CLI.Core.Parser do
       plugins_dir: :string,
       enabled_plugins_file: :string,
       aliases_file: :string,
-      erlang_cookie: :atom
+      erlang_cookie: :atom,
+      help: :boolean
     ]
   end
 
@@ -231,7 +232,8 @@ defmodule RabbitMQ.CLI.Core.Parser do
       l: :longnames,
       # for backwards compatibility,
       # not all commands support timeouts
-      t: :timeout
+      t: :timeout,
+      "?": :help
     ]
   end
 

--- a/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -36,12 +36,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
         all_usage(opts)
 
       command ->
-        Enum.join(
-          [base_usage(command, opts)] ++
-            options_usage() ++
-            additional_usage(command),
-          "\n\n"
-        )
+        all_usage(command, opts)
     end
   end
 
@@ -70,6 +65,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
         additional_usage(),
       "\n\n"
     )
+  end
+
+  def all_usage(command, opts) do
+    Enum.join([base_usage(command, opts)] ++
+              options_usage() ++
+              additional_usage(command),
+              "\n\n")
   end
 
   def usage(), do: "help (<command> | [--list-commands])"

--- a/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -113,6 +113,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
     ["General options:
     short            | long          | description
     -----------------|---------------|--------------------------------
+    -?               | --help        | displays command usage information
     -n <node>        | --node <node> | connect to node <node>
     -l               | --longnames   | use long host names
     -q               | --quiet       | suppress informational messages

--- a/test/rabbitmqctl_test.exs
+++ b/test/rabbitmqctl_test.exs
@@ -29,6 +29,15 @@ defmodule RabbitMQCtlTest do
     :ok
   end
 
+## ------------------------ --help option -------------------------------------
+
+  test "--help option prints help for command and exits normally" do
+    command = ["status", "--help"]
+    assert capture_io(fn ->
+      error_check(command, exit_ok())
+    end) =~ ~r/Usage:/
+  end
+
 ## ------------------------ Error Messages ------------------------------------
   test "print error message on a bad connection" do
     command = ["status", "-n", "sandwich@pastrami"]


### PR DESCRIPTION
Add a new default switch `help`
Add an alias `?`

Make rabbitmqctl display command help if this option is true for known commands.