### PR TITLE
Ensure longnames option is passed to normalise_node

### DIFF
--- a/lib/rabbitmq/cli/core/exit_codes.ex
+++ b/lib/rabbitmq/cli/core/exit_codes.ex
@@ -56,5 +56,6 @@ defmodule RabbitMQ.CLI.Core.ExitCodes do
   def exit_code_for({:timeout, _}), do: exit_tempfail()
   def exit_code_for({:badrpc_multi, :nodedown, _}), do: exit_unavailable()
   def exit_code_for({:badrpc, :nodedown}), do: exit_unavailable()
+  def exit_code_for({:node_name, _}), do: exit_dataerr()
   def exit_code_for({:error, _}), do: exit_unavailable()
 end

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -24,8 +24,6 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     normalise_node(Config.get_option(:node), node_name_type)
   end
 
-  def normalise_node(name, node_name_type \\ :shortnames)
-
   def normalise_node(nil, node_name_type) do
     normalise_node(Config.get_option(:node), node_name_type)
   end

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -37,8 +37,12 @@ defmodule RabbitMQ.CLI.Core.Helpers do
   def normalise_node_option(options) do
     node_opt = Config.get_option(:node, options)
     longnames_opt = Config.get_option(:longnames, options)
-    normalised_node_opt = normalise_node(node_opt, longnames_opt)
-    Map.put(options, :node, normalised_node_opt)
+    case NodeName.create(node_opt, longnames_opt) do
+      {:error, _} = err ->
+        err
+      {:ok, normalised_node_opt} ->
+        {:ok, Map.put(options, :node, normalised_node_opt)}
+    end
   end
 
   def validate_step(:ok, step) do

--- a/lib/rabbitmq/cli/core/node_name.ex
+++ b/lib/rabbitmq/cli/core/node_name.ex
@@ -70,7 +70,7 @@ defmodule RabbitMQ.CLI.Core.NodeName do
             {:ok, String.to_atom(head <> "@" <> host_part)}
 
           false ->
-            {:error, :badarg}
+            {:error, {:node_name, :hostname_not_allowed}}
         end
 
       {:error, :long} when attempt == 1 ->
@@ -83,14 +83,14 @@ defmodule RabbitMQ.CLI.Core.NodeName do
             {:ok, String.to_atom(head <> "@" <> hostname() <> "." <> domain())}
 
           false ->
-            {:error, :badarg}
+            {:error, {:node_name, :hostname_not_allowed}}
         end
 
       {:error, :hostname_not_allowed} ->
-        {:error, :badarg}
+        {:error, {:node_name, :hostname_not_allowed}}
 
-      {:error, _err_type} ->
-        {:error, :badarg}
+      {:error, err_type} ->
+        {:error, {:node_name, err_type}}
     end
   end
 

--- a/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
@@ -39,7 +39,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
 
-  def run([target_node], options=%{node: node_name, ram: ram, disc: disc}) do
+  def run([target_node], %{node: node_name, ram: ram, disc: disc} = opts) do
     node_type =
       case {ram, disc} do
         {true, false} -> :ram
@@ -48,7 +48,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
         {false, false} -> :disc
       end
 
-    long_or_short_names = Config.get_option(:longnames, options)
+    long_or_short_names = Config.get_option(:longnames, opts)
     target_node_normalised = Helpers.normalise_node(target_node, long_or_short_names)
 
     :rabbit_misc.rpc_call(

--- a/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
@@ -14,7 +14,7 @@
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
-  alias RabbitMQ.CLI.Core.Helpers
+  alias RabbitMQ.CLI.Core.{Config, Helpers}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -39,7 +39,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
 
-  def run([target_node], %{node: node_name, ram: ram, disc: disc}) do
+  def run([target_node], options=%{node: node_name, ram: ram, disc: disc}) do
     node_type =
       case {ram, disc} do
         {true, false} -> :ram
@@ -48,11 +48,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
         {false, false} -> :disc
       end
 
+    long_or_short_names = Config.get_option(:longnames, options)
+    target_node_normalised = Helpers.normalise_node(target_node, long_or_short_names)
+
     :rabbit_misc.rpc_call(
       node_name,
       :rabbit_mnesia,
       :join_cluster,
-      [Helpers.normalise_node(target_node), node_type]
+      [target_node_normalised, node_type]
     )
   end
 

--- a/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
@@ -14,7 +14,7 @@
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.UpdateClusterNodesCommand do
-  alias RabbitMQ.CLI.Core.Helpers
+  alias RabbitMQ.CLI.Core.{Config, Helpers}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -22,12 +22,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.UpdateClusterNodesCommand do
   use RabbitMQ.CLI.Core.AcceptsOnePositionalArgument
   use RabbitMQ.CLI.Core.RequiresRabbitAppStopped
 
-  def run([seed_node], %{node: node_name}) do
+  def run([seed_node], options=%{node: node_name}) do
+    long_or_short_names = Config.get_option(:longnames, options)
+    seed_node_normalised = Helpers.normalise_node(seed_node, long_or_short_names)
     :rabbit_misc.rpc_call(
       node_name,
       :rabbit_mnesia,
       :update_cluster_nodes,
-      [Helpers.normalise_node(seed_node)]
+      [seed_node_normalised]
     )
   end
 

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -503,6 +503,7 @@ defmodule RabbitMQCtl do
 
      * See the CLI, clustering and networking guides on http://rabbitmq.com/documentation.html to learn more
      * Consult server logs on node #{node}
+     * If target node is configured to use long node names, don't forget to use --longnames with CLI tools
     """
   end
 

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -105,32 +105,33 @@ defmodule RabbitMQCtl do
 
             maybe_with_distribution(command, options, fn ->
               # rabbitmq/rabbitmq-cli#278
-              options = Helpers.normalise_node_option(options)
-
-              # The code below implements a tiny decision tree that has
-              # to do with CLI argument and environment state validation.
-
-              # validate CLI arguments
-              case command.validate(arguments, options) do
-                :ok ->
-                  # then optionally validate execution environment
-                  case maybe_validate_execution_environment(command, arguments, options) do
+              case Helpers.normalise_node_option(options) do
+                {:error, _} = err ->
+                  format_error(err, options, command)
+                {:ok, options} ->
+                  # The code below implements a tiny decision tree that has
+                  # to do with CLI argument and environment state validation.
+                  case command.validate(arguments, options) do
                     :ok ->
-                      result = proceed_to_execution(command, arguments, options)
-                      handle_command_output(result, command, options, output_fun)
+                      # then optionally validate execution environment
+                      case maybe_validate_execution_environment(command, arguments, options) do
+                        :ok ->
+                          result = proceed_to_execution(command, arguments, options)
+                          handle_command_output(result, command, options, output_fun)
+
+                        {:validation_failure, err} ->
+                          environment_validation_error_output(err, command, unparsed_command, options)
+
+                        {:error, _} = err ->
+                          format_error(err, options, command)
+                      end
 
                     {:validation_failure, err} ->
-                      environment_validation_error_output(err, command, unparsed_command, options)
+                      argument_validation_error_output(err, command, unparsed_command, options)
 
                     {:error, _} = err ->
                       format_error(err, options, command)
                   end
-
-                {:validation_failure, err} ->
-                  argument_validation_error_output(err, command, unparsed_command, options)
-
-                {:error, _} = err ->
-                  format_error(err, options, command)
               end
             end)
         end
@@ -352,6 +353,13 @@ defmodule RabbitMQCtl do
   defp exit_program(code) do
     :net_kernel.stop()
     exit({:shutdown, code})
+  end
+
+  defp format_error({:error, {:node_name, err_reason} = result}, opts, module) do
+    op = CommandModules.module_to_command(module)
+    node = opts[:node]
+    {:error, ExitCodes.exit_code_for(result),
+      "Error: operation #{op} failed due to invalid node name (node: #{node} reason: #{err_reason}).\nIf using FQDN node names, use the -l / --longnames argument"}
   end
 
   defp format_error({:error, {:badrpc_multi, :nodedown, [node | _]} = result}, opts, _) do

--- a/test/core/helpers_test.exs
+++ b/test/core/helpers_test.exs
@@ -69,43 +69,43 @@ defmodule HelpersTest do
   ## ------------------- normalise_node tests (:shortnames) --------------------
 
   test "shortnames: if nil input, retrieve standard rabbit hostname" do
-    assert @subject.normalise_node(nil) == get_rabbit_hostname()
+    assert @subject.normalise_node(nil, :shortnames) == get_rabbit_hostname()
   end
 
   test "shortnames: if input is an atom short name, return the atom with hostname" do
     want = String.to_atom("rabbit_test@#{hostname()}")
-    got = @subject.normalise_node(:rabbit_test)
+    got = @subject.normalise_node(:rabbit_test, :shortnames)
     assert want == got
   end
 
   test "shortnames: if input is a string fully qualified node name, return an atom" do
     want = String.to_atom("rabbit_test@#{hostname()}")
-    got = @subject.normalise_node("rabbit_test@#{hostname()}")
+    got = @subject.normalise_node("rabbit_test@#{hostname()}", :shortnames)
     assert want == got
   end
 
   test "shortnames: if input is a short node name, host name is added" do
     want = String.to_atom("rabbit_test@#{hostname()}")
-    got = @subject.normalise_node("rabbit_test")
+    got = @subject.normalise_node("rabbit_test", :shortnames)
     assert want == got
   end
 
   test "shortnames: if input is a hostname without a node name, default node name is added" do
     default_name = Config.get_option(:node)
     want = String.to_atom("#{default_name}@#{hostname()}")
-    got = @subject.normalise_node("@#{hostname()}")
+    got = @subject.normalise_node("@#{hostname()}", :shortnames)
     assert want == got
   end
 
   test "shortnames: if input is a short node name with an @ and no hostname, local host name is added" do
     want = String.to_atom("rabbit_test@#{hostname()}")
-    got = @subject.normalise_node("rabbit_test@")
+    got = @subject.normalise_node("rabbit_test@", :shortnames)
     assert want == got
   end
 
   test "shortnames: if input contains more than one @, return an atom" do
     want = String.to_atom("rabbit@rabbit_test@#{hostname()}")
-    got = @subject.normalise_node("rabbit@rabbit_test@#{hostname()}")
+    got = @subject.normalise_node("rabbit@rabbit_test@#{hostname()}", :shortnames)
     assert want == got
   end
 

--- a/test/core/helpers_test.exs
+++ b/test/core/helpers_test.exs
@@ -56,13 +56,13 @@ defmodule HelpersTest do
   test "longnames: 'rabbit' as node name, correct domain is used" do
     default_name = Config.get_option(:node)
     options = %{node: default_name, longnames: true}
-    options = @subject.normalise_node_option(options)
+    {:ok, options} = @subject.normalise_node_option(options)
     assert options[:node] == :"rabbit@#{hostname()}.#{domain()}"
   end
 
   test "shortnames: 'rabbit' as node name, no domain is used" do
     options = %{node: :rabbit, longnames: false}
-    options = @subject.normalise_node_option(options)
+    {:ok, options} = @subject.normalise_node_option(options)
     assert options[:node] == :"rabbit@#{hostname()}"
   end
 

--- a/test/ctl/close_all_connections_command_test.exs
+++ b/test/ctl/close_all_connections_command_test.exs
@@ -55,7 +55,7 @@ defmodule CloseAllConnectionsCommandTest do
   test "run: a close connections request in an existing vhost with all defaults closes all connections", context do
     with_connection(@vhost, fn(_) ->
       Process.sleep(500)
-      node = @helpers.normalise_node(context[:node])
+      node = @helpers.normalise_node(context[:node], :shortnames)
       nodes = @helpers.nodes_in_cluster(node)
       [[vhost: @vhost]] = fetch_connection_vhosts(node, nodes)
       opts = %{node: node, vhost: @vhost, global: false, per_connection_delay: 0, limit: 0}
@@ -68,7 +68,7 @@ defmodule CloseAllConnectionsCommandTest do
   test "run: close a limited number of connections in an existing vhost closes a subset of connections", context do
     with_connections([@vhost, @vhost, @vhost], fn(_) ->
       Process.sleep(500)
-      node = @helpers.normalise_node(context[:node])
+      node = @helpers.normalise_node(context[:node], :shortnames)
       nodes = @helpers.nodes_in_cluster(node)
       [[vhost: @vhost], [vhost: @vhost], [vhost: @vhost]] = fetch_connection_vhosts(node, nodes)
       opts = %{node: node, vhost: @vhost, global: false, per_connection_delay: 0, limit: 2}
@@ -81,7 +81,7 @@ defmodule CloseAllConnectionsCommandTest do
   test "run: a close connections request for a non-existing vhost does nothing", context do
     close_all_connections(get_rabbit_hostname())
     with_connection(@vhost, fn(_) ->
-      node = @helpers.normalise_node(context[:node])
+      node = @helpers.normalise_node(context[:node], :shortnames)
       nodes = @helpers.nodes_in_cluster(node)
       [[vhost: @vhost]] = fetch_connection_vhosts(node, nodes)
       opts = %{node: node, vhost: "burrow", global: false, per_connection_delay: 0, limit: 0}
@@ -93,7 +93,7 @@ defmodule CloseAllConnectionsCommandTest do
   test "run: a close connections request to an existing node with --global (all vhosts)", context do
     with_connection(@vhost, fn(_) ->
       Process.sleep(500)
-      node = @helpers.normalise_node(context[:node])
+      node = @helpers.normalise_node(context[:node], :shortnames)
       nodes = @helpers.nodes_in_cluster(node)
       [[vhost: @vhost]] = fetch_connection_vhosts(node, nodes)
       opts = %{node: node, vhost: "fakeit", global: true, per_connection_delay: 0, limit: 0}
@@ -111,7 +111,7 @@ defmodule CloseAllConnectionsCommandTest do
   end
 
   test "banner for vhost option", context do
-    node = @helpers.normalise_node(context[:node])
+    node = @helpers.normalise_node(context[:node], :shortnames)
     opts = %{node: node, vhost: "burrow", global: false, per_connection_delay: 0, limit: 0}
     s = @command.banner(["some reason"], opts)
     assert s =~ ~r/Closing all connections in vhost burrow/
@@ -119,7 +119,7 @@ defmodule CloseAllConnectionsCommandTest do
   end
 
   test "banner for vhost option with limit", context do
-    node = @helpers.normalise_node(context[:node])
+    node = @helpers.normalise_node(context[:node], :shortnames)
     opts = %{node: node, vhost: "burrow", global: false, per_connection_delay: 0, limit: 2}
     s = @command.banner(["some reason"], opts)
     assert s =~ ~r/Closing 2 connections in vhost burrow/

--- a/test/ctl/close_connection_command_test.exs
+++ b/test/ctl/close_connection_command_test.exs
@@ -54,7 +54,7 @@ defmodule CloseConnectionCommandTest do
   test "run: a close connection request on an existing connection", context do
     with_connection("/", fn(_) ->
       Process.sleep(500)
-      node = @helpers.normalise_node(context[:node])
+      node = @helpers.normalise_node(context[:node], :shortnames)
       nodes = @helpers.nodes_in_cluster(node)
       [[pid: pid]] = fetch_connection_pids(node, nodes)
       assert :ok == @command.run([:rabbit_misc.pid_to_string(pid), "test"], %{node: node})
@@ -65,7 +65,7 @@ defmodule CloseConnectionCommandTest do
 
   test "run: a close connection request on for a non existing connection returns successfully", context do
     assert match?(:ok,
-      @command.run(["<#{node()}.2.121.12>", "test"], %{node: @helpers.normalise_node(context[:node])}))
+      @command.run(["<#{node()}.2.121.12>", "test"], %{node: @helpers.normalise_node(context[:node], :shortnames)}))
   end
 
   test "run: a close_connection request on nonexistent RabbitMQ node returns nodedown" do

--- a/test/ctl/start_app_command_test.exs
+++ b/test/ctl/start_app_command_test.exs
@@ -44,7 +44,7 @@ defmodule StartAppCommandTest do
   end
 
   test "run: request to an active node succeeds", context do
-    node = RabbitMQ.CLI.Core.Helpers.normalise_node(context[:node])
+    node = RabbitMQ.CLI.Core.Helpers.normalise_node(context[:node], :shortnames)
     stop_rabbitmq_app()
     refute :rabbit_misc.rpc_call(node, :rabbit, :is_running, [])
     assert @command.run([], context[:opts])

--- a/test/ctl/stop_app_command_test.exs
+++ b/test/ctl/stop_app_command_test.exs
@@ -41,7 +41,7 @@ defmodule StopAppCommandTest do
   end
 
   test "run: request to an active node succeeds", context do
-    node = RabbitMQ.CLI.Core.Helpers.normalise_node(context[:node])
+    node = RabbitMQ.CLI.Core.Helpers.normalise_node(context[:node], :shortnames)
     assert :rabbit_misc.rpc_call(node, :rabbit, :is_running, [])
     assert @command.run([], context[:opts])
     refute :rabbit_misc.rpc_call(node, :rabbit, :is_running, [])


### PR DESCRIPTION
Fixes #311 

Bug introduced by #279

To reproduce, start two nodes with `RABBITMQ_USE_LONGNAME=true` and long node names, and try to join them into a cluster. You will see the error reported via the mailing list:

```
** (FunctionClauseError) no function clause matching in RabbitMQCtl.format_error/3    
    
    The following arguments were given to RabbitMQCtl.format_error/3:
    
        # 1
        {:badmatch, {:error, :badarg}}
    
        # 2
        %{disc: false, longnames: true, node: :"rabbit@tec-19.example.com", ram: false, timeout: :infinity}
    
        # 3
        RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand
    
    (rabbitmqctl) lib/rabbitmqctl.ex:290: RabbitMQCtl.format_error/3
    (rabbitmqctl) lib/rabbitmqctl.ex:76: anonymous fn/5 in RabbitMQCtl.exec_command/2
    (rabbitmqctl) lib/rabbitmqctl.ex:36: RabbitMQCtl.main/1
    (elixir) lib/kernel/cli.ex:105: anonymous fn/3 in Kernel.CLI.exec_fun/2
```