### PR TITLE
ctl shutdown: infer hostnames from node names

### DIFF
--- a/test/ctl/shutdown_command_test.exs
+++ b/test/ctl/shutdown_command_test.exs
@@ -42,14 +42,6 @@ defmodule ShutdownCommandTest do
     assert @command.validate([], Map.merge(%{wait: false}, context[:opts])) == :ok
   end
 
-  # this command performs rpc calls in validate/2
-  test "validate: request to a non-existent node returns nodedown" do
-    target = :jake@thedog
-
-    opts = %{node: target, wait: true, timeout: 10}
-    assert match?({:error, {:badrpc, _}}, @command.validate([], opts))
-  end
-
   test "run: request to a non-existent node returns nodedown" do
     target = :jake@thedog
 


### PR DESCRIPTION
inet_db is not a very reliable source as it doesn't take
node name CLI arguments and ERL_INETRC file settings.
That can lead to false positives in environments where
inet_db returns the same value (e.g. `localhost`) for
every cluster member.

Per discussion with @gerhard.

Closes #327.
References #309.