### PR TITLE
Backport help command and command behavior improvements

### DIFF
--- a/lib/rabbitmq/cli/command_behaviour.ex
+++ b/lib/rabbitmq/cli/command_behaviour.ex
@@ -48,7 +48,7 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
   @callback aliases() :: Keyword.t()
 
   @callback formatter() :: atom()
-  @callback scopes() :: [atom()]
+  @callback scopes() :: [atom()] | nil
   @callback description() :: String.t()
   @callback help_section() :: String.t()
   @callback usage_additional() :: String.t() | [String.t()]

--- a/lib/rabbitmq/cli/core/accepts_two_positional_arguments.ex
+++ b/lib/rabbitmq/cli/core/accepts_two_positional_arguments.ex
@@ -13,26 +13,22 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
-defmodule RabbitMQ.CLI.Ctl.Commands.AddVhostCommand do
-  alias RabbitMQ.CLI.Core.Helpers
+# Should be used by commands that require rabbit app to be stopped
+# but need no other execution environment validators.
+defmodule RabbitMQ.CLI.Core.AcceptsTwoPositionalArguments do
+  defmacro __using__(_) do
+    quote do
+      def validate(args, _) when length(args) < 2 do
+        {:validation_failure, :not_enough_args}
+      end
 
-  @behaviour RabbitMQ.CLI.CommandBehaviour
+      def validate(args, _) when length(args) > 2 do
+        {:validation_failure, :too_many_args}
+      end
 
-  use RabbitMQ.CLI.Core.MergesNoDefaults
-  use RabbitMQ.CLI.Core.AcceptsOnePositionalArgument
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
-
-  def run([vhost], %{node: node_name}) do
-    :rabbit_misc.rpc_call(node_name, :rabbit_vhost, :add, [vhost, Helpers.cli_acting_user()])
+      # Note: this will accept everything, so it must be the
+      # last validation clause defined!
+      def validate([_, _], _), do: :ok
+    end
   end
-
-  use RabbitMQ.CLI.DefaultOutput
-
-  def usage, do: "add_vhost <vhost>"
-
-  def help_section(), do: :virtual_hosts
-
-  def description(), do: "Creates a virtual host"
-
-  def banner([vhost], _), do: "Adding vhost \"#{vhost}\" ..."
 end

--- a/lib/rabbitmq/cli/core/command_modules.ex
+++ b/lib/rabbitmq/cli/core/command_modules.ex
@@ -15,6 +15,7 @@
 
 alias RabbitMQ.CLI.Core.{Config, Helpers}
 alias RabbitMQ.CLI.Plugins.Helpers, as: PluginsHelpers
+alias RabbitMQ.CLI.CommandBehaviour
 
 defmodule RabbitMQ.CLI.Core.CommandModules do
   @commands_ns ~r/RabbitMQ.CLI.(.*).Commands/
@@ -70,7 +71,7 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
           require Logger
 
           Logger.warn(
-            "Unable to read the enebled plugins file.\n" <>
+            "Unable to read the enabled plugins file.\n" <>
               "  Reason: #{inspect(err)}\n" <>
               "  Commands provided by plugins will not be available.\n" <>
               "  Please make sure your user has sufficient permissions to read to\n" <>
@@ -187,17 +188,16 @@ defmodule RabbitMQ.CLI.Core.CommandModules do
   end
 
   defp command_scopes(cmd) do
-    case :erlang.function_exported(cmd, :scopes, 0) do
-      true ->
-        cmd.scopes()
-
-      false ->
+    case CommandBehaviour.scopes(cmd) do
+      nil ->
         Regex.recompile!(@commands_ns)
         |> Regex.run(to_string(cmd), capture: :all_but_first)
         |> List.first()
         |> to_snake_case
         |> String.to_atom()
         |> List.wrap()
+      scopes ->
+        scopes
     end
   end
 end

--- a/lib/rabbitmq/cli/core/config.ex
+++ b/lib/rabbitmq/cli/core/config.ex
@@ -16,6 +16,7 @@
 defmodule RabbitMQ.CLI.Core.Config do
 
   alias RabbitMQ.CLI.{
+    CommandBehaviour,
     FormatterBehaviour,
     PrinterBehaviour
   }
@@ -94,12 +95,12 @@ defmodule RabbitMQ.CLI.Core.Config do
 
     case Code.ensure_loaded(module_name) do
       {:module, _} -> module_name
-      {:error, :nofile} -> default_formatter(command)
+      {:error, :nofile} -> CommandBehaviour.formatter(command)
     end
   end
 
   def get_formatter(command, _) do
-    default_formatter(command)
+    CommandBehaviour.formatter(command)
   end
 
   def get_printer(%{printer: printer}) do
@@ -117,12 +118,5 @@ defmodule RabbitMQ.CLI.Core.Config do
 
   def default_printer() do
     RabbitMQ.CLI.Printers.StdIO
-  end
-
-  def default_formatter(command) do
-    case function_exported?(command, :formatter, 0) do
-      true -> command.formatter
-      false -> RabbitMQ.CLI.Formatters.String
-    end
   end
 end

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -288,6 +288,7 @@ defmodule RabbitMQ.CLI.Core.Helpers do
   end
 
   def apply_if_exported(mod, fun, args, default) do
+    Code.ensure_loaded(mod)
     case function_exported?(mod, fun, length(args)) do
       true -> apply(mod, fun, args)
       false -> default

--- a/lib/rabbitmq/cli/core/parser.ex
+++ b/lib/rabbitmq/cli/core/parser.ex
@@ -14,6 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Core.Parser do
+  alias RabbitMQ.CLI.{CommandBehaviour, FormatterBehaviour}
   alias RabbitMQ.CLI.Core.{CommandModules, Config}
 
   # Use the same jaro distance limit as in Elixir `did_you_mean`
@@ -236,8 +237,8 @@ defmodule RabbitMQ.CLI.Core.Parser do
   end
 
   defp build_switches(default, command, formatter) do
-    command_switches = apply_if_exported(command, :switches, [], [])
-    formatter_switches = apply_if_exported(formatter, :switches, [], [])
+    command_switches = CommandBehaviour.switches(command)
+    formatter_switches = FormatterBehaviour.switches(formatter)
 
     assert_no_conflict(
       command,
@@ -269,8 +270,8 @@ defmodule RabbitMQ.CLI.Core.Parser do
   end
 
   defp build_aliases(default, command, formatter) do
-    command_aliases = apply_if_exported(command, :aliases, [], [])
-    formatter_aliases = apply_if_exported(formatter, :aliases, [], [])
+    command_aliases = CommandBehaviour.aliases(command)
+    formatter_aliases = FormatterBehaviour.aliases(formatter)
 
     assert_no_conflict(command, command_aliases, formatter_aliases, :redefining_formatter_aliases)
 
@@ -283,15 +284,6 @@ defmodule RabbitMQ.CLI.Core.Parser do
       command_aliases,
       {:command_invalid, {command, {:redefining_global_aliases, default, command_aliases}}}
     )
-  end
-
-  defp apply_if_exported(mod, fun, args, default) do
-    Code.ensure_loaded(mod)
-
-    case function_exported?(mod, fun, length(args)) do
-      true -> apply(mod, fun, args)
-      false -> default
-    end
   end
 
   defp merge_if_different(default, specific, error) do

--- a/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -46,6 +46,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
   end
 
   def usage, do: "add_user <username> <password>"
+  def help_section(), do: :user_management
+
+  def description(), do: "Creates a new user in the internal database"
 
   def banner([username, _password], _), do: "Adding user \"#{username}\" ..."
 

--- a/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex
@@ -34,6 +34,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AuthenticateUserCommand do
   end
 
   def usage, do: "authenticate_user <username> <password>"
+  def help_section(), do: :user_management
+
+  def description(), do: "Checks username and password"
 
   def banner([username, _password], _), do: "Authenticating user \"#{username}\" ..."
 

--- a/lib/rabbitmq/cli/ctl/commands/await_online_nodes_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/await_online_nodes_command.ex
@@ -38,9 +38,12 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AwaitOnlineNodesCommand do
     :rabbit_misc.rpc_call(node_name, :rabbit_nodes, :await_running_count, [n, timeout])
   end
 
-  def usage() do
-    "await_online_nodes <count>"
+  def output({:error, :timeout}, %{node: node_name}) do
+    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software(),
+     "Error: timed out while waiting. Not enough nodes joined #{node_name}'s cluster."}
   end
+
+  use RabbitMQ.CLI.DefaultOutput
 
   def banner([count], %{node: node_name, timeout: timeout}) when is_number(timeout) do
     "Will wait for at least #{count} nodes to join the cluster of #{node_name}. Timeout: #{
@@ -52,10 +55,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AwaitOnlineNodesCommand do
     "Will wait for at least #{count} nodes to join the cluster of #{node_name}."
   end
 
-  def output({:error, :timeout}, %{node: node_name}) do
-    {:error, RabbitMQ.CLI.Core.ExitCodes.exit_software(),
-     "Error: timed out while waiting. Not enough nodes joined #{node_name}'s cluster."}
+  def usage() do
+    "await_online_nodes <count>"
   end
 
-  use RabbitMQ.CLI.DefaultOutput
+  def usage_additional() do
+    "<count>: how many cluster members must be up in order for this command to exit. When <count> is 1, always exits immediately."
+  end
+
+  def help_section(), do: :cluster_management
+
+  def description(), do: "Waits for <count> nodes to join the cluster"
 end

--- a/lib/rabbitmq/cli/ctl/commands/await_startup_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/await_startup_command.ex
@@ -46,5 +46,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AwaitStartupCommand do
 
   def usage, do: "await_startup"
 
+  def help_section(), do: :node_management
+
+  def description(), do: "Waits for the RabbitMQ application to start on the target node"
+
   def banner(_, _), do: nil
 end

--- a/lib/rabbitmq/cli/ctl/commands/cancel_sync_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/cancel_sync_queue_command.ex
@@ -37,6 +37,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CancelSyncQueueCommand do
 
   def usage, do: "cancel_sync_queue [--vhost <vhost>] queue"
 
+  def help_section(), do: :replication
+
+  def description(), do: "Instructs a synchronising mirrored queue to stop synchronising itself"
+
   def banner([queue], %{vhost: vhost, node: _node}) do
     "Stopping synchronising queue '#{queue}' in vhost '#{vhost}' ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/change_cluster_node_type_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/change_cluster_node_type_command.ex
@@ -53,6 +53,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ChangeClusterNodeTypeCommand do
     "change_cluster_node_type <disc|ram>"
   end
 
+  def help_section(), do: :cluster_management
+
+  def description(), do: "Changes the type of the cluster node"
+
   def banner([node_type], %{node: node_name}) do
     "Turning #{node_name} into a #{node_type} node"
   end

--- a/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
@@ -37,5 +37,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ChangePasswordCommand do
 
   def usage, do: "change_password <username> <password>"
 
+  def help_section(), do: :user_management
+
+  def description(), do: "Changes the user password"
+
   def banner([user | _], _), do: "Changing password for user \"#{user}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/clear_global_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_global_parameter_command.ex
@@ -35,6 +35,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearGlobalParameterCommand do
 
   def usage, do: "clear_global_parameter <key>"
 
+  def help_section(), do: :parameters
+
+  def description(), do: "Clears a global runtime parameter."
+
   def banner([key], _) do
     "Clearing global runtime parameter \"#{key}\" ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_operator_policy_command.ex
@@ -36,6 +36,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearOperatorPolicyCommand do
 
   def usage, do: "clear_operator_policy [--vhost <vhost>] <key>"
 
+  def help_section(), do: :policies
+
+  def description(), do: "Clears an operator policy"
+
   def banner([key], %{vhost: vhost}) do
     "Clearing operator policy \"#{key}\" on vhost \"#{vhost}\" ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/clear_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_parameter_command.ex
@@ -46,6 +46,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearParameterCommand do
 
   def usage, do: "clear_parameter [--vhost <vhost>] <component_name> <key>"
 
+  def help_section(), do: :parameters
+
+  def description(), do: "Clears a runtime parameter."
+
   def banner([component_name, key], %{vhost: vhost}) do
     "Clearing runtime parameter \"#{key}\" for component \"#{component_name}\" on vhost \"#{vhost}\" ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/clear_password_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_password_command.ex
@@ -34,6 +34,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearPasswordCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "clear_password <username>"
+  def help_section(), do: :user_management
+
+  def description(), do: "Removes the user password"
 
   def banner([user], _), do: "Clearing password for user \"#{user}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_permissions_command.ex
@@ -36,6 +36,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearPermissionsCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "clear_permissions [-p vhost] <username>"
+  def help_section(), do: :access_control
+  def description(), do: "Removes all user permissions for a vhost"
 
   def banner([username], %{vhost: vhost}) do
     "Clearing permissions for user \"#{username}\" in vhost \"#{vhost}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/clear_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_policy_command.ex
@@ -36,6 +36,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearPolicyCommand do
 
   def usage, do: "clear_policy [--vhost <vhost>] <key>"
 
+  def help_section(), do: :policies
+
+  def description(), do: "Clears a policy"
+
   def banner([key], %{vhost: vhost}) do
     "Clearing policy \"#{key}\" on vhost \"#{vhost}\" ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/clear_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_topic_permissions_command.ex
@@ -54,6 +54,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearTopicPermissionsCommand do
   end
 
   def usage, do: "clear_topic_permissions [-p vhost] <username> [<exchange>]"
+  def help_section(), do: :access_control
+  def description(), do: "Clears user topic permissions for a vhost or exchange"
 
   def banner([username], %{vhost: vhost}) do
     "Clearing topic permissions for user \"#{username}\" in vhost \"#{vhost}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/clear_vhost_limits_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/clear_vhost_limits_command.ex
@@ -36,6 +36,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClearVhostLimitsCommand do
 
   def usage, do: "clear_vhost_limits [--vhost <vhost>]"
 
+  def help_section(), do: :virtual_hosts
+
+  def description(), do: "Clears virtual host limits"
+
   def banner([], %{vhost: vhost}) do
     "Clearing vhost \"#{vhost}\" limits ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/close_all_connections_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/close_all_connections_command.ex
@@ -15,6 +15,9 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.CloseAllConnectionsCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def switches(), do: [global: :boolean, per_connection_delay: :integer, limit: :integer]
+
   def merge_defaults(args, opts) do
     {args, Map.merge(%{global: false, vhost: "/", per_connection_delay: 0, limit: 0}, opts)}
   end
@@ -57,25 +60,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseAllConnectionsCommand do
     end
   end
 
-  defp apply_limit(conns, 0) do
-    conns
-  end
-
-  defp apply_limit(conns, number) do
-    :lists.sublist(conns, number)
-  end
-
   def output({:stream, stream}, _opts) do
     {:stream, Stream.filter(stream, fn x -> x != :ok end)}
   end
-
   use RabbitMQ.CLI.DefaultOutput
-
-  def switches(), do: [global: :boolean, per_connection_delay: :integer, limit: :integer]
-
-  def usage,
-    do:
-      "close_all_connections [-p <vhost> --limit <limit>] [-n <node> --global] [--per-connection-delay <delay>] <explanation>"
 
   def banner([explanation], %{node: node_name, global: true}) do
     "Closing all connections to node #{node_name} (across all vhosts), reason: #{explanation}..."
@@ -87,5 +75,33 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseAllConnectionsCommand do
 
   def banner([explanation], %{vhost: vhost, limit: limit}) do
     "Closing #{limit} connections in vhost #{vhost}, reason: #{explanation}..."
+  end
+
+  def usage do
+    "close_all_connections [-p <vhost> --limit <limit>] [-n <node> --global] [--per-connection-delay <delay>] <explanation>"
+  end
+
+  def usage_additional do
+    [
+      "--global: consider connections across all virtual hosts",
+      "--limit <number>: close up to this many connections",
+      "--per-connection-delay <milliseconds>: inject a delay between closures"
+    ]
+  end
+
+  def help_section(), do: :operations
+
+  def description(), do: "Instructs the broker to close all connections for the specified vhost or entire RabbitMQ node"
+
+  #
+  # Implementation
+  #
+
+  defp apply_limit(conns, 0) do
+    conns
+  end
+
+  defp apply_limit(conns, number) do
+    :lists.sublist(conns, number)
   end
 end

--- a/lib/rabbitmq/cli/ctl/commands/close_connection_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/close_connection_command.ex
@@ -15,12 +15,9 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.CloseConnectionCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
-  use RabbitMQ.CLI.DefaultOutput
-  def merge_defaults(args, opts), do: {args, opts}
 
-  def validate(args, _) when length(args) > 2, do: {:validation_failure, :too_many_args}
-  def validate(args, _) when length(args) < 2, do: {:validation_failure, :not_enough_args}
-  def validate([_, _], _), do: :ok
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsTwoPositionalArguments
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
@@ -31,7 +28,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.CloseConnectionCommand do
     ])
   end
 
-  def usage, do: "close_connection <connectionpid> <explanation>"
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage, do: "close_connection <connection pid> <explanation>"
+
+  def help_section(), do: :operations
+
+  def description(), do: "Instructs the broker to close the connection associated with the Erlang process id"
 
   def banner([pid, explanation], _), do: "Closing connection #{pid}, reason: #{explanation}..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/cluster_status_command.ex
@@ -48,6 +48,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ClusterStatusCommand do
 
   def usage, do: "cluster_status"
 
+  def help_section(), do: :cluster_management
+
+  def description(), do: "Displays all the nodes in the cluster grouped by node type, together with the currently running nodes"
+
   def banner(_, %{node: node_name}), do: "Cluster status of node #{node_name} ..."
 
   #

--- a/lib/rabbitmq/cli/ctl/commands/decode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/decode_command.ex
@@ -88,12 +88,29 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DecodeCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
-  def usage,
-    do: "decode value passphrase [--cipher cipher] [--hash hash] [--iterations iterations]"
-
   def banner([_, _], _) do
     "Decrypting value ..."
   end
+
+  def usage, do: "decode value passphrase [--cipher <cipher>] [--hash <hash>] [--iterations <iterations>]"
+
+  def usage_additional() do
+    [
+      "<value>: config value to decode",
+      "<passphrase>: passphrase to use with the config value encryption key",
+      "--cipher <cipher>: cipher suite to use",
+      "--hash <hash>: hashing function to use",
+      "--iterations <iterations>: number of iteration to apply"
+    ]
+  end
+
+  def help_section(), do: :configuration
+
+  def description(), do: "Decrypts an encrypted configuration value"
+
+  #
+  # Implementation
+  #
 
   defp supports_cipher(cipher), do: Enum.member?(:rabbit_pbe.supported_ciphers(), cipher)
 

--- a/lib/rabbitmq/cli/ctl/commands/delete_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/delete_queue_command.ex
@@ -19,25 +19,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteQueueCommand do
   def switches(), do: [if_empty: :boolean, if_unused: :boolean, timeout: :integer]
   def aliases(), do: [e: :if_empty, u: :is_unused, t: :timeout]
 
-  def usage(), do: "delete_queue queue_name [--if_empty|-e] [--if_unused|-u]"
-
-  def banner([qname], %{vhost: vhost, if_empty: if_empty, if_unused: if_unused}) do
-    if_empty_str =
-      case if_empty do
-        true -> ["if queue is empty "]
-        false -> []
-      end
-
-    if_unused_str =
-      case if_unused do
-        true -> ["if queue is unused "]
-        false -> []
-      end
-
-    "Deleting queue '#{qname}' on vhost '#{vhost}' " <>
-      Enum.join(Enum.concat([if_empty_str, if_unused_str]), "and ") <> "..."
-  end
-
   def merge_defaults(args, options) do
     {
       args,
@@ -111,4 +92,35 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteQueueCommand do
 
   ## Use default output for all non-special case outputs
   use RabbitMQ.CLI.DefaultOutput
+
+  def banner([qname], %{vhost: vhost, if_empty: if_empty, if_unused: if_unused}) do
+    if_empty_str =
+      case if_empty do
+        true -> ["if queue is empty "]
+        false -> []
+      end
+
+    if_unused_str =
+      case if_unused do
+        true -> ["if queue is unused "]
+        false -> []
+      end
+
+    "Deleting queue '#{qname}' on vhost '#{vhost}' " <>
+      Enum.join(Enum.concat([if_empty_str, if_unused_str]), "and ") <> "..."
+  end
+
+  def usage(), do: "delete_queue queue_name [--if_empty|-e] [--if_unused|-u]"
+
+  def usage_additional() do
+    [
+      "--if_empty: delete the queue if it is empty (has no messages ready for delivery)",
+      "--if_unused: delete the queue only if it has no consumers"
+    ]
+  end
+
+
+  def help_section(), do: :queues
+
+  def description(), do: "Deletes a queue"
 end

--- a/lib/rabbitmq/cli/ctl/commands/delete_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/delete_user_command.ex
@@ -34,6 +34,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteUserCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "delete_user <username>"
+  def help_section(), do: :user_management
+
+  def description(), do: "Removes the specified user"
 
   def banner([arg], _), do: "Deleting user \"#{arg}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/delete_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/delete_vhost_command.ex
@@ -30,5 +30,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.DeleteVhostCommand do
 
   def usage, do: "delete_vhost <vhost>"
 
+  def help_section(), do: :virtual_hosts
+
+  def description(), do: "Deletes a virtual host"
+
   def banner([arg], _), do: "Deleting vhost \"#{arg}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/encode_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/encode_command.ex
@@ -78,12 +78,29 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EncodeCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
-  def usage,
-    do: "encode value passphrase [--cipher cipher] [--hash hash] [--iterations iterations]"
-
   def banner([_, _], _) do
     "Encrypting value ..."
   end
+
+  def usage, do: "encode value passphrase [--cipher <cipher>] [--hash <hash>] [--iterations <iterations>]"
+
+  def usage_additional() do
+    [
+      "<value>: config value to encode",
+      "<passphrase>: passphrase to use with the config value encryption key",
+      "--cipher <cipher>: cipher suite to use",
+      "--hash <hash>: hashing function to use",
+      "--iterations <iterations>: number of iteration to apply"
+    ]
+  end
+
+  def help_section(), do: :configuration
+
+  def description(), do: "Encrypts a sensitive configuration value"
+
+  #
+  # Implementation
+  #
 
   defp supports_cipher(cipher), do: Enum.member?(:rabbit_pbe.supported_ciphers(), cipher)
 

--- a/lib/rabbitmq/cli/ctl/commands/environment_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/environment_command.ex
@@ -31,5 +31,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EnvironmentCommand do
 
   def usage, do: "environment"
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Displays the name and value of each variable in the application environment for each running application"
+
   def banner(_, %{node: node_name}), do: "Application environment of node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/eval_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/eval_command.ex
@@ -49,6 +49,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.EvalCommand do
 
   def usage, do: "eval <expr>"
 
+  def help_section(), do: :operations
+
+  def description(), do: "Executes Erlang code on the RabbitMQ node"
+
   def banner(_, _), do: nil
 
   #

--- a/lib/rabbitmq/cli/ctl/commands/exec_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/exec_command.ex
@@ -62,7 +62,16 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExecCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Inspect
 
+  def banner(_, _), do: nil
+
   def usage, do: "exec <expr> [--offline]"
 
-  def banner(_, _), do: nil
+  def usage_additional() do
+    "--offline: do not initialize Erlang distribution"
+  end
+
+
+  def help_section(), do: :operations
+
+  def description(), do: "Executes Elixir code on the CLI node"
 end

--- a/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/force_boot_command.ex
@@ -52,5 +52,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceBootCommand do
 
   def usage, do: "force_boot"
 
+  def help_section(), do: :cluster_management
+
+  def description(), do: "Ensures that the node will start next time, even if it was not the last to shut down"
+
   def banner(_, _), do: nil
 end

--- a/lib/rabbitmq/cli/ctl/commands/force_gc_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/force_gc_command.ex
@@ -26,6 +26,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceGcCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
+  def help_section(), do: :operations
+
   def description, do: "Makes all Erlang processes on the target node perform/schedule a full sweep garbage collection"
 
   def usage, do: "force_gc"

--- a/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/force_reset_command.ex
@@ -35,5 +35,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForceResetCommand do
 
   def usage, do: "force_reset"
 
+  def help_section(), do: :cluster_management
+
+  def description(), do: "Forcefully returns a RabbitMQ node to its virgin state"
+
   def banner(_, %{node: node_name}), do: "Forcefully resetting node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/forget_cluster_node_command.ex
@@ -70,6 +70,14 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ForgetClusterNodeCommand do
     "forget_cluster_node [--offline] <existing_cluster_member_node>"
   end
 
+  def usage_additional() do
+    "--offline: try to update cluster membership state directly. Use when target node is stopped. Only works for local nodes."
+  end
+
+  def help_section(), do: :cluster_management
+
+  def description(), do: "Removes a node from the cluster"
+
   def banner([node_to_remove], _) do
     "Removing node #{node_to_remove} from the cluster"
   end

--- a/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -13,17 +13,18 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
+alias RabbitMQ.CLI.CommandBehaviour
+
 defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
   alias RabbitMQ.CLI.Core.{CommandModules, Config, ExitCodes}
+  alias RabbitMQ.CLI.Core.CommandModules
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
   def scopes(), do: [:ctl, :diagnostics, :plugins]
-
   def switches(), do: [list_commands: :boolean]
 
   def distribution(_), do: :none
-
   use RabbitMQ.CLI.Core.MergesNoDefaults
 
   def validate(_, _), do: :ok
@@ -36,7 +37,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
         all_usage(opts)
 
       command ->
-        all_usage(command, opts)
+        command_usage(command, opts)
     end
   end
 
@@ -44,7 +45,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
     CommandModules.load(opts)
 
     case opts[:list_commands] do
-      true -> commands()
+      true -> commands_description()
       _ -> all_usage(opts)
     end
   end
@@ -53,33 +54,45 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
     {:error, ExitCodes.exit_ok(), result}
   end
 
-  def program_name(opts) do
-    Config.get_option(:script_name, opts)
-  end
+  def banner(_, _), do: nil
 
-  def all_usage(opts) do
-    Enum.join(
-      tool_usage(program_name(opts)) ++
-        options_usage() ++
-        [Enum.join(["Commands:"] ++ commands(), "\n")] ++
-        additional_usage(),
-      "\n\n"
-    )
-  end
+  def help_section(), do: :help
 
-  def all_usage(command, opts) do
-    Enum.join([base_usage(command, opts)] ++
-              options_usage() ++
-              additional_usage(command),
-              "\n\n")
-  end
+  def description(), do: "Displays usage information for a command"
 
   def usage(), do: "help (<command> | [--list-commands])"
 
+  def usage_additional() do
+    "--list-commands: only output a list of discovered commands"
+  end
+
+
+  #
+  # Implementation
+  #
+
+  def all_usage(opts) do
+    tool_name = program_name(opts)
+    Enum.join(
+      tool_usage(tool_name) ++
+        [Enum.join(["Available commands:"] ++ commands_description(), "\n")] ++
+        help_additional(tool_name),
+      "\n\n"
+    ) <> "\n"
+  end
+
+  def command_usage(command, opts) do
+    Enum.join([base_usage(command, opts)] ++
+              command_description(command) ++
+              additional_usage(command) ++
+              general_options_usage(),
+              "\n\n") <> "\n"
+  end
+
   defp tool_usage(tool_name) do
     [
-      "\nUsage:\n" <>
-        "#{tool_name} [-n <node>] [-t <timeout>] [-l] [-q] <command> [<command options>]"
+      "\nUsage\n\n" <>
+        "#{tool_name} [-n <node>] [-t <timeout>] [-l|--longnames] [-q|--quiet] <command> [<command options>]"
     ]
   end
 
@@ -88,12 +101,12 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
 
     maybe_timeout =
       case command_supports_timeout(command) do
-        true -> " [-t <timeout>]"
+        true -> " [--timeout <timeout>]"
         false -> ""
       end
 
     Enum.join([
-      "\nUsage:\n",
+      "\n## Usage\n\n",
       "#{tool_name} [-n <node>] [-l] [-q] " <>
         flatten_string(command.usage(), maybe_timeout)
     ])
@@ -109,101 +122,194 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HelpCommand do
     str <> additional
   end
 
-  defp options_usage() do
-    ["General options:
-    short            | long          | description
-    -----------------|---------------|--------------------------------
-    -?               | --help        | displays command usage information
-    -n <node>        | --node <node> | connect to node <node>
-    -l               | --longnames   | use long host names
-    -q               | --quiet       | suppress informational messages
-    -s               | --silent      | suppress informational messages
-                                     | and table header row
+  defp general_options_usage() do
+    [
+    "## General Options
 
-Default node is \"rabbit@server\", where `server` is the local hostname. On a host
-named \"server.example.com\", the node name of the RabbitMQ Erlang node will
-usually be rabbit@server (unless RABBITMQ_NODENAME has been set to some
-non-default value at broker startup time). The output of hostname -s is usually
-the correct suffix to use after the \"@\" sign. See rabbitmq-server(1) for
-details of configuring the RabbitMQ broker.
+The following options are accepted by most or all commands.
+
+short            | long          | description
+-----------------|---------------|--------------------------------
+-?               | --help        | displays command help
+-n <node>        | --node <node> | connect to node <node>
+-l               | --longnames   | use long host names
+-t               | --timeout <n> | for commands that support it, operation timeout in seconds
+-q               | --quiet       | suppress informational messages
+-s               | --silent      | suppress informational messages
+                                 | and table header row
+-p               | --vhost       | for commands that are scoped to a virtual host,
+                 |               | virtual host to use
+                 | --formatter   | alternative result formatter to use
+                                 | if supported: json, pretty_table, table, csv",
+
+    "## Target Node Name
+
+Default node is \"rabbit@hostname\", where `hostname` is the target node's hostname.
+On a host named \"eng.example.com\", the node name of the RabbitMQ node will
+usually be rabbit@eng. Node name can be overridden using the RABBITMQ_NODENAME environment
+variable at node startup time. The output of hostname -s is usually
+the correct suffix to use after the \"@\" sign. See rabbitmq-server(8)
+and RabbitMQ configuration and networking guides to learn more.
+
+If target RabbitMQ node is configured to use long node names, the \"--longnames\"
+option must be specified.",
+
+    "## Disabling Options
 
 Most options have a corresponding \"long option\" i.e. \"-q\" or \"--quiet\".
 Long options for boolean values may be negated with the \"--no-\" prefix,
-i.e. \"--no-quiet\" or \"--no-table-headers\"
-
-Quiet output mode is selected with the \"-q\" flag. Informational messages are
-suppressed when quiet mode is in effect.
-
-If target RabbitMQ node is configured to use long node names, the \"--longnames\"
-option must be specified.
-
-Some commands accept an optional virtual host parameter for which
-to display results. The default value is \"/\"."]
+i.e. \"--no-quiet\" or \"--no-table-headers\""]
   end
 
-  def commands() do
-    # Enum.map obtains the usage string for each command module.
-    # Enum.each prints them all.
-    CommandModules.module_map()
-    |> Map.values()
-    |> Enum.sort()
-    |> Enum.map(fn cmd ->
-      maybe_timeout =
-        case command_supports_timeout(cmd) do
-          true -> " [-t <timeout>]"
-          false -> ""
-        end
-
-      case cmd.usage() do
-        bin when is_binary(bin) ->
-          bin <> maybe_timeout
-
-        list when is_list(list) ->
-          Enum.map(list, fn line -> line <> maybe_timeout end)
-      end
-    end)
-    |> List.flatten()
-    |> Enum.sort()
-    |> Enum.map(fn cmd_usage -> "    #{cmd_usage}" end)
+  defp command_description(command) do
+    [CommandBehaviour.description(command) <> ".\n"]
   end
 
   defp additional_usage(command) do
-    if :erlang.function_exported(command, :usage_additional, 0) do
-      case command.usage_additional() do
-        list when is_list(list) ->
-          ["<timeout> - operation timeout in seconds. Default is \"infinity\"." | list]
-
-        bin when is_binary(bin) ->
-          ["<timeout> - operation timeout in seconds. Default is \"infinity\".", bin]
+    command_usage =
+      case CommandBehaviour.usage_additional(command) do
+        list when is_list(list) -> list |> Enum.map(fn(ln) -> "#{ln}\n" end)
+        bin when is_binary(bin) -> ["#{bin}\n"]
       end
-    else
-      case command_supports_timeout(command) do
-        true ->
-          ["<timeout> - operation timeout in seconds. Default is \"infinity\"."]
-
-        false ->
-          []
-      end
+    case command_usage do
+      []    -> []
+      usage ->
+        [flatten_string(["## Arguments and options\n" | usage], "")]
     end
   end
 
-  defp additional_usage() do
-    [
-      "<timeout> - operation timeout in seconds. Default is \"infinity\".",
-      CommandModules.module_map()
-      |> Map.values()
-      |> Enum.filter(&:erlang.function_exported(&1, :usage_additional, 0))
-      |> Enum.map(& &1.usage_additional)
-      |> Enum.join("\n\n")
-    ]
+  defp help_additional(tool_name) do
+    ["Use '#{tool_name} help <command>' to learn more about a specific command"]
   end
 
   defp command_supports_timeout(command) do
-    case :erlang.function_exported(command, :switches, 0) do
-      true -> nil != command.switches[:timeout]
-      false -> false
+    nil != CommandBehaviour.switches(command)[:timeout]
+  end
+
+  defp commands_description() do
+    module_map = CommandModules.module_map()
+
+    pad_commands_to = Enum.reduce(module_map, 0,
+      fn({name, _}, longest) ->
+        name_length = String.length(name)
+        case name_length > longest do
+          true  -> name_length
+          false -> longest
+        end
+      end)
+
+    module_map
+    |> Enum.map(
+      fn({name, cmd}) ->
+        description = CommandBehaviour.description(cmd)
+        help_section = CommandBehaviour.help_section(cmd)
+        {name, {description, help_section}}
+      end)
+    |> Enum.group_by(fn({_, {_, help_section}}) -> help_section end)
+    |> Enum.sort_by(
+      fn({help_section, _}) ->
+        ## TODO: sort help sections
+        case help_section do
+          :other -> 100
+          {:plugin, _} -> 99
+          :help -> 1
+          :node_management -> 2
+          :cluster_management -> 3
+          :replication -> 3
+          :user_management -> 4
+          :access_control -> 5
+          :observability_and_health_checks -> 6
+          :parameters -> 7
+          :policies -> 8
+          :virtual_hosts -> 9
+          _ -> 98
+        end
+      end)
+    |> Enum.map(
+      fn({help_section, section_helps}) ->
+        [
+          "\n## " <> section_head(help_section) <> ":\n" |
+          Enum.sort(section_helps)
+          |> Enum.map(
+            fn({name, {description, _}}) ->
+              "   #{String.pad_trailing(name, pad_commands_to)}  #{description}"
+            end)
+        ]
+
+      end)
+    |> Enum.concat()
+  end
+
+  defp section_head(help_section) do
+    case help_section do
+      :help ->
+        "Help"
+      :user_management ->
+        "Users"
+      :cluster_management ->
+        "Cluster"
+      :replication ->
+        "Replication"
+      :node_management ->
+        "Nodes"
+      :queues ->
+        "Queues"
+      :observability_and_health_checks ->
+        "Monitoring, observability and health checks"
+      :virtual_hosts ->
+          "Virtual hosts"
+      :access_control ->
+        "Access Control"
+      :parameters ->
+        "Parameters"
+      :policies ->
+        "Policies"
+      :configuration ->
+        "Node configuration"
+      :other ->
+        "Other"
+      {:plugin, plugin} ->
+        plugin_section(plugin) <> " plugin"
+      custom ->
+        snake_case_to_capitalized_string(custom)
     end
   end
 
-  def banner(_, _), do: nil
+  defp strip_rabbitmq_prefix(value) do
+    Regex.replace(~r/^rabbitmq_/, value, "")
+  end
+
+  defp format_known_plugin_name_fragments(value) do
+    case value do
+      ["amqp1.0"]    -> "AMQP 1.0"
+      ["amqp1", "0"] -> "AMQP 1.0"
+      ["management"]  -> "Management"
+      ["management", "agent"]  -> "Management"
+      ["mqtt"]       -> "MQTT"
+      ["stomp"]      -> "STOMP"
+      ["web", "mqtt"]  -> "Web MQTT"
+      ["web", "stomp"] -> "Web STOMP"
+      [other]        -> snake_case_to_capitalized_string(other)
+      fragments      -> snake_case_to_capitalized_string(Enum.join(fragments, "_"))
+    end
+  end
+
+  defp plugin_section(plugin) do
+    to_string(plugin)
+    # drop rabbitmq_
+    |> strip_rabbitmq_prefix()
+    |> String.split("_")
+    |> format_known_plugin_name_fragments()
+  end
+
+  defp snake_case_to_capitalized_string(value) do
+    to_string(value)
+    |> String.split("_")
+    |> Enum.map(&String.capitalize/1)
+    |> Enum.join(" ")
+  end
+
+  defp program_name(opts) do
+    Config.get_option(:script_name, opts)
+  end
 end

--- a/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/hipe_compile_command.ex
@@ -67,6 +67,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.HipeCompileCommand do
 
   def usage, do: "hipe_compile <directory>"
 
+  def help_section(), do: :operations
+
+  def description() do
+    "Performs HiPE-compilation of [some] server modules to the given directory "
+    <> "to be used with RABBITMQ_SERVER_CODE_PATH"
+  end
+
   def banner([target_dir], _) do
     "Will pre-compile RabbitMQ server modules with HiPE to #{target_dir} ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/join_cluster_command.ex
@@ -59,14 +59,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
     )
   end
 
-  def usage() do
-    "join_cluster [--disc|--ram] <existing_cluster_member_node>"
-  end
-
-  def banner([target_node], %{node: node_name}) do
-    "Clustering node #{node_name} with #{target_node}"
-  end
-
   def output({:ok, :already_member}, _) do
     {:ok, "The node is already a member of this cluster"}
   end
@@ -82,4 +74,24 @@ defmodule RabbitMQ.CLI.Ctl.Commands.JoinClusterCommand do
   end
 
   use RabbitMQ.CLI.DefaultOutput
+
+  def banner([target_node], %{node: node_name}) do
+    "Clustering node #{node_name} with #{target_node}"
+  end
+
+  def usage() do
+    "join_cluster [--disc|--ram] <existing_cluster_member_node>"
+  end
+
+  def usage_additional() do
+    [
+      "--disc: new node should be a disk one (stores its schema on disk). Highly recommended, used by default.",
+      "--ram: new node should be a RAM one (stores schema in RAM). Not recommended. Consult clustering doc guides first.",
+    ]
+  end
+
+
+  def help_section(), do: :cluster_management
+
+  def description(), do: "Instructs the node to become a member of the cluster that the specified node is in"
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_bindings_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_bindings_command.ex
@@ -69,8 +69,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListBindingsCommand do
     "list_bindings [--vhost <vhost>] [--no-table-headers] [<column> ...]"
   end
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists all bindings on a vhost"
+
   def usage_additional() do
-    "<column> must be one of " <> Enum.join(Enum.sort(@info_keys), ", ")
+    "<column> must be one of " <>
+      Enum.join(Enum.sort(@info_keys), ", ")
   end
 
   def banner(_, %{vhost: vhost}), do: "Listing bindings for vhost #{vhost}..."

--- a/lib/rabbitmq/cli/ctl/commands/list_channels_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_channels_command.ex
@@ -70,6 +70,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListChannelsCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
+  def banner(_, _), do: "Listing channels ..."
+
   def usage() do
     "list_channels [--no-table-headers] [<column> ...]"
   end
@@ -81,5 +83,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListChannelsCommand do
     ]
   end
 
-  def banner(_, _), do: "Listing channels ..."
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists all channels in the node"
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_ciphers_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_ciphers_command.ex
@@ -32,5 +32,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListCiphersCommand do
 
   def usage, do: "list_ciphers"
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists cipher suites supported by encoding commands"
+
   def banner(_, _), do: "Listing supported ciphers ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_connections_command.ex
@@ -73,6 +73,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConnectionsCommand do
     "list_connections [--no-table-headers] [<column> ...]"
   end
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists AMQP 0.9.1 connections for the node"
+
   def usage_additional() do
     [
       "<column> must be one of " <> Enum.join(Enum.sort(@info_keys), ", "),

--- a/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
@@ -11,7 +11,7 @@
 ## The Original Code is RabbitMQ.
 ##
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
-## Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
   alias RabbitMQ.CLI.Core.Helpers
@@ -29,7 +29,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
   def info_keys(), do: @info_keys
 
   def merge_defaults([], opts) do
-    {Enum.map(@info_keys, &Atom.to_string/1), Map.merge(%{vhost: "/", table_headers: true}, opts)}
+    {Enum.map(@info_keys -- [:activity_status], &Atom.to_string/1),
+     Map.merge(%{vhost: "/", table_headers: true}, opts)}
   end
 
   def merge_defaults(args, opts) do
@@ -49,14 +50,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
     info_keys = InfoKeys.prepare_info_keys(args)
 
     Helpers.with_nodes_in_cluster(node_name, fn nodes ->
-      RpcStream.receive_list_items(
+      RpcStream.receive_list_items_with_fun(
         node_name,
-        :rabbit_amqqueue,
+        [{:rabbit_amqqueue,
         :emit_consumers_all,
-        [nodes, vhost],
+        [nodes, vhost]}],
         timeout,
         info_keys,
-        Kernel.length(nodes)
+        Kernel.length(nodes),
+        fn item -> fill_consumer_active_fields(item) end
       )
     end)
   end
@@ -69,9 +71,35 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
     "list_consumers [-p vhost] [--no-table-headers] [<column> ...]"
   end
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists all consumers for a vhost"
+
   def usage_additional() do
     "<column> must be one of " <> Enum.join(Enum.sort(@info_keys), ", ")
   end
 
   def banner(_, %{vhost: vhost}), do: "Listing consumers on vhost #{vhost} ..."
+
+  # add missing fields if response comes from node < 3.8
+  def fill_consumer_active_fields({[], {chunk, :continue}}) do
+    {[], {chunk, :continue}}
+  end
+
+  def fill_consumer_active_fields({items, {chunk, :continue}}) do
+    {Enum.map(items, fn item ->
+                          case Keyword.has_key?(item, :active) do
+                            true ->
+                              item
+                            false ->
+                              Keyword.drop(item, [:arguments])
+                                ++ [active: true, activity_status: :up]
+                                ++ [arguments: Keyword.get(item, :arguments, [])]
+                          end
+                        end), {chunk, :continue}}
+  end
+
+  def fill_consumer_active_fields(v) do
+    v
+  end
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_consumers_command.ex
@@ -63,7 +63,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
-  def banner(_, %{vhost: vhost}), do: "Listing consumers on vhost #{vhost} ..."
+  def banner(_, %{vhost: vhost}), do: "Listing consumers in vhost #{vhost} ..."
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
@@ -77,5 +77,5 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListConsumersCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Lists all consumers for a vhost"
+  def description(), do: "Lists all consumers in a vhost"
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_exchanges_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_exchanges_command.ex
@@ -58,13 +58,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListExchangesCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists exchanges"
+
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def usage(), do: "list_exchanges [--vhost <vhost>] [--no-table-headers] [<column> ...]"
 
-  def usage_additional() do
-    "<column> must be one of " <> Enum.join(Enum.sort(@info_keys), ", ")
-  end
+  def usage_additional(), do: "<column> must be one of " <> Enum.join(Enum.sort(@info_keys), ", ")
 
   def banner(_, %{vhost: vhost}), do: "Listing exchanges for vhost #{vhost} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_global_parameters_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_global_parameters_command.ex
@@ -42,5 +42,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListGlobalParametersCommand do
 
   def usage, do: "list_global_parameters [--no-table-headers]"
 
+  def help_section(), do: :parameters
+
+  def description(), do: "Lists all global runtime parameters"
+
   def banner(_, _), do: "Listing global runtime parameters ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_hashes_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_hashes_command.ex
@@ -32,5 +32,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListHashesCommand do
 
   def usage, do: "list_hashes"
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists hash functions supported by encoding commands"
+
   def banner(_, _), do: "Listing supported hash algorithms ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_operator_policies_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_operator_policies_command.ex
@@ -41,6 +41,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListOperatorPoliciesCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def usage, do: "list_operator_policies [--vhost <vhost>] [--no-table-headers]"
+  def help_section(), do: :policies
+
+  def description(), do: "Lists operator policy overrides for a virtual host"
 
   def banner(_, %{vhost: vhost}),
     do: "Listing operator policy overrides for vhost \"#{vhost}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/list_parameters_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_parameters_command.ex
@@ -41,6 +41,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListParametersCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def usage, do: "list_parameters [--vhost <vhost>] [--no-table-headers]"
+  def help_section(), do: :parameters
+
+  def description(), do: "Lists all parameters for a virtual host"
 
   def banner(_, %{vhost: vhost}), do: "Listing runtime parameters for vhost \"#{vhost}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_permissions_command.ex
@@ -41,6 +41,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListPermissionsCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def usage, do: "list_permissions [--vhost <vhost>] [--no-table-headers]"
+  def help_section(), do: :access_control
+  def description(), do: "Lists user permissions in a virtual host"
 
   def banner(_, %{vhost: vhost}), do: "Listing permissions for vhost \"#{vhost}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_policies_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_policies_command.ex
@@ -41,6 +41,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListPoliciesCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def usage, do: "list_policies [--vhost <vhost>] [--no-table-headers]"
+  def help_section(), do: :policies
+
+  def description(), do: "Lists all policies for a virtual host"
 
   def banner(_, %{vhost: vhost}), do: "Listing policies for vhost \"#{vhost}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
@@ -30,21 +30,18 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
             messages_persistent message_bytes message_bytes_ready
             message_bytes_unacknowledged message_bytes_ram message_bytes_persistent
             head_message_timestamp disk_reads disk_writes consumers
-            consumer_utilisation memory slave_pids synchronised_slave_pids state)a
+            consumer_utilisation memory slave_pids synchronised_slave_pids state type)a
+
+  def description(), do: "Lists queues and their properties"
+  def usage(), do: "list_queues [--vhost <vhost>] [--online] [--offline] [--local] [--no-table-headers] [<column>, ...]"
+  def scopes(), do: [:ctl, :diagnostics]
+  def switches(), do: [offline: :boolean,
+                       online: :boolean,
+                       local: :boolean,
+                       timeout: :integer ]
+  def aliases(), do: [t: :timeout]
 
   def info_keys(), do: @info_keys
-
-  def scopes(), do: [:ctl, :diagnostics]
-
-  def switches(),
-    do: [
-      offline: :boolean,
-      online: :boolean,
-      local: :boolean,
-      timeout: :integer
-    ]
-
-  def aliases(), do: [t: :timeout]
 
   defp default_opts() do
     %{vhost: "/", offline: false, online: false, local: false, table_headers: true}
@@ -128,7 +125,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
-  def usage(), do: "list_queues [--vhost <vhost>] [--online] [--offline] [--local] [--no-table-headers] [<column>, ...]"
+  def help_section(), do: :observability_and_health_checks
 
   def usage_additional do
     [

--- a/lib/rabbitmq/cli/ctl/commands/list_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_topic_permissions_command.ex
@@ -41,6 +41,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListTopicPermissionsCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def usage, do: "list_topic_permissions [--vhost <vhost>] [--no-table-headers]"
+  def help_section(), do: :access_control
+  def description(), do: "Lists topic permissions in a virtual host"
 
   def banner(_, %{vhost: vhost}), do: "Listing topic permissions for vhost \"#{vhost}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_unresponsive_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_unresponsive_queues_command.ex
@@ -84,6 +84,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUnresponsiveQueuesCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
+  def banner(_, %{vhost: vhost}), do: "Listing unresponsive queues for vhost #{vhost} ..."
+
   def usage() do
     "list_unresponsive_queues [--local] [--queue-timeout <milliseconds>] [<column> ...] [--no-table-headers]"
   end
@@ -96,5 +98,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUnresponsiveQueuesCommand do
     ]
   end
 
-  def banner(_, %{vhost: vhost}), do: "Listing unresponsive queues for vhost #{vhost} ..."
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Tests queues to respond within timeout. Lists those which did not respond"
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_user_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_user_permissions_command.ex
@@ -44,6 +44,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserPermissionsCommand do
   end
 
   def usage, do: "list_user_permissions [--no-table-headers] <username>"
+  def help_section(), do: :access_control
+  def description(), do: "Lists user permissions"
 
   def banner([username], _), do: "Listing permissions for user \"#{username}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_user_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_user_topic_permissions_command.ex
@@ -41,6 +41,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUserTopicPermissionsCommand do
   def formatter(), do: RabbitMQ.CLI.Formatters.Table
 
   def usage, do: "list_user_topic_permissions [--no-table-headers] <username>"
+  def help_section(), do: :access_control
+  def description(), do: "Lists user topic permissions"
 
   def banner([username], _), do: "Listing topic permissions for user \"#{username}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_users_command.ex
@@ -36,5 +36,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListUsersCommand do
 
   def usage, do: "list_users [--no-table-headers]"
 
+  def help_section(), do: :user_management
+
+  def description(), do: "List user names and tags"
+
   def banner(_, _), do: "Listing users ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_vhost_limits_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_vhost_limits_command.ex
@@ -71,6 +71,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostLimitsCommand do
 
   def usage, do: "list_vhost_limits [--vhost <vhost>] [--global] [--no-table-headers]"
 
+  def usage_additional() do
+    "--global: list global limits (those not associated with a virtual host)"
+  end
+
+
+  def help_section(), do: :virtual_hosts
+
+  def description(), do: "Displays configured virtual host limits"
+
   def banner([], %{global: true}) do
     "Listing limits for all vhosts ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_vhosts_command.ex
@@ -51,6 +51,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListVhostsCommand do
   end
 
   def usage, do: "list_vhosts [--no-table-headers] [<column> ...]"
+  def help_section(), do: :access_control
+
+  def description(), do: "Lists virtual hosts"
 
   def usage_additional() do
     "<column> must be one of name, tracing, cluster_state"

--- a/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/node_health_check_command.ex
@@ -70,6 +70,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.NodeHealthCheckCommand do
 
   def usage, do: "node_health_check"
 
+  def help_section(), do: :observability_and_health_checks
+  def description(), do: "Performs several health checks of the target node"
+
   def banner(_, %{node: node_name, timeout: timeout}) do
     ["Timeout: #{trunc(timeout / 1000)} seconds ...", "Checking health of node #{node_name} ..."]
   end

--- a/lib/rabbitmq/cli/ctl/commands/ping_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/ping_command.ex
@@ -66,6 +66,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.PingCommand do
     "ping"
   end
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Checks that the node OS process is up, registered with EPMD and CLI tools can authenticate with it"
+
   def banner([], %{node: node_name, timeout: timeout}) when is_number(timeout) do
     "Will ping #{node_name}. This only checks if the OS process is running and registered with epmd. Timeout: #{
       timeout

--- a/lib/rabbitmq/cli/ctl/commands/purge_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/purge_queue_command.ex
@@ -45,6 +45,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.PurgeQueueCommand do
 
   def usage, do: "purge_queue <queue>"
 
+  def help_section(), do: :queues
+
+  def description(), do: "Purges a queue (removes all messages in it)"
+
   def banner([queue], %{vhost: vhost}) do
     "Purging queue '#{queue}' in vhost '#{vhost}' ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/rename_cluster_node_command.ex
@@ -59,6 +59,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RenameClusterNodeCommand do
     "rename_cluster_node <oldnode1> <newnode1> [oldnode2] [newnode2] ..."
   end
 
+  def help_section(), do: :cluster_management
+
+  def description(), do: "Renames cluster nodes in the local database"
+
   def banner(args, _) do
     [
       "Renaming cluster nodes: \n ",

--- a/lib/rabbitmq/cli/ctl/commands/report_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/report_command.ex
@@ -89,6 +89,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
 
   def usage, do: "report"
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Generate a server status report containing a concatenation of all server status information for support purposes"
+
   def banner(_, %{node: node_name}), do: "Reporting server status of node #{node_name} ..."
 
   #
@@ -104,6 +108,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ReportCommand do
 
   defp info_keys(command) do
     command.info_keys()
-    |> Enum.map(&Atom.to_string/1)
+    |> Enum.map(&to_string/1)
   end
 end

--- a/lib/rabbitmq/cli/ctl/commands/reset_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/reset_command.ex
@@ -33,5 +33,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ResetCommand do
 
   def usage, do: "reset"
 
+  def help_section(), do: :node_management
+
+  def description(), do: "Instructs a RabbitMQ node to leave the cluster and eturn to its virgin state"
+
   def banner(_, %{node: node_name}), do: "Resetting node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/restart_vhost_command.ex
@@ -28,6 +28,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RestartVhostCommand do
   def run([], %{node: node_name, vhost: vhost, timeout: timeout}) do
     :rabbit_misc.rpc_call(node_name, :rabbit_vhost_sup_sup, :start_vhost, [vhost], timeout)
   end
+
   def output({:ok, _pid}, %{vhost: vhost, node: node_name}) do
     {:ok, "Successfully restarted vhost '#{vhost}' on node '#{node_name}'"}
   end
@@ -43,9 +44,13 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RestartVhostCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
+  def usage, do: "restart_vhost [--vhost <vhost>]"
+
+  def help_section(), do: :virtual_hosts
+
+  def description(), do: "Restarts a failed vhost data storage and queues"
+
   def banner(_, %{node: node_name, vhost: vhost}) do
     "Trying to restart vhost '#{vhost}' on node '#{node_name}' ..."
   end
-
-  def usage, do: "restart_vhost [--vhost <vhost>]"
 end

--- a/lib/rabbitmq/cli/ctl/commands/rotate_logs_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/rotate_logs_command.ex
@@ -27,5 +27,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.RotateLogsCommand do
 
   def usage, do: "rotate_logs"
 
+  def help_section(), do: :node_management
+
+  def description(), do: "Instructs the RabbitMQ node to perform internal log rotation"
+
   def banner(_, %{node: node_name}), do: "Rotating logs for node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/set_cluster_name_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_cluster_name_command.ex
@@ -36,4 +36,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetClusterNameCommand do
   end
 
   def usage, do: "set_cluster_name <name>"
+
+  def help_section(), do: :configuration
+
+  def description(), do: "Sets the cluster name to name"
 end

--- a/lib/rabbitmq/cli/ctl/commands/set_disk_free_limit_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_disk_free_limit_command.ex
@@ -87,6 +87,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetDiskFreeLimitCommand do
 
   def usage, do: "set_disk_free_limit <disk_limit>\nset_disk_free_limit mem_relative <fraction>"
 
+  def help_section(), do: :configuration
+
+  def description(), do: "Sets the disk_free_limit setting"
+
   #
   # Implementation
   #

--- a/lib/rabbitmq/cli/ctl/commands/set_global_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_global_parameter_command.ex
@@ -43,6 +43,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetGlobalParameterCommand do
 
   def usage, do: "set_global_parameter <name> <value>"
 
+  def help_section(), do: :parameters
+
+  def description(), do: "Sets a runtime parameter."
+
   def banner([name, value], _) do
     "Setting global runtime parameter \"#{name}\" to \"#{value}\" ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/set_log_level_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_log_level_command.ex
@@ -55,6 +55,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetLogLevelCommand do
 
   def usage, do: "set_log_level <log_level>"
 
+  def help_section(), do: :configuration
+
+  def description(), do: "Sets log level in the running node"
+
   def banner([log_level], _), do: "Setting log level to \"#{log_level}\" ..."
 
   def output({:error, {:invalid_log_level, level}}, _opts) do

--- a/lib/rabbitmq/cli/ctl/commands/set_operator_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_operator_policy_command.ex
@@ -70,6 +70,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetOperatorPolicyCommand do
     ]
   end
 
+  def help_section(), do: :policies
+
+  def description(), do: "Sets an operator policy that overrides a subset of arguments in user policies"
+
   def banner([name, pattern, definition], %{vhost: vhost, priority: priority}) do
     "Setting operator policy override \"#{name}\" for pattern \"#{pattern}\" to \"#{definition}\" with priority \"#{
       priority

--- a/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
@@ -51,6 +51,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetParameterCommand do
 
   def usage, do: "set_parameter [--vhost <vhost>] <component_name> <name> <value>"
 
+  def help_section(), do: :parameters
+
+  def description(), do: "Sets a runtime parameter."
+
   def banner([component_name, name, value], %{vhost: vhost}) do
     "Setting runtime parameter \"#{component_name}\" for component \"#{name}\" to \"#{value}\" in vhost \"#{
       vhost

--- a/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_permissions_command.ex
@@ -50,6 +50,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPermissionsCommand do
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "set_permissions [--vhost <vhost>] <username> <conf> <write> <read>"
+  def help_section(), do: :access_control
+  def description(), do: "Sets user permissions for a vhost"
 
   def banner([user | _], %{vhost: vhost}),
     do: "Setting permissions for user \"#{user}\" in vhost \"#{vhost}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/set_policy_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_policy_command.ex
@@ -67,6 +67,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetPolicyCommand do
     ]
   end
 
+  def help_section(), do: :policies
+
+  def description(), do: "Sets or updates a policy"
+
   def banner([name, pattern, definition], %{vhost: vhost, priority: priority}) do
     "Setting policy \"#{name}\" for pattern \"#{pattern}\" to \"#{definition}\" with priority \"#{
       priority

--- a/lib/rabbitmq/cli/ctl/commands/set_topic_permissions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_topic_permissions_command.ex
@@ -46,6 +46,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetTopicPermissionsCommand do
   def usage,
     do: "set_topic_permissions [--vhost <vhost>] <username> <exchange> <write_pattern> <read_pattern>"
 
+  def help_section(), do: :access_control
+
+  def description(), do: "Sets user topic permissions for an exchange"
+
   def banner([user, exchange, _, _], %{vhost: vhost}),
     do:
       "Setting topic permissions on \"#{exchange}\" for user \"#{user}\" in vhost \"#{vhost}\" ..."

--- a/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_user_tags_command.ex
@@ -40,6 +40,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetUserTagsCommand do
 
   def usage, do: "set_user_tags <username> <tag> [...]"
 
+  def help_section(), do: :user_management
+
+  def description(), do: "Sets user tags"
+
   def banner([user | tags], _) do
     "Setting tags for user \"#{user}\" to [#{tags |> Enum.join(", ")}] ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/set_vhost_limits_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_vhost_limits_command.ex
@@ -37,6 +37,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetVhostLimitsCommand do
 
   def usage, do: "set_vhost_limits [--vhost <vhost>] <definition>"
 
+  def help_section(), do: :virtual_hosts
+
+  def description(), do: "Sets virtual host limits"
+
   def banner([definition], %{vhost: vhost}) do
     "Setting vhost limits to \"#{definition}\" for vhost \"#{vhost}\" ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/set_vm_memory_high_watermark_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_vm_memory_high_watermark_command.ex
@@ -112,6 +112,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetVmMemoryHighWatermarkCommand do
       "set_vm_memory_high_watermark absolute <value>"
     ]
 
+  def help_section(), do: :configuration
+
+  def description(), do: "Sets the vm_memory_high_watermark setting"
+
   def banner(["absolute", arg], %{node: node_name}) do
     "Setting memory threshold on #{node_name} to #{arg} bytes ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/shutdown_command.ex
@@ -64,6 +64,17 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ShutdownCommand do
 
   def usage, do: "shutdown [--wait]"
 
+  def usage_additional() do
+    [
+      "--wait: if set, will wait for target node to terminate (by inferring and monitoring its PID file). Only works for local nodes.",
+      "--no-wait: if set, will not wait for target node to terminate"
+    ]
+  end
+
+  def help_section(), do: :node_management
+
+  def description(), do: "Stops RabbitMQ and its runtime (Erlang VM). Monitors progress for local nodes. Does not require a PID file path."
+
   def banner(_, _), do: nil
 
 

--- a/lib/rabbitmq/cli/ctl/commands/start_app_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/start_app_command.ex
@@ -26,5 +26,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StartAppCommand do
 
   def usage, do: "start_app"
 
+  def help_section(), do: :node_management
+
+  def description(), do: "Starts the RabbitMQ application but leaves the runtime (Erlang VM) running"
+
   def banner(_, %{node: node_name}), do: "Starting node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/status_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/status_command.ex
@@ -31,5 +31,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
 
   def usage, do: "status"
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Displays broker status information"
+
   def banner(_, %{node: node_name}), do: "Status of node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/stop_app_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/stop_app_command.ex
@@ -27,5 +27,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StopAppCommand do
 
   def usage, do: "stop_app"
 
+  def help_section(), do: :node_management
+
+  def description(), do: "Stops the RabbitMQ application, leaving the runtme (Erlang VM) running"
+
   def banner(_, %{node: node_name}), do: "Stopping rabbit application on node #{node_name} ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/stop_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/stop_command.ex
@@ -61,6 +61,17 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StopCommand do
 
   def usage, do: "stop [--idempotent] [<pidfile>]"
 
+  def usage_additional() do
+    [
+      "<pidfile>: node PID file path to monitor. To avoid using a PID file, use 'rabbitmqctl shutdown'",
+      "--idempotent: return success if target node is not running (cannot be contacted)"
+    ]
+  end
+
+  def description(), do: "Stops RabbitMQ and its runtime (Erlang VM). Requires a local node pid file path to monitor progress."
+
+  def help_section(), do: :node_management
+
   def banner([pidfile_path], %{node: node_name}) do
     "Stopping and halting node #{node_name} (will monitor pid file #{pidfile_path}) ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/sync_queue_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/sync_queue_command.ex
@@ -37,6 +37,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SyncQueueCommand do
 
   def usage, do: "sync_queue [--vhost <vhost>] queue"
 
+  def help_section(), do: :replication
+
+  def description(), do: "Instructs a mirrored queue with unsynchronised mirrors (follower replicas) to synchronise them"
+
   def banner([queue], %{vhost: vhost, node: _node}) do
     "Synchronising queue '#{queue}' in vhost '#{vhost}' ..."
   end

--- a/lib/rabbitmq/cli/ctl/commands/trace_off_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/trace_off_command.ex
@@ -34,5 +34,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.TraceOffCommand do
 
   def usage, do: "trace_off [--vhost <vhost>]"
 
+  def help_section(), do: :virtual_hosts
+
   def banner(_, %{vhost: vhost}), do: "Stopping tracing for vhost \"#{vhost}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/trace_on_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/trace_on_command.ex
@@ -34,5 +34,7 @@ use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "trace_on [--vhost <vhost>]"
 
+  def help_section(), do: :virtual_hosts
+
   def banner(_, %{vhost: vhost}), do: "Starting tracing for vhost \"#{vhost}\" ..."
 end

--- a/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/update_cluster_nodes_command.ex
@@ -37,6 +37,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.UpdateClusterNodesCommand do
     "update_cluster_nodes <existing_cluster_member_node_to_seed_from>"
   end
 
+  def help_section(), do: :cluster_management
+
+  def description(), do: "Instructs an already clustered node to contact <clusternode> to cluster when waking up"
+
   def banner([seed_node], %{node: node_name}) do
     "Will seed #{node_name} from #{seed_node} on next start"
   end

--- a/lib/rabbitmq/cli/ctl/commands/version_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/version_command.ex
@@ -39,6 +39,10 @@ defmodule RabbitMQ.CLI.Ctl.Commands.VersionCommand do
   end
   use RabbitMQ.CLI.DefaultOutput
 
+  def help_section, do: :help
+
+  def description, do: "Displays CLI tools version"
+
   def usage, do: "version"
 
   def banner(_, _), do: nil

--- a/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -73,11 +73,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
     )
   end
 
-  def usage, do: "wait [<pid_file>] [--pid|-P <pid>]"
-
-  ## Banners are included in wait steps
-  def banner(_, _), do: nil
-
   def output({:error, err}, _opts) do
     case format_error(err) do
       :undefined -> RabbitMQ.CLI.DefaultOutput.output({:error, err})
@@ -101,6 +96,26 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
   end
 
   use RabbitMQ.CLI.DefaultOutput
+
+  # Banner is printed in wait steps
+  def banner(_, _), do: nil
+
+  def usage, do: "wait [<pidfile>] [--pid|-P <pid>]"
+
+  def usage_additional() do
+    [
+      "<pidfile>: PID file path",
+      "--pid <pid>: operating system PID to monitor"
+    ]
+  end
+
+  def help_section(), do: :node_management
+
+  def description(), do: "Waits for RabbitMQ node startup by monitoring a local PID file. See also 'rabbitmqctl await_online_nodes'"
+
+  #
+  # Implementation
+  #
 
   def wait_for(timeout, fun) do
     sleep = round(timeout / 10)
@@ -144,10 +159,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
         other
     end
   end
-
-  #
-  # Implementation
-  #
 
   defp wait_for_pid_funs(node_name, app_names, timeout, quiet) do
     app_names_formatted = :io_lib.format('~p', [app_names])

--- a/lib/rabbitmq/cli/diagnostics/commands/alarms_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/alarms_command.ex
@@ -77,6 +77,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.AlarmsCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists resource alarms (local or cluster-wide) in effect on the target node"
+
   def usage, do: "alarms"
 
   def banner([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/diagnostics/commands/check_alarms_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/check_alarms_command.ex
@@ -86,6 +86,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckAlarmsCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Health check that exits with a non-zero code if the target node reports any alarms, local or cluster-wide."
+
   def usage, do: "check_alarms"
 
   def banner([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/diagnostics/commands/check_local_alarms_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/check_local_alarms_command.ex
@@ -17,7 +17,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckLocalAlarmsCommand do
   @moduledoc """
   Exits with a non-zero code if the target node reports any local alarms.
 
-  This command meant to be used in health checks.
+  This command is meant to be used in health checks.
   """
 
   alias RabbitMQ.CLI.Core.Helpers
@@ -81,6 +81,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckLocalAlarmsCommand do
   end
 
   use RabbitMQ.CLI.DefaultOutput
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Health check that exits with a non-zero code if the target node reports any local alarms"
 
   def usage, do: "check_local_alarms"
 

--- a/lib/rabbitmq/cli/diagnostics/commands/check_port_connectivity_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/check_port_connectivity_command.ex
@@ -15,10 +15,11 @@
 
 defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
   @moduledoc """
-  Displays all listeners on a node.
+  Checks all listeners on the target node by opening a TCP connection to each
+  and immediately closing it.
 
   Returns a code of 0 unless there were connectivity and authentication
-  errors. This command is not meant to be used in health checks.
+  errors. This command is meant to be used in health checks.
   """
 
   alias RabbitMQ.CLI.Core.Helpers
@@ -100,6 +101,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand do
 
     {:error, Enum.join(lines, Helpers.line_separator())}
   end
+
+  def description(), do: "Basic TCP connectivity health check for each listener's port on the target node"
+
+  def help_section(), do: :observability_and_health_checks
 
   def usage, do: "check_port_connectivity"
 

--- a/lib/rabbitmq/cli/diagnostics/commands/check_port_listener_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/check_port_listener_command.ex
@@ -79,6 +79,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckPortListenerCommand do
        "Found listeners that use the following ports: #{ports}"}
   end
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Health check that exits with a non-zero code if target node does not have an active listener for given port"
+
   def usage, do: "check_port_listener <port>"
 
   def banner([port], %{node: node_name}) do

--- a/lib/rabbitmq/cli/diagnostics/commands/check_protocol_listener_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/check_protocol_listener_command.ex
@@ -87,6 +87,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckProtocolListenerCommand do
        "Found listeners for the following protocols: #{protocols}"}
   end
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Health check that exits with a non-zero code if target node does not have an active listener for given protocol"
+
   def usage, do: "check_protocol_listener <protocol>"
 
   def banner([proto], %{node: node_name}) do

--- a/lib/rabbitmq/cli/diagnostics/commands/check_running_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/check_running_command.ex
@@ -43,6 +43,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CheckRunningCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Health check that exits with a non-zero code if the RabbitMQ app on the target node is not running"
+
   def usage, do: "check_running"
 
   def banner([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -28,8 +28,6 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
 
   def validate(_, _), do: :ok
 
-  def usage, do: "cipher_suites [--openssl-format]"
-
   def run([], %{node: node_name, timeout: timeout, openssl_format: openssl_format}) do
     args = case openssl_format do
       true  -> [:openssl]
@@ -38,8 +36,21 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
     :rabbit_misc.rpc_call(node_name, :ssl, :cipher_suites, args, timeout)
   end
 
+  def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
+
   def banner([], %{openssl_format: true}),  do: "Listing available cipher suites in the OpenSSL format"
   def banner([], %{openssl_format: false}), do: "Listing available cipher suites in the Erlang term format"
 
-  def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists cipher suites available (but not necessarily allowed) on the target node"
+
+  def usage, do: "cipher_suites [--openssl-format] [--erlang-format]"
+
+  def usage_additional() do
+    [
+     "--openssl-format: use OpenSSL cipher suite format",
+     "--erlang-format: use Erlang cipher suite format"
+    ]
+  end
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/discover_peers_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/discover_peers_command.ex
@@ -35,6 +35,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.DiscoverPeersCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Performs peer discovery and lists discovered nodes, if any"
+
   def usage, do: "discover_peers"
 
   def banner(_, _), do: "Discovering peers nodes ..."

--- a/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_hash_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_hash_command.ex
@@ -28,9 +28,13 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieHashCommand do
     {:ok, result}
   end
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Displays a hash of the Erlang cookie (shared secret) used by the target node"
+
+  def usage, do: "erlang_cookie_hash"
+
   def banner([], %{node: node_name}) do
     "Asking node #{node_name} its Erlang cookie hash..."
   end
-
-  def usage, do: "erlang_cookie_hash"
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/erlang_version_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/erlang_version_command.ex
@@ -41,9 +41,18 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangVersionCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Displays Erlang/OTP version on the target node"
+
+  def usage, do: "erlang_version"
+
+  def usage_additional() do
+    "--details: when set, display additional Erlang/OTP system information"
+  end
+
+
   def banner([], %{node: node_name}) do
     "Asking node #{node_name} for its Erlang/OTP version..."
   end
-
-  def usage, do: "erlang_version"
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/is_booting_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/is_booting_command.ex
@@ -35,6 +35,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.IsBootingCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Checks if RabbitMQ is still booting on the target node"
+
   def usage, do: "is_booting"
 
   def banner([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/diagnostics/commands/is_running_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/is_running_command.ex
@@ -37,6 +37,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.IsRunningCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Checks if RabbitMQ is fully booted and running on the target node"
+
   def usage, do: "is_running"
 
   def banner([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/diagnostics/commands/listeners_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/listeners_command.ex
@@ -70,8 +70,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ListenersCommand do
     {:ok, "Node #{node_name} reported no enabled listeners."}
   end
 
-  def output(listeners, %{formatter: "json"}) do
-    {:ok, %{"result" => "ok", "listeners" => listener_maps(listeners)}}
+  def output(listeners, %{node: node_name, formatter: "json"}) do
+    {:ok, %{"result" => "ok", "node" => node_name, "listeners" => listener_maps(listeners)}}
   end
 
   def output(listeners, %{formatter: "csv"}) do
@@ -83,6 +83,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ListenersCommand do
 
     {:ok, Enum.join(lines, Helpers.line_separator())}
   end
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists active connection listeners (bound interface, port, protocol) on the target node"
 
   def usage, do: "listeners"
 

--- a/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/maybe_stuck_command.ex
@@ -26,9 +26,13 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MaybeStuckCommand do
     :rabbit_misc.rpc_call(node_name, :rabbit_diagnostics, :maybe_stuck, [], timeout)
   end
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Detects Erlang processes (\"lightweight threads\") potentially not making progress on the target node"
+
+  def usage, do: "maybe_stuck"
+
   def banner(_, %{node: node_name}) do
     "Asking node #{node_name} to detect potentially stuck Erlang processes..."
   end
-
-  def usage, do: "maybe_stuck"
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/memory_breakdown_command.ex
@@ -67,7 +67,18 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand do
     {:ok, compute_relative_values(result)}
   end
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Provides a memory usage breakdown on the target node."
+
   def usage, do: "memory_breakdown [--unit <unit>]"
+
+  def usage_additional() do
+    [
+      "--unit <bytes | mb | gb>: byte multiple (bytes, megabytes, gigabytes) to use",
+      "--formatter <json | csv>: alternative formatter to use, JSON or CSV"
+    ]
+  end
 
   def banner([], %{node: node_name}) do
     "Reporting memory breakdown on node #{node_name}..."

--- a/lib/rabbitmq/cli/diagnostics/commands/runtime_thread_stats_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/runtime_thread_stats_command.ex
@@ -51,11 +51,19 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.RuntimeThreadStatsCommand do
     {:ok, result}
   end
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Provides a breakdown of runtime thread activity stats on the target node"
+
+  def usage, do: "runtime_thread_stats [--sample-interval <interval>]"
+
+  def usage_additional() do
+    "--sample-interval <seconds>: sampling interval to use in seconds"
+  end
+
   def banner([], %{node: node_name, sample_interval: interval}) do
     "Will collect runtime thread stats on #{node_name} for #{interval} seconds..."
   end
-
-  def usage, do: "runtime_thread_stats [--sample-interval <interval>]"
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Msacc
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/server_version_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/server_version_command.ex
@@ -30,6 +30,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ServerVersionCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Displays server version on the target node"
+
   def usage, do: "server_version"
 
   def banner([], %{node: node_name}) do

--- a/lib/rabbitmq/cli/diagnostics/commands/tls_versions_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/tls_versions_command.ex
@@ -38,6 +38,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.TlsVersionsCommand do
     {:ok, vs}
   end
 
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists TLS versions supported (but not necessarily allowed) on the target node"
+
   def usage, do: "tls_versions"
 
   def formatter(), do: RabbitMQ.CLI.Formatters.StringPerLine

--- a/lib/rabbitmq/cli/formatter_behaviour.ex
+++ b/lib/rabbitmq/cli/formatter_behaviour.ex
@@ -26,6 +26,14 @@ defmodule RabbitMQ.CLI.FormatterBehaviour do
   @callback switches() :: Keyword.t()
   @callback aliases() :: Keyword.t()
 
+  def switches(formatter) do
+    Helpers.apply_if_exported(formatter, :switches, [], [])
+  end
+
+  def aliases(formatter) do
+    Helpers.apply_if_exported(formatter, :aliases, [], [])
+  end
+
   def module_name(nil) do
     nil
   end

--- a/lib/rabbitmq/cli/formatters/report.ex
+++ b/lib/rabbitmq/cli/formatters/report.ex
@@ -47,7 +47,7 @@ defmodule RabbitMQ.CLI.Formatters.Report do
   end
 
   def format_result(command, output, options) do
-    formatter = Config.default_formatter(command)
+    formatter = Config.get_formatter(command, options)
 
     case Output.format_output(output, formatter, options) do
       :ok -> []

--- a/lib/rabbitmq/cli/plugins/commands/directories_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/directories_command.ex
@@ -63,16 +63,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
     Validators.node_is_running(args, opts)
   end
 
-  def usage, do: "directories [--offline] [--online]"
-
-  def banner([], %{offline: true}) do
-    "Listing plugin directories inferred from local environment..."
-  end
-
-  def banner([], %{online: true, node: node}) do
-    "Listing plugin directories used by node #{node}"
-  end
-
   def run([], %{online: true, node: node_name}) do
     do_run(fn key ->
       :rabbit_misc.rpc_call(node_name, :rabbit_plugins, key, [])
@@ -104,6 +94,31 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
   end
 
   use RabbitMQ.CLI.DefaultOutput
+
+  def banner([], %{offline: true}) do
+    "Listing plugin directories inferred from local environment..."
+  end
+
+  def banner([], %{online: true, node: node}) do
+    "Listing plugin directories used by node #{node}"
+  end
+
+  def usage, do: "directories [--offline] [--online]"
+
+  def usage_additional() do
+    [
+      "--offline: do not contact target node. Try to infer directories from the environment.",
+      "--online: infer directories from target node."
+    ]
+  end
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Displays plugin directory and enabled plugin file paths"
+
+  #
+  # Implementation
+  #
 
   defp do_run(fun) do
     # return an error or an {:ok, map} tuple

--- a/lib/rabbitmq/cli/plugins/commands/disable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/disable_command.ex
@@ -58,16 +58,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
     )
   end
 
-  def usage, do: "disable <plugin>|--all [--offline] [--online]"
-
-  def banner([], %{all: true, node: node_name}) do
-    "Disabling ALL plugins on node #{node_name}"
-  end
-
-  def banner(plugins, %{node: node_name}) do
-    ["Disabling plugins on node #{node_name}:" | plugins]
-  end
-
   def run(plugin_names, %{all: all_flag, node: node_name} = opts) do
     plugins =
       case all_flag do
@@ -112,6 +102,35 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
     end
   end
 
+  use RabbitMQ.CLI.Plugins.ErrorOutput
+
+  def banner([], %{all: true, node: node_name}) do
+    "Disabling ALL plugins on node #{node_name}"
+  end
+
+  def banner(plugins, %{node: node_name}) do
+    ["Disabling plugins on node #{node_name}:" | plugins]
+  end
+
+  def usage, do: "disable <plugin1> [ <plugin2>] | --all [--offline] [--online]"
+
+  def usage_additional() do
+    [
+      "<plugin1> [ <plugin2>]: names of plugins to disable separated by a space",
+      "--online: contact target node to disable the plugins. Changes are applied immediately.",
+      "--offline: update enabled plugins file directly without contacting target node. Changes will be delayed until the node is restarted.",
+      "--all: disable all currently enabled plugins"
+    ]
+  end
+
+  def help_section(), do: :plugin_management
+
+  def description(), do: "Disables one or more plugins"
+
+  #
+  # Implementation
+  #
+
   defp filter_strictly_plugins(map, _all, []) do
     map
   end
@@ -126,6 +145,4 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DisableCommand do
         filter_strictly_plugins(Map.put(map, head, value), all, tail)
     end
   end
-
-  use RabbitMQ.CLI.Plugins.ErrorOutput
 end

--- a/lib/rabbitmq/cli/plugins/commands/enable_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/enable_command.ex
@@ -58,16 +58,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
     )
   end
 
-  def usage, do: "enable <plugin>|--all [--offline] [--online]"
-
-  def banner([], %{all: true, node: node_name}) do
-    "Enabling ALL plugins on node #{node_name}"
-  end
-
-  def banner(plugins, %{node: node_name}) do
-    ["Enabling plugins on node #{node_name}:" | plugins]
-  end
-
   def run(plugin_names, %{all: all_flag} = opts) do
     plugins =
       case all_flag do
@@ -80,6 +70,35 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
       other -> other
     end
   end
+
+  use RabbitMQ.CLI.Plugins.ErrorOutput
+
+  def banner([], %{all: true, node: node_name}) do
+    "Enabling ALL plugins on node #{node_name}"
+  end
+
+  def banner(plugins, %{node: node_name}) do
+    ["Enabling plugins on node #{node_name}:" | plugins]
+  end
+
+  def usage, do: "enable <plugin1> [ <plugin2>] | --all [--offline] [--online]"
+
+  def usage_additional() do
+    [
+      "<plugin1> [ <plugin2>]: names of plugins to enable separated by a space",
+      "--online: contact target node to enable the plugins. Changes are applied immediately.",
+      "--offline: update enabled plugins file directly without contacting target node. Changes will be delayed until the node is restarted.",
+      "--all: enable all available plugins. Not recommended as some plugins may conflict or otherwise be incompatible!"
+    ]
+  end
+
+  def help_section(), do: :plugin_management
+
+  def description(), do: "Enables one or more plugins"
+
+  #
+  # Implementation
+  #
 
   def do_run(plugins, %{node: node_name} = opts) do
     enabled = PluginHelpers.read_enabled(opts)
@@ -136,6 +155,4 @@ defmodule RabbitMQ.CLI.Plugins.Commands.EnableCommand do
         filter_strictly_plugins(Map.put(map, head, value), all, tail)
     end
   end
-
-  use RabbitMQ.CLI.Plugins.ErrorOutput
 end

--- a/lib/rabbitmq/cli/plugins/commands/list_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/list_command.ex
@@ -55,10 +55,6 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
     )
   end
 
-  def usage, do: "list [pattern] [--verbose] [--minimal] [--enabled] [--implicitly-enabled]"
-
-  def banner([pattern], _), do: "Listing plugins with pattern \"#{pattern}\" ..."
-
   def run([pattern], %{node: node_name} = opts) do
     %{verbose: verbose, minimal: minimal, enabled: only_enabled, implicitly_enabled: all_enabled} =
       opts
@@ -117,6 +113,29 @@ defmodule RabbitMQ.CLI.Plugins.Commands.ListCommand do
       plugins: format_plugins(plugins, format, enabled, enabled_implicitly, running)
     }
   end
+
+  def banner([pattern], _), do: "Listing plugins with pattern \"#{pattern}\" ..."
+
+  def usage, do: "list [pattern] [--verbose] [--minimal] [--enabled] [--implicitly-enabled]"
+
+  def usage_additional() do
+    [
+      "<pattern>: only list plugins that match a regular expression pattern",
+      "--verbose: output more information",
+      "--minimal: only print plugin names. Most useful in compbination with --silent and --enabled.",
+      "--enabled: only list enabled plugins",
+      "--implicitly-enabled: include plugins enabled as dependencies of other plugins"
+    ]
+  end
+
+
+  def help_section(), do: :plugin_management
+
+  def description(), do: "Lists plugins and their state"
+
+  #
+  # Implementation
+  #
 
   defp remote_running_plugins(node) do
     case :rabbit_misc.rpc_call(node, :rabbit_plugins, :running_plugins, []) do

--- a/test/ctl/help_command_test.exs
+++ b/test/ctl/help_command_test.exs
@@ -28,7 +28,9 @@ defmodule HelpCommandTest do
   end
 
   test "run: prints basic usage info" do
-    assert @command.run([], %{}) =~ ~r/Default node is \"rabbit@server\"/
+    output = @command.run([], %{})
+    assert output =~ ~r/[-n <node>] [-t <timeout>]/
+    assert output =~ ~r/commands/i
   end
 
   test "run: ctl command usage info is printed if command is specified" do
@@ -47,7 +49,7 @@ defmodule HelpCommandTest do
   end
 
   test "run prints command info" do
-    assert @command.run([], %{}) =~ ~r/Commands:\n/
+    assert @command.run([], %{}) =~ ~r/commands/i
 
     # Checks to verify that each module's command appears in the list.
     ctl_commands = CommandModules.module_map
@@ -59,24 +61,8 @@ defmodule HelpCommandTest do
     Enum.each(
       ctl_commands,
       fn(command) ->
-        assert @command.run([], %{}) =~ ~r/\n    #{command}.*\n/
+        assert @command.run([], %{}) =~ ~r/\n\s+#{command}.*\n/
       end)
-  end
-
-  test "run: sorts commands alphabetically" do
-    [cmd1, cmd2, cmd3] = CommandModules.module_map
-    |> Map.keys
-    |> Enum.sort
-    |> Enum.take(3)
-
-    output = @command.run([], %{})
-
-    {start1, _} = :binary.match(output, cmd1)
-    {start2, _} = :binary.match(output, cmd2)
-    {start3, _} = :binary.match(output, cmd3)
-
-    assert start1 < start2
-    assert start2 < start3
   end
 
   test "run: exits with code of OK" do
@@ -85,10 +71,10 @@ defmodule HelpCommandTest do
   end
 
   test "run: no arguments print general help" do
-    assert @command.run([], %{}) =~ ~r/Usage:/
+    assert @command.run([], %{}) =~ ~r/usage/i
   end
 
   test "run: unrecognised arguments print general help" do
-    assert @command.run(["extra1", "extra2"], %{}) =~ ~r/Usage:/
+    assert @command.run(["extra1", "extra2"], %{}) =~ ~r/usage/i
   end
 end

--- a/test/rabbitmqctl_test.exs
+++ b/test/rabbitmqctl_test.exs
@@ -35,7 +35,7 @@ defmodule RabbitMQCtlTest do
     command = ["status", "--help"]
     assert capture_io(fn ->
       error_check(command, exit_ok())
-    end) =~ ~r/Usage:/
+    end) =~ ~r/Usage/
   end
 
 ## ------------------------ Error Messages ------------------------------------
@@ -68,28 +68,28 @@ defmodule RabbitMQCtlTest do
     command = []
     assert capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/\nUsage:\n/
+    end) =~ ~r/usage/i
   end
 
   test "when invoked with only a --help, shows a generic usage message and exits with a success" do
     command = ["--help"]
     assert capture_io(:stdio, fn ->
       error_check(command, exit_ok())
-    end) =~ ~r/\nUsage:\n/
+    end) =~ ~r/usage/i
   end
 
   test "when invoked with --help [command], shows a generic usage message and exits with a success" do
     command = ["--help", "status"]
     assert capture_io(:stdio, fn ->
       error_check(command, exit_ok())
-    end) =~ ~r/\nUsage:\n/
+    end) =~ ~r/usage/i
   end
 
   test "Empty command with options shows usage, and exit with usage exit code" do
     command = ["-n", "sandwich@pastrami"]
     assert capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/\nUsage:\n/
+    end) =~ ~r/usage/i
   end
 
   test "Short names without host connect properly" do
@@ -101,21 +101,27 @@ defmodule RabbitMQCtlTest do
     command = ["not_real"]
     assert capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/\nUsage\:/
+    end) =~ ~r/Usage/
   end
 
   test "Extraneous arguments return a usage error" do
     command = ["status", "extra"]
-    assert capture_io(:stderr, fn ->
+    output = capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/given:\n\t.*\n\nUsage:\n.* status/
+    end)
+    assert output =~ ~r/too many arguments/
+    assert output =~ ~r/Usage/
+    assert output =~ ~r/status/
   end
 
   test "Insufficient arguments return a usage error" do
     command = ["list_user_permissions"]
-    assert capture_io(:stderr, fn ->
+    output = capture_io(:stderr, fn ->
       error_check(command, exit_usage())
-    end) =~ ~r/given:\n\t.*\n\nUsage:\n.* list_user_permissions/
+    end)
+    assert output =~ ~r/not enough arguments/
+    assert output =~ ~r/Usage/
+    assert output =~ ~r/list_user_permissions/
   end
 
   test "A bad argument returns a data error" do


### PR DESCRIPTION
This backports the help command, command list table, related
core infra (CommandBehaviour improvements) and command-specific
documentation from master.

This only changes the help command and --help behavior, which are
considered documentation and thus appropriate for a patch release.

Per discussion with the team.

Plugin-provided CLI commands need to be updated to show up in the new categorized command
list.