### PR TITLE
Feature flag commands: handle missing rabbit_ff_extra modules on target node

### DIFF
--- a/lib/rabbitmq/cli/core/exit_codes.ex
+++ b/lib/rabbitmq/cli/core/exit_codes.ex
@@ -57,5 +57,6 @@ defmodule RabbitMQ.CLI.Core.ExitCodes do
   def exit_code_for({:badrpc_multi, :nodedown, _}), do: exit_unavailable()
   def exit_code_for({:badrpc, :nodedown}), do: exit_unavailable()
   def exit_code_for({:node_name, _}), do: exit_dataerr()
+  def exit_code_for({:incompatible_version, _, _}), do: exit_unavailable()
   def exit_code_for({:error, _}), do: exit_unavailable()
 end

--- a/lib/rabbitmq/cli/ctl/commands/list_feature_flags_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_feature_flags_command.ex
@@ -15,7 +15,7 @@
 
 
 defmodule RabbitMQ.CLI.Ctl.Commands.ListFeatureFlagsCommand do
-  alias RabbitMQ.CLI.Core.{DocGuide, Validators, Version}
+  alias RabbitMQ.CLI.Core.{DocGuide, Validators}
   alias RabbitMQ.CLI.Ctl.InfoKeys
 
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/ctl/commands/list_feature_flags_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_feature_flags_command.ex
@@ -52,13 +52,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListFeatureFlagsCommand do
 
   def run([_|_] = args, %{node: node_name, timeout: timeout}) do
     case :rabbit_misc.rpc_call(node_name, :rabbit_ff_extra, :cli_info, [], timeout) do
-      # server version does not provide rabbit_ff_extra
-      {:badrpc, {:EXIT, {:undef, _}}} ->
-        case Version.remote_version(node_name, timeout) do
-          {:badrpc, _} = err -> err
-          remote_vsn         ->
-            {:error, {:incompatible_version, Version.local_version(), remote_vsn}}
-        end
+      # Server does not support feature flags, consider none are available.
+      # See rabbitmq/rabbitmq-cli#344 for context. MK.
+      {:badrpc, {:EXIT, {:undef, _}}} -> []
       {:badrpc, _} = err    -> err
       val                   -> filter_by_arg(val, args)
     end

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -427,6 +427,10 @@ defmodule RabbitMQCtl do
     {:error, ExitCodes.exit_code_for(result), "Virtual host '#{vhost}' does not exist"}
   end
 
+  defp format_error({:error, {:incompatible_version, local_version, remote_version} = result}, _opts, _) do
+    {:error, ExitCodes.exit_code_for(result), "Detected potential version incompatibility. CLI tool version: #{local_version}, server: #{remote_version}"}
+  end
+
   defp format_error({:error, {:timeout, to} = result}, opts, module) do
     op = CommandModules.module_to_command(module)
 

--- a/test/ctl/enable_feature_flag_test.exs
+++ b/test/ctl/enable_feature_flag_test.exs
@@ -36,7 +36,7 @@ defmodule EnableFeatureFlagCommandTest do
   end
 
   test "validate: passing an empty string for feature_flag name is an arg error", context do
-    assert @command.validate([""], context[:opts]) == {:validation_failure, {:bad_argument, "feature_flag cannot be empty string."}}
+    assert match?({:validation_failure, {:bad_argument, _}}, @command.validate([""], context[:opts]))
   end
 
   test "run: passing a valid feature_flag name to a running RabbitMQ node succeeds", context do


### PR DESCRIPTION
This makes `ctl list_feature_flags` handle missing rabbit_ff_extra modules on target node.

@dumbbell @lukebakken @gerhard  if this is the behavior we want I will extend it to more commands. Alternatively we could return an empty list of feature flags (this may be more operator-friendly during upgrades).

[#163980302]