### PR TITLE
Add a flag to cipher_suites command to get all ciphers. Add --format flag to select format. Remove openssl_format flag

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -56,19 +56,19 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
-  def banner([], %{format: "openssl"}),  do: "Listing available cipher suites in the OpenSSL format"
-  def banner([], %{format: "erlang"}), do: "Listing available cipher suites in the Erlang term format"
-  def banner([], %{format: "map"}), do: "Listing available cipher suites in the new map-based format"
+  def banner([], %{format: "openssl"}),  do: "Listing available cipher suites in OpenSSL format"
+  def banner([], %{format: "erlang"}), do: "Listing available cipher suites in Erlang term format"
+  def banner([], %{format: "map"}), do: "Listing available cipher suites in map format"
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Lists cipher suites available (but not necessarily allowed) on the target node"
+  def description(), do: "Lists available (but not necessarily enabled) cipher suites on the target node"
 
   def usage, do: "cipher_suites [--format (openssl | erlang | map)] [--all]"
 
   def usage_additional() do
     [
-      ["--format", "an output format to use. Can be either openssl, erlang or map. Case insensitive"],
+      ["--format", "output format to use: openssl, erlang or map"],
       ["--all", "list all available suites"]
     ]
   end

--- a/test/diagnostics/cipher_suites_command_test.exs
+++ b/test/diagnostics/cipher_suites_command_test.exs
@@ -30,50 +30,37 @@ defmodule CipherSuitesCommandTest do
     {:ok, opts: %{
         node: get_rabbit_hostname(),
         timeout: context[:test_timeout] || 30000,
-        openssl_format: true,
-        erlang_format: false,
-        map_format: false,
+        format: context[:format] || "openssl",
         all: false
       }}
   end
 
-  test "validate: providing no arguments passes validation", context do
+  test "merge_defaults: defaults to the OpenSSL format" do
+    assert @command.merge_defaults([], %{}) == {[], %{format: "openssl", all: false}}
+  end
+
+  test "merge_defaults: format is case insensitive" do
+    assert @command.merge_defaults([], %{format: "OpenSSL"}) == {[], %{format: "openssl", all: false}}
+    assert @command.merge_defaults([], %{format: "Erlang"}) == {[], %{format: "erlang", all: false}}
+    assert @command.merge_defaults([], %{format: "Map"}) == {[], %{format: "map", all: false}}
+  end
+
+  test "merge_defaults: Can specify format" do
+    assert @command.merge_defaults([], %{format: "map"}) == {[], %{format: "map", all: false}}
+  end
+
+  test "validate: treats positional arguments as a failure", context do
+    assert @command.validate(["extra-arg"], context[:opts]) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success", context do
     assert @command.validate([], context[:opts]) == :ok
   end
 
-  test "validate: providing --openssl-format passes validation", context do
-    assert @command.validate([], Map.merge(context[:opts], %{openssl_format: true})) == :ok
-  end
-
-  test "validate: providing --erlang-format passes validation", context do
-    assert @command.validate([], Map.merge(context[:opts], %{erlang_format: true, openssl_format: false})) == :ok
-  end
-
-  test "validate: providing any arguments fails validation", context do
-    assert @command.validate(["a", "b", "c"], context[:opts]) ==
-      {:validation_failure, :too_many_args}
-  end
-
-  test "validate: setting all formats to false fails validation", context do
-    assert @command.validate([], Map.merge(context[:opts],
-                                           %{openssl_format: false,
-                                             erlang_format: false,
-                                             map_format: false})) ==
-      {:validation_failure, {:bad_argument, "At least one format must be selected"}}
-  end
-
-  test "validate: setting both --openssl-format and --erlang-format to true fails validation", context do
-    assert @command.validate([], Map.merge(context[:opts], %{openssl_format: true, erlang_format: true})) ==
-      {:validation_failure, {:bad_argument, "Cannot use multiple formats together"}}
-  end
-
-  test "validate: treats empty positional arguments and default switches as a success" do
-    assert @command.validate([], %{openssl_format: true,
-                                   erlang_format: false}) == :ok
-  end
-
-  test "validate: treats empty positional arguments Erlang term format flag and default flag as a success" do
-    assert @command.validate([], %{erlang_format: true}) == :ok
+  test "validate: supports openssl, erlang and map formats", context do
+    assert @command.validate([], Map.merge(context[:opts], %{format: "openssl"})) == :ok
+    assert @command.validate([], Map.merge(context[:opts], %{format: "erlang"})) == :ok
+    assert @command.validate([], Map.merge(context[:opts], %{format: "map"})) == :ok
   end
 
   @tag test_timeout: 3000
@@ -81,6 +68,7 @@ defmodule CipherSuitesCommandTest do
     assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
   end
 
+  @tag format: "openssl"
   test "run: returns a list of cipher suites in OpenSSL format", context do
     res = @command.run([], context[:opts])
     for cipher <- res, do: assert true == is_list(cipher)
@@ -89,9 +77,9 @@ defmodule CipherSuitesCommandTest do
     assert length(res) > 0
   end
 
+  @tag format: "erlang"
   test "run: returns a list of cipher suites in erlang format", context do
-    res = @command.run([], Map.merge(context[:opts], %{openssl_format: false,
-                                                       erlang_format: true}))
+    res = @command.run([], context[:opts])
 
     for cipher <- res, do: assert true = is_tuple(cipher)
     # the list is long and its values are environment-specific,
@@ -99,9 +87,9 @@ defmodule CipherSuitesCommandTest do
     assert length(res) > 0
   end
 
+  @tag format: "map"
   test "run: returns a list of cipher suites in map format", context do
-    res = @command.run([], Map.merge(context[:opts], %{openssl_format: false,
-                                                       map_format: true}))
+    res = @command.run([], context[:opts])
     for cipher <- res, do: assert true = is_map(cipher)
     # the list is long and its values are environment-specific,
     # so we simply assert that it is non-empty. MK.

--- a/test/diagnostics/cipher_suites_command_test.exs
+++ b/test/diagnostics/cipher_suites_command_test.exs
@@ -45,7 +45,7 @@ defmodule CipherSuitesCommandTest do
     assert @command.merge_defaults([], %{format: "Map"}) == {[], %{format: "map", all: false}}
   end
 
-  test "merge_defaults: Can specify format" do
+  test "merge_defaults: format can be overridden" do
     assert @command.merge_defaults([], %{format: "map"}) == {[], %{format: "map", all: false}}
   end
 

--- a/test/diagnostics/cipher_suites_command_test.exs
+++ b/test/diagnostics/cipher_suites_command_test.exs
@@ -30,8 +30,10 @@ defmodule CipherSuitesCommandTest do
     {:ok, opts: %{
         node: get_rabbit_hostname(),
         timeout: context[:test_timeout] || 30000,
-        openssl_format: context[:openssl_format] || true,
-        erlang_format: context[:erlang_format] || false
+        openssl_format: true,
+        erlang_format: false,
+        map_format: false,
+        all: false
       }}
   end
 
@@ -40,11 +42,11 @@ defmodule CipherSuitesCommandTest do
   end
 
   test "validate: providing --openssl-format passes validation", context do
-    assert @command.validate([], Map.merge(%{openssl_format: true}, context[:opts])) == :ok
+    assert @command.validate([], Map.merge(context[:opts], %{openssl_format: true})) == :ok
   end
 
   test "validate: providing --erlang-format passes validation", context do
-    assert @command.validate([], Map.merge(%{erlang_format: true}, context[:opts])) == :ok
+    assert @command.validate([], Map.merge(context[:opts], %{erlang_format: true, openssl_format: false})) == :ok
   end
 
   test "validate: providing any arguments fails validation", context do
@@ -52,21 +54,25 @@ defmodule CipherSuitesCommandTest do
       {:validation_failure, :too_many_args}
   end
 
-  test "validate: setting both --openssl-format and --erlang-format to false fails validation", context do
-    assert @command.validate([], Map.merge(context[:opts], %{openssl_format: false, erlang_format: false})) ==
-      {:validation_failure, {:bad_argument, "Either OpenSSL or Erlang term format must be selected"}}
+  test "validate: setting all formats to false fails validation", context do
+    assert @command.validate([], Map.merge(context[:opts],
+                                           %{openssl_format: false,
+                                             erlang_format: false,
+                                             map_format: false})) ==
+      {:validation_failure, {:bad_argument, "At least one format must be selected"}}
   end
 
   test "validate: setting both --openssl-format and --erlang-format to true fails validation", context do
     assert @command.validate([], Map.merge(context[:opts], %{openssl_format: true, erlang_format: true})) ==
-      {:validation_failure, {:bad_argument, "Cannot use both formats together"}}
+      {:validation_failure, {:bad_argument, "Cannot use multiple formats together"}}
   end
 
   test "validate: treats empty positional arguments and default switches as a success" do
-    assert @command.validate([], %{openssl_format: true, erlang_format: false}) == :ok
+    assert @command.validate([], %{openssl_format: true,
+                                   erlang_format: false}) == :ok
   end
 
-  test "validate: treats empty positional arguments and an Erlang term format flag as a success" do
+  test "validate: treats empty positional arguments Erlang term format flag and default flag as a success" do
     assert @command.validate([], %{erlang_format: true}) == :ok
   end
 
@@ -75,17 +81,40 @@ defmodule CipherSuitesCommandTest do
     assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
   end
 
-  test "run: returns a list of cipher suites", context do
+  test "run: returns a list of cipher suites in OpenSSL format", context do
     res = @command.run([], context[:opts])
+    for cipher <- res, do: assert true == is_list(cipher)
     # the list is long and its values are environment-specific,
     # so we simply assert that it is non-empty. MK.
     assert length(res) > 0
   end
 
-  @tag openssl_format: true
-  test "run: returns a list cipher suites in the OpenSSL format", context do
-    res = @command.run([], context[:opts])
-    # see the test above
+  test "run: returns a list of cipher suites in erlang format", context do
+    res = @command.run([], Map.merge(context[:opts], %{openssl_format: false,
+                                                       erlang_format: true}))
+
+    for cipher <- res, do: assert true = is_tuple(cipher)
+    # the list is long and its values are environment-specific,
+    # so we simply assert that it is non-empty. MK.
     assert length(res) > 0
   end
+
+  test "run: returns a list of cipher suites in map format", context do
+    res = @command.run([], Map.merge(context[:opts], %{openssl_format: false,
+                                                       map_format: true}))
+    for cipher <- res, do: assert true = is_map(cipher)
+    # the list is long and its values are environment-specific,
+    # so we simply assert that it is non-empty. MK.
+    assert length(res) > 0
+  end
+
+  test "run: returns more cipher suites when all suites requested", context do
+    all_suites_opts = Map.merge(context[:opts], %{all: true})
+    default_suites_opts = Map.merge(context[:opts], %{all: false})
+    all_suites = @command.run([], all_suites_opts)
+    default_suites = @command.run([], default_suites_opts)
+    assert length(all_suites) > length(default_suites)
+    assert length(default_suites -- all_suites) == 0
+  end
+
 end


### PR DESCRIPTION
Support new map format for cipher suites added in OTP-20.3
Support `--all` flag to get all available ciphers

Addresses #342
Depends on changes in rabbitmq-server https://github.com/rabbitmq/rabbitmq-server/pull/1991