### PR TITLE
Add a flag to cipher_suites command to return all available suites. Add format flag to select suite format. 3.7

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -19,13 +19,17 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
 
   def merge_defaults(args, opts) do
     format_opts = case opts do
-      %{openssl_format: true} -> %{format: "openssl"};
-      %{}                     -> %{format: "erlang"}
+      %{openssl_format: true} -> %{format: "openssl", all: false};
+      %{}                     -> %{format: "erlang", all: false}
     end
     {args, Map.merge(format_opts,
-                     Map.merge(%{all: false},
-                               Map.delete(opts, :openssl_format)))}
+                     Map.delete(case_insensitive_format(opts), :openssl_format))}
   end
+
+  defp case_insensitive_format(%{format: format} = opts) do
+    %{ opts | format: String.downcase(format) }
+  end
+  defp case_insensitive_format(opts), do: opts
 
   def switches(), do: [timeout: :integer,
                        openssl_format: :boolean,

--- a/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -17,40 +17,122 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
   @behaviour RabbitMQ.CLI.CommandBehaviour
   use RabbitMQ.CLI.DefaultOutput
 
-  def merge_defaults(args, opts), do: {args, Map.merge(%{openssl_format: false}, opts)}
+  def merge_defaults(args, opts) do
+    format_opts = case opts do
+      %{openssl_format: true} -> %{format: "openssl"};
+      %{}                     -> %{format: "erlang"}
+    end
+    {args, Map.merge(format_opts,
+                     Map.merge(%{all: false},
+                               Map.delete(opts, :openssl_format)))}
+  end
 
-  def switches(), do: [openssl_format: :boolean, timeout: :integer]
+  def switches(), do: [timeout: :integer,
+                       openssl_format: :boolean,
+                       format: :string,
+                       all: :boolean]
   def aliases(), do: [t: :timeout]
 
+  def validate(_, %{format: format})
+      when format != "openssl" and format != "erlang" and format != "map" do
+    {:validation_failure, {:bad_argument, "Format should be either openssl, erlang or map"}}
+  end
   def validate(args, _) when length(args) > 0 do
     {:validation_failure, :too_many_args}
   end
 
   def validate(_, _), do: :ok
 
-  def run([], %{node: node_name, timeout: timeout, openssl_format: openssl_format}) do
-    args = case openssl_format do
-      true  -> [:openssl]
-      false -> []
+  def run([], %{node: node_name, timeout: timeout, format: format} = opts) do
+    {mod, function} = case format do
+      "openssl" -> {:rabbit_ssl, :cipher_suites_openssl};
+      "erlang"  -> {:rabbit_ssl, :cipher_suites_erlang};
+      "map"     -> {:rabbit_ssl, :cipher_suites}
     end
-    :rabbit_misc.rpc_call(node_name, :ssl, :cipher_suites, args, timeout)
+    args = case opts do
+      %{all: true} -> [:all];
+      %{}          -> [:default]
+    end
+    :rabbit_misc.rpc_call(node_name, mod, function, args, timeout)
   end
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
-  def banner([], %{openssl_format: true}),  do: "Listing available cipher suites in the OpenSSL format"
-  def banner([], %{openssl_format: false}), do: "Listing available cipher suites in the Erlang term format"
+  def banner([], %{format: "openssl"}),  do: "Listing available cipher suites in the OpenSSL format"
+  def banner([], %{format: "erlang"}), do: "Listing available cipher suites in the Erlang term format"
+  def banner([], %{format: "map"}), do: "Listing available cipher suites in the new map-based format"
 
   def help_section(), do: :observability_and_health_checks
 
   def description(), do: "Lists cipher suites available (but not necessarily allowed) on the target node"
 
-  def usage, do: "cipher_suites [--openssl-format] [--erlang-format]"
+  def usage, do: "cipher_suites [--format (openssl | erlang | map)] [--all]"
 
   def usage_additional() do
     [
-      ["--openssl-format", "use OpenSSL cipher suite format"],
-      ["--erlang-format", "use Erlang cipher suite format"]
+      ["--format", "an output format to use. Can be either openssl, erlang or map"],
+      ["--all", "list all available suites"],
+      ["--openssl_format", "use OpenSSL format. Deprecated: use --format=openssl instead"]
     ]
   end
+
+  defmodule Formatter do
+    alias RabbitMQ.CLI.Formatters.FormatterHelpers
+
+    @behaviour RabbitMQ.CLI.FormatterBehaviour
+
+    def format_output(item, %{format: "erlang"} = _opts) do
+      to_string(:io_lib.format("~p", [item]))
+    end
+
+    def format_output(item, %{format: "map"} = opts) do
+      to_string(:io_lib.format("~p", [item]))
+    end
+
+    def format_output(item, %{format: "openssl"} = opts) do
+      RabbitMQ.CLI.Formatters.String.format_output(item, opts)
+    end
+
+    def format_stream(stream, %{format: "erlang"} = opts) do
+      comma_separated(stream, opts)
+    end
+
+    def format_stream(stream, %{format: "map"} = opts) do
+      comma_separated(stream, opts)
+    end
+
+    def format_stream(stream, %{format: 'openssl'} = opts) do
+      Stream.map(
+        stream,
+        FormatterHelpers.without_errors_1(fn el ->
+          format_output(el, opts)
+        end)
+      )
+    end
+
+    defp comma_separated(stream, opts) do
+      elements =
+        Stream.scan(
+          stream,
+          :empty,
+          FormatterHelpers.without_errors_2(fn element, previous ->
+            separator =
+              case previous do
+                :empty -> ""
+                _ -> ","
+              end
+
+            format_element(element, separator, opts)
+          end)
+        )
+
+      Stream.concat([["["], elements, ["]"]])
+    end
+
+    defp format_element(val, separator, opts) do
+      separator <> format_output(val, opts)
+    end
+  end
+
+  def formatter(), do: Formatter
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -39,7 +39,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
 
   def validate(_, %{format: format})
       when format != "openssl" and format != "erlang" and format != "map" do
-    {:validation_failure, {:bad_argument, "Format should be either openssl, erlang or map"}}
+    {:validation_failure, {:bad_argument, "Format must be one of: openssl, erlang or map"}}
   end
   def validate(args, _) when length(args) > 0 do
     {:validation_failure, :too_many_args}
@@ -62,21 +62,21 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
 
   def formatter(), do: RabbitMQ.CLI.Formatters.Erlang
 
-  def banner([], %{format: "openssl"}),  do: "Listing available cipher suites in the OpenSSL format"
-  def banner([], %{format: "erlang"}), do: "Listing available cipher suites in the Erlang term format"
-  def banner([], %{format: "map"}), do: "Listing available cipher suites in the new map-based format"
+  def banner([], %{format: "openssl"}),  do: "Listing available cipher suites in OpenSSL format"
+  def banner([], %{format: "erlang"}), do: "Listing available cipher suites in Erlang term format"
+  def banner([], %{format: "map"}), do: "Listing available cipher suites in map format"
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Lists cipher suites available (but not necessarily allowed) on the target node"
+  def description(), do: "Lists available (but not necessarily enabled) cipher suites on the target node"
 
   def usage, do: "cipher_suites [--format (openssl | erlang | map)] [--all]"
 
   def usage_additional() do
     [
-      ["--format", "an output format to use. Can be either openssl, erlang or map"],
+      ["--format", "output format to use: openssl, erlang or map"],
       ["--all", "list all available suites"],
-      ["--openssl_format", "use OpenSSL format. Deprecated: use --format=openssl instead"]
+      ["--openssl-format", "use OpenSSL format. Deprecated: use --format=openssl instead"]
     ]
   end
 

--- a/test/diagnostics/cipher_suites_command_test.exs
+++ b/test/diagnostics/cipher_suites_command_test.exs
@@ -40,6 +40,12 @@ defmodule CipherSuitesCommandTest do
     assert @command.merge_defaults([], %{}) == {[], %{format: "erlang", all: false}}
   end
 
+  test "merge_defaults: format is case insensitive" do
+    assert @command.merge_defaults([], %{format: "OpenSSL"}) == {[], %{format: "openssl", all: false}}
+    assert @command.merge_defaults([], %{format: "Erlang"}) == {[], %{format: "erlang", all: false}}
+    assert @command.merge_defaults([], %{format: "Map"}) == {[], %{format: "map", all: false}}
+  end
+
   test "merge_defaults: OpenSSL format can be switched on" do
     assert @command.merge_defaults([], %{openssl_format: true}) == {[], %{format: "openssl", all: false}}
   end

--- a/test/diagnostics/cipher_suites_command_test.exs
+++ b/test/diagnostics/cipher_suites_command_test.exs
@@ -54,7 +54,7 @@ defmodule CipherSuitesCommandTest do
     assert @command.merge_defaults([], %{openssl_format: false}) == {[], %{format: "erlang", all: false}}
   end
 
-  test "merge_defaults: Can specify format" do
+  test "merge_defaults: format can be overridden" do
     assert @command.merge_defaults([], %{format: "map"}) == {[], %{format: "map", all: false}}
   end
 

--- a/test/diagnostics/cipher_suites_command_test.exs
+++ b/test/diagnostics/cipher_suites_command_test.exs
@@ -30,32 +30,40 @@ defmodule CipherSuitesCommandTest do
     {:ok, opts: %{
         node: get_rabbit_hostname(),
         timeout: context[:test_timeout] || 30000,
-        openssl_format: context[:openssl_format] || false
+        openssl_format: context[:openssl_format] || false,
+        format: context[:format] || "erlang",
+        all: false
       }}
   end
 
   test "merge_defaults: defaults to the Erlang term format (that is, non-OpenSSL)" do
-    assert @command.merge_defaults([], %{}) == {[], %{openssl_format: false}}
+    assert @command.merge_defaults([], %{}) == {[], %{format: "erlang", all: false}}
   end
 
   test "merge_defaults: OpenSSL format can be switched on" do
-    assert @command.merge_defaults([], %{openssl_format: true}) == {[], %{openssl_format: true}}
+    assert @command.merge_defaults([], %{openssl_format: true}) == {[], %{format: "openssl", all: false}}
   end
 
   test "merge_defaults: OpenSSL format can be switched off" do
-    assert @command.merge_defaults([], %{openssl_format: false}) == {[], %{openssl_format: false}}
+    assert @command.merge_defaults([], %{openssl_format: false}) == {[], %{format: "erlang", all: false}}
+  end
+
+  test "merge_defaults: Can specify format" do
+    assert @command.merge_defaults([], %{format: "map"}) == {[], %{format: "map", all: false}}
   end
 
   test "validate: treats positional arguments as a failure" do
     assert @command.validate(["extra-arg"], %{openssl_format: false}) == {:validation_failure, :too_many_args}
   end
 
-  test "validate: treats empty positional arguments and default switches as a success" do
-    assert @command.validate([], %{openssl_format: false}) == :ok
+  test "validate: treats empty positional arguments and default switches as a success", context do
+    assert @command.validate([], context[:opts]) == :ok
   end
 
-  test "validate: treats empty positional arguments and an OpenSSL format flag as a success" do
-    assert @command.validate([], %{openssl_format: true}) == :ok
+  test "validate: supports openssl, erlang and map formats", context do
+    assert @command.validate([], Map.merge(context[:opts], %{format: "openssl"})) == :ok
+    assert @command.validate([], Map.merge(context[:opts], %{format: "erlang"})) == :ok
+    assert @command.validate([], Map.merge(context[:opts], %{format: "map"})) == :ok
   end
 
   @tag test_timeout: 3000
@@ -63,17 +71,41 @@ defmodule CipherSuitesCommandTest do
     assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
   end
 
-  test "run: returns a list of cipher suites", context do
+  @tag format: "openssl"
+  test "run: returns a list of cipher suites in OpenSSL format", context do
     res = @command.run([], context[:opts])
+    for cipher <- res, do: assert true == is_list(cipher)
     # the list is long and its values are environment-specific,
     # so we simply assert that it is non-empty. MK.
     assert length(res) > 0
   end
 
-  @tag openssl_format: true
-  test "run: returns a list cipher suites in the OpenSSL format", context do
+  @tag format: "erlang"
+  test "run: returns a list of cipher suites in erlang format", context do
     res = @command.run([], context[:opts])
-    # see the test above
+
+    for cipher <- res, do: assert true = is_tuple(cipher)
+    # the list is long and its values are environment-specific,
+    # so we simply assert that it is non-empty. MK.
     assert length(res) > 0
   end
+
+  @tag format: "map"
+  test "run: returns a list of cipher suites in map format", context do
+    res = @command.run([], context[:opts])
+    for cipher <- res, do: assert true = is_map(cipher)
+    # the list is long and its values are environment-specific,
+    # so we simply assert that it is non-empty. MK.
+    assert length(res) > 0
+  end
+
+  test "run: returns more cipher suites when all suites requested", context do
+    all_suites_opts = Map.merge(context[:opts], %{all: true})
+    default_suites_opts = Map.merge(context[:opts], %{all: false})
+    all_suites = @command.run([], all_suites_opts)
+    default_suites = @command.run([], default_suites_opts)
+    assert length(all_suites) > length(default_suites)
+    assert length(default_suites -- all_suites) == 0
+  end
+
 end


### PR DESCRIPTION
This is a backport of #347.
    
Default format is erlang and the `--openssl-format` flag is supported
for backwards compatibility.

Addresses #342 for 3.7

Depends on changes in rabbitmq/rabbitmq-server#1992