### PR TITLE
WIP Make rabbitmqctl work with any endianness.

### DIFF
--- a/lib/rabbitmq/cli/core/listeners.ex
+++ b/lib/rabbitmq/cli/core/listeners.ex
@@ -179,7 +179,8 @@ defmodule RabbitMQ.CLI.Core.Listeners do
     # This simplistic way of distinguishing IPv6 addresses,
     # networks address ranges, etc actually works better
     # for the kind of values we can get here than :inet functions. MK.
-    case value =~ ~r/:/ do
+    regex = Regex.recompile!(~r/:/)
+    case value =~ regex do
       true -> "[#{value}]"
       false -> value
     end

--- a/lib/rabbitmq/cli/ctl/commands/help_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/help_command.ex
@@ -290,8 +290,8 @@ short            | long          | description
     end
   end
 
-  defp strip_rabbitmq_prefix(value) do
-    Regex.replace(~r/^rabbitmq_/, value, "")
+  defp strip_rabbitmq_prefix(value, regex) do
+    Regex.replace(regex, value, "")
   end
 
   defp format_known_plugin_name_fragments(value) do
@@ -310,9 +310,11 @@ short            | long          | description
   end
 
   defp plugin_section(plugin) do
+    regex = Regex.recompile!(~r/^rabbitmq_/)
+
     to_string(plugin)
     # drop rabbitmq_
-    |> strip_rabbitmq_prefix()
+    |> strip_rabbitmq_prefix(regex)
     |> String.split("_")
     |> format_known_plugin_name_fragments()
   end

--- a/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
+++ b/lib/rabbitmq/cli/diagnostics/diagnostics_helpers.ex
@@ -15,7 +15,8 @@
 
 defmodule RabbitMQ.CLI.Diagnostics.Helpers do
   def check_port_connectivity(port, node_name, timeout) do
-    hostname = Regex.replace(~r/^(.+)@/, to_string(node_name), "") |> to_charlist
+    regex = Regex.recompile!(~r/^(.+)@/)
+    hostname = Regex.replace(regex, to_string(node_name), "") |> to_charlist
 
     try do
       case :gen_tcp.connect(hostname, port, [], timeout) do


### PR DESCRIPTION
Elixir checks endianness and prints this warning:
```
Elixir is running in a system with a different endianness than the one its source code was compiled in. Please make sure Elixir and all source files were compiled in a machine with the same endianness as the current one: big"
```
on big endian systems.
This warning is mostly there because of precompiled regexp fearure in Elixir.

To make code work on all systems, regexes are now recompiled in runtime.

Another question is: should we remove the warning now when the code may run on any endianness?