### PR TITLE
Observer CLI integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 PROJECT = rabbitmq_cli
 
+dep_observer_cli = git https://github.com/michaelklishin/observer_cli recon-2.4.0
+
 BUILD_DEPS = rabbit_common
+DEPS = observer_cli
 TEST_DEPS = amqp_client rabbit
 
 DEP_EARLY_PLUGINS = rabbit_common/mk/rabbitmq-early-plugin.mk

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = rabbitmq_cli
 
-dep_observer_cli = hex observer_cli 1.4.4
+dep_observer_cli = git https://github.com/zhongwencool/observer_cli 1.4.4
 
 BUILD_DEPS = rabbit_common
 DEPS = observer_cli

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = rabbitmq_cli
 
-dep_observer_cli = hex observer_cli 1.4.3
+dep_observer_cli = hex observer_cli 1.4.4
 
 BUILD_DEPS = rabbit_common
 DEPS = observer_cli

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = rabbitmq_cli
 
-dep_observer_cli = git https://github.com/michaelklishin/observer_cli recon-2.4.0
+dep_observer_cli = hex observer_cli 1.4.3
 
 BUILD_DEPS = rabbit_common
 DEPS = observer_cli

--- a/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
@@ -30,6 +30,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ObserverCommand do
 
   def run([], %{node: node_name, interval: interval}) do
     case :observer_cli.start(node_name, [{:interval, interval * 1000}]) do
+      # See zhongwencool/observer_cli#54
+      {:badrpc, _} = err   -> err
       {:error, _} = err    -> err
       {:error, _, _} = err -> err
       :ok   -> {:ok, "Disconnected from #{node_name}."}

--- a/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
@@ -1,0 +1,50 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.ObserverCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+  use RabbitMQ.CLI.DefaultOutput
+
+  def switches(), do: [interval: :integer]
+  def aliases(), do: [i: :interval]
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{interval: 5}, opts)}
+  end
+
+
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, interval: interval}) do
+    :observer_cli.start(node_name, [{:interval, interval * 1000}])
+  end
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Starts a CLI observer interface on the target node"
+
+  def usage, do: "observer [--interval <seconds>]"
+
+  def usage_additional() do
+    [
+      ["--interval <seconds>", "Update interval to use, in seconds"]
+    ]
+  end
+
+  def banner(_, %{node: node_name}) do
+    "Starting a CLI observer interface on node #{node_name}..."
+  end
+end

--- a/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
@@ -35,6 +35,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ObserverCommand do
       {:error, _} = err    -> err
       {:error, _, _} = err -> err
       :ok   -> {:ok, "Disconnected from #{node_name}."}
+      :quit -> {:ok, "Disconnected from #{node_name}."}
       other -> other
     end
   end

--- a/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
@@ -29,7 +29,16 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ObserverCommand do
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, interval: interval}) do
-    :observer_cli.start(node_name, [{:interval, interval * 1000}])
+    case :observer_cli.start(node_name, [{:interval, interval * 1000}]) do
+      {:error, _} = err ->
+        err
+
+      {:error, _, _} = err ->
+        err
+
+      _other ->
+        {:ok, "Disconnected from #{node_name}."}
+    end
   end
 
   def help_section(), do: :observability_and_health_checks

--- a/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
@@ -30,14 +30,10 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ObserverCommand do
 
   def run([], %{node: node_name, interval: interval}) do
     case :observer_cli.start(node_name, [{:interval, interval * 1000}]) do
-      {:error, _} = err ->
-        err
-
-      {:error, _, _} = err ->
-        err
-
-      _other ->
-        {:ok, "Disconnected from #{node_name}."}
+      {:error, _} = err    -> err
+      {:error, _, _} = err -> err
+      :ok   -> {:ok, "Disconnected from #{node_name}."}
+      other -> other
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -93,7 +93,7 @@ defmodule RabbitMQCtl.MixfileBase do
       {:amqp, "~> 1.2.0", only: :test},
       {:dialyxir, "~> 0.5", only: :test, runtime: false},
       {:temp, "~> 0.4", only: :test},
-      {:observer_cli, git: "https://github.com/michaelklishin/observer_cli", branch: "recon-2.4.0"},
+      {:observer_cli, "~> 1.4.3"},
     ]
 
     rabbitmq_deps = case System.get_env("DEPS_DIR") do

--- a/mix.exs
+++ b/mix.exs
@@ -93,6 +93,7 @@ defmodule RabbitMQCtl.MixfileBase do
       {:amqp, "~> 1.2.0", only: :test},
       {:dialyxir, "~> 0.5", only: :test, runtime: false},
       {:temp, "~> 0.4", only: :test},
+      {:observer_cli, git: "https://github.com/michaelklishin/observer_cli", branch: "recon-2.4.0"},
     ]
 
     rabbitmq_deps = case System.get_env("DEPS_DIR") do

--- a/mix.exs
+++ b/mix.exs
@@ -89,11 +89,11 @@ defmodule RabbitMQCtl.MixfileBase do
       {:json, "~> 1.2.0"},
       {:csv, "~> 2.0.0"},
       {:stdout_formatter, "~> 0.2.3"},
+      {:observer_cli, "~> 1.4.4"},
 
       {:amqp, "~> 1.2.0", only: :test},
       {:dialyxir, "~> 0.5", only: :test, runtime: false},
-      {:temp, "~> 0.4", only: :test},
-      {:observer_cli, "~> 1.4.4"},
+      {:temp, "~> 0.4", only: :test}
     ]
 
     rabbitmq_deps = case System.get_env("DEPS_DIR") do
@@ -101,7 +101,7 @@ defmodule RabbitMQCtl.MixfileBase do
         # rabbitmq_cli is built as a standalone Elixir application.
         [
           {:rabbit_common, "~> 3.7.0"},
-          {:amqp_client, "~> 3.7.0", only: :test},
+          {:amqp_client, "~> 3.7.0", only: :test}
         ]
       deps_dir ->
         # rabbitmq_cli is built as part of RabbitMQ.

--- a/mix.exs
+++ b/mix.exs
@@ -93,7 +93,7 @@ defmodule RabbitMQCtl.MixfileBase do
       {:amqp, "~> 1.2.0", only: :test},
       {:dialyxir, "~> 0.5", only: :test, runtime: false},
       {:temp, "~> 0.4", only: :test},
-      {:observer_cli, "~> 1.4.3"},
+      {:observer_cli, "~> 1.4.4"},
     ]
 
     rabbitmq_deps = case System.get_env("DEPS_DIR") do

--- a/test/diagnostics/observer_command_test.exs
+++ b/test/diagnostics/observer_command_test.exs
@@ -1,0 +1,56 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule ObserverCommandTest do
+  use ExUnit.Case
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.ObserverCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        interval: 5,
+        timeout: context[:test_timeout] || 15000
+      }}
+  end
+
+  test "merge_defaults: injects a default interval of 5s" do
+    assert @command.merge_defaults([], %{}) == {[], %{interval: 5}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  # Depends on zhongwencool/observer_cli#54
+  #
+  @tag test_timeout: 3000
+  @tag disabled: true
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert match?({:badrpc, _}, @command.run([], %{node: :jake@thedog, interval: 5}))
+  end
+end

--- a/test/diagnostics/observer_command_test.exs
+++ b/test/diagnostics/observer_command_test.exs
@@ -46,10 +46,7 @@ defmodule ObserverCommandTest do
     assert @command.validate([], %{}) == :ok
   end
 
-  # Depends on zhongwencool/observer_cli#54
-  #
   @tag test_timeout: 3000
-  @tag disabled: true
   test "run: targeting an unreachable node throws a badrpc", context do
     assert match?({:badrpc, _}, @command.run([], %{node: :jake@thedog, interval: 5}))
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -14,6 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 
+ExUnit.configure(exclude: [disabled: true])
 ExUnit.start()
 
 defmodule TestHelper do


### PR DESCRIPTION
This introduces a new command, `rabbitmq-diagnostics observer`, which provides a way to start [observer CLI](https://github.com/zhongwencool/observer_cli) on the target node.

Depends on https://github.com/rabbitmq/rabbitmq-server/pull/2006.

Per discussion with @gerhard.