### PR TITLE
remove unsupported type argument from list queues command

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/list_queues_command.ex
@@ -30,7 +30,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ListQueuesCommand do
             messages_persistent message_bytes message_bytes_ready
             message_bytes_unacknowledged message_bytes_ram message_bytes_persistent
             head_message_timestamp disk_reads disk_writes consumers
-            consumer_utilisation memory slave_pids synchronised_slave_pids state type)a
+            consumer_utilisation memory slave_pids synchronised_slave_pids state)a
 
   def description(), do: "Lists queues and their properties"
   def usage(), do: "list_queues [--vhost <vhost>] [--online] [--offline] [--local] [--no-table-headers] [<column>, ...]"


### PR DESCRIPTION
Type is a new argument for 3.8.x. Listing it here causes rabbitmqctl report to
crash with {nocatch,{bad_argument,type}} when it tries to list queues with all
arguments.