### PR TITLE
Command to log schema information

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/schema_info_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/schema_info_command.ex
@@ -1,0 +1,82 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.SchemaInfoCommand do
+  @moduledoc """
+  Lists all tables on the mnesia schema
+  """
+
+  alias RabbitMQ.CLI.Ctl.InfoKeys
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  @info_keys ~w(name snmp load_order active_replicas all_nodes attributes checkpoints disc_copies 
+    disc_only_copies external_copies frag_properties master_nodes ram_copies 
+    storage_properties subscribers user_properties cstruct local_content 
+    where_to_commit where_to_read name access_mode cookie load_by_force 
+    load_node record_name size storage_type type where_to_write index arity 
+    majority memory commit_work where_to_wlock load_reason record_validation 
+   version wild_pattern index_info)a
+
+  def info_keys(), do: @info_keys
+
+  def scopes(), do: [:ctl, :diagnostics]
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def merge_defaults([], opts) do
+    merge_defaults(
+      ~w(name cookie active_replicas user_properties),
+      opts
+    )
+  end
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{table_headers: true}, opts)}
+  end
+
+  def validate(args, _) do
+    case InfoKeys.validate_info_keys(args, @info_keys) do
+      {:ok, _} -> :ok
+      err -> err
+    end
+  end
+
+  def run([_ | _] = args, %{node: node_name, timeout: timeout}) do
+    info_keys = InfoKeys.prepare_info_keys(args)
+    :rabbit_misc.rpc_call(node_name, :rabbit_mnesia, :schema_info, [info_keys], timeout)
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.Table
+
+  def usage() do
+    "schema_info [--no-table-headers] [<column> ...]"
+  end
+
+  def usage_additional() do
+    [
+      ["<column>", "must be one of " <> Enum.join(Enum.sort(@info_keys), ", ")]
+    ]
+  end
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists all tables on the mnesia schema"
+
+  def banner(_, %{node: node_name}), do: "Asking node #{node_name} to report the mnesia schema..."
+end

--- a/lib/rabbitmq/cli/diagnostics/commands/schema_info_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/schema_info_command.ex
@@ -22,12 +22,12 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.SchemaInfoCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  @info_keys ~w(name snmp load_order active_replicas all_nodes attributes checkpoints disc_copies 
-    disc_only_copies external_copies frag_properties master_nodes ram_copies 
-    storage_properties subscribers user_properties cstruct local_content 
-    where_to_commit where_to_read name access_mode cookie load_by_force 
-    load_node record_name size storage_type type where_to_write index arity 
-    majority memory commit_work where_to_wlock load_reason record_validation 
+  @info_keys ~w(name snmp load_order active_replicas all_nodes attributes checkpoints disc_copies
+    disc_only_copies external_copies frag_properties master_nodes ram_copies
+    storage_properties subscribers user_properties cstruct local_content
+    where_to_commit where_to_read name access_mode cookie load_by_force
+    load_node record_name size storage_type type where_to_write index arity
+    majority memory commit_work where_to_wlock load_reason record_validation
    version wild_pattern index_info)a
 
   def info_keys(), do: @info_keys
@@ -76,7 +76,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.SchemaInfoCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Lists all tables on the mnesia schema"
+  def description(), do: "Lists schema database tables and their properties"
 
-  def banner(_, %{node: node_name}), do: "Asking node #{node_name} to report the mnesia schema..."
+  def banner(_, %{node: node_name}), do: "Asking node #{node_name} to report its schema..."
 end

--- a/test/diagnostics/schema_info_command_test.exs
+++ b/test/diagnostics/schema_info_command_test.exs
@@ -1,0 +1,71 @@
+defmodule SchemaInfoCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.SchemaInfoCommand
+  @vhost "test1"
+  @user "guest"
+  @default_timeout :infinity
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {
+      :ok,
+      opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || @default_timeout
+      }
+    }
+  end
+
+  test "merge_defaults: adds all keys if none specificed", context do
+    default_keys = ~w(name cookie active_replicas user_properties)
+
+    {keys, _} = @command.merge_defaults([], context[:opts])
+    assert default_keys == keys
+  end
+
+  test "merge_defaults: includes table headers by default", _context do
+    {_, opts} = @command.merge_defaults([], %{})
+    assert opts[:table_headers]
+  end
+
+  test "validate: returns bad_info_key on a single bad arg", context do
+    assert @command.validate(["quack"], context[:opts]) ==
+      {:validation_failure, {:bad_info_key, [:quack]}}
+  end
+
+  test "validate: returns multiple bad args return a list of bad info key values", context do
+    assert @command.validate(["quack", "oink"], context[:opts]) ==
+      {:validation_failure, {:bad_info_key, [:oink, :quack]}}
+  end
+
+  test "validate: return bad_info_key on mix of good and bad args", context do
+    assert @command.validate(["quack", "cookie"], context[:opts]) ==
+      {:validation_failure, {:bad_info_key, [:quack]}}
+    assert @command.validate(["access_mode", "oink"], context[:opts]) ==
+      {:validation_failure, {:bad_info_key, [:oink]}}
+    assert @command.validate(["access_mode", "oink", "name"], context[:opts]) ==
+      {:validation_failure, {:bad_info_key, [:oink]}}
+  end
+
+  @tag test_timeout: 0
+  test "run: timeout causes command to return badrpc", context do
+    assert run_command_to_list(@command, [["source_name"], context[:opts]]) ==
+      {:badrpc, :timeout}
+  end
+
+  test "run: can filter info keys", context do
+    wanted_keys = ~w(name access_mode)
+    assert match?([[name: _, access_mode: _] | _], run_command_to_list(@command, [wanted_keys, context[:opts]]))
+  end
+
+  test "banner" do
+    assert String.starts_with?(@command.banner([], %{node: "node@node"}), "Asking node")
+  end
+end

--- a/test/diagnostics/schema_info_command_test.exs
+++ b/test/diagnostics/schema_info_command_test.exs
@@ -3,8 +3,6 @@ defmodule SchemaInfoCommandTest do
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.SchemaInfoCommand
-  @vhost "test1"
-  @user "guest"
   @default_timeout :infinity
 
   setup_all do


### PR DESCRIPTION
Logs by default name, cookie, active_replicas and user_properties
Any other mnesia property can be requested as info key

Needs https://github.com/rabbitmq/rabbitmq-server/pull/2033
Closes #330 

[#164550205]