### PR TITLE
Diagnostics commands that access server logs

### DIFF
--- a/lib/rabbitmq/cli/command_behaviour.ex
+++ b/lib/rabbitmq/cli/command_behaviour.ex
@@ -34,6 +34,7 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
               | {:error, RabbitMQ.CLI.Core.ExitCodes.exit_code(), [String.t()]}
 
   @optional_callbacks formatter: 0,
+                      printer: 0,
                       scopes: 0,
                       usage_additional: 0,
                       usage_doc_guides: 0,
@@ -52,6 +53,7 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
   @callback aliases() :: Keyword.t()
 
   @callback formatter() :: atom()
+  @callback printer() :: atom()
   @callback scopes() :: [atom()] | nil
   @callback description() :: String.t()
   @callback help_section() :: String.t()
@@ -149,8 +151,12 @@ defmodule RabbitMQ.CLI.CommandBehaviour do
     Helpers.apply_if_exported(cmd, :usage_doc_guides, [], [])
   end
 
-  def formatter(cmd) do
-    Helpers.apply_if_exported(cmd, :formatter, [], RabbitMQ.CLI.Formatters.String)
+  def formatter(cmd, default) do
+    Helpers.apply_if_exported(cmd, :formatter, [], default)
+  end
+
+  def printer(cmd, default) do
+    Helpers.apply_if_exported(cmd, :printer, [], default)
   end
 
   def switches(cmd) do

--- a/lib/rabbitmq/cli/core/config.ex
+++ b/lib/rabbitmq/cli/core/config.ex
@@ -96,25 +96,29 @@ defmodule RabbitMQ.CLI.Core.Config do
 
     case Code.ensure_loaded(module_name) do
       {:module, _} -> module_name
-      {:error, :nofile} -> CommandBehaviour.formatter(command)
+      {:error, :nofile} -> CommandBehaviour.formatter(command, default_formatter())
     end
   end
 
   def get_formatter(command, _) do
-    CommandBehaviour.formatter(command)
+    CommandBehaviour.formatter(command, default_formatter())
   end
 
-  def get_printer(%{printer: printer}) do
+  def get_printer(command, %{printer: printer}) do
     module_name = PrinterBehaviour.module_name(printer)
 
     case Code.ensure_loaded(module_name) do
       {:module, _} -> module_name
-      {:error, :nofile} -> default_printer()
+      {:error, :nofile} -> CommandBehaviour.printer(command, default_printer())
     end
   end
 
-  def get_printer(_) do
-    default_printer()
+  def get_printer(command, _) do
+    CommandBehaviour.printer(command, default_printer())
+  end
+
+  def default_formatter() do
+    RabbitMQ.CLI.Formatters.String
   end
 
   def default_printer() do

--- a/lib/rabbitmq/cli/core/log_files.ex
+++ b/lib/rabbitmq/cli/core/log_files.ex
@@ -1,0 +1,61 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Core.LogFiles do
+  @spec get_log_locations(atom, integer | :infinity) :: [String.t] | {:badrpc, term}
+  def get_log_locations(node_name, timeout) do
+    case :rabbit_misc.rpc_call(node_name,
+                               :rabbit_lager, :log_locations, [],
+                               timeout) do
+      {:badrpc, _} = error -> error;
+      list -> Enum.map(list, &to_string/1)
+    end
+  end
+
+  @spec get_default_log_location(atom, integer | :infinity) ::
+    {:ok, String.t} | {:badrpc, term} | {:error, term}
+  def get_default_log_location(node_name, timeout) do
+    case get_log_locations(node_name, timeout) do
+      {:badrpc, _} = error -> error;
+      [] -> {:error, "No log files configured on the node"};
+      [first_log | _] = log_locations ->
+        case get_log_config_file_location(node_name, timeout) do
+          {:badrpc, _} = error -> error;
+          nil      -> {:ok, first_log};
+          location ->
+            case Enum.member?(log_locations, location) do
+              true  -> {:ok, to_string(location)};
+              ## Configured location was not propagated to lager?
+              false -> {:ok, first_log}
+            end
+        end
+    end
+  end
+
+  defp get_log_config_file_location(node_name, timeout) do
+    case :rabbit_misc.rpc_call(node_name,
+                               :application, :get_env, [:rabbit, :log, :none],
+                               timeout) do
+      {:badrpc, _} = error -> error;
+      :none      -> nil;
+      log_config ->
+        case log_config[:file] do
+          nil -> nil;
+          file_config ->
+            file_config[:file]
+        end
+    end
+  end
+end

--- a/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
@@ -37,6 +37,25 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogLocationCommand do
     end
   end
 
+  def run([], %{node: node_name, timeout: timeout, all: all}) do
+    case all do
+      true  -> LogFiles.get_log_locations(node_name, timeout);
+      false -> LogFiles.get_default_log_location(node_name, timeout)
+    end
+  end
+
+  def output({:ok, location}, %{node: node_name, formatter: "json"}) do
+    {:ok, %{
+      "result" => "ok",
+      "paths"  => [location]
+    }}
+  end
+  def output(locations, %{node: node_name, formatter: "json"}) do
+    {:ok, %{
+      "result" => "ok",
+      "paths"  => locations
+    }}
+  end
   use RabbitMQ.CLI.DefaultOutput
 
   def help_section(), do: :configuration

--- a/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
@@ -41,11 +41,11 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogLocationCommand do
 
   def help_section(), do: :configuration
 
-  def description(), do: "Shows the log file location(s) on the target node"
+  def description(), do: "Shows log file location(s) on the target node"
 
   def usage, do: "log_location [--all|-a]"
 
   def banner([], %{node: node_name}) do
-    "Log file location on node #{node_name} ..."
+    "Log file location(s) on node #{node_name} ..."
   end
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
@@ -41,7 +41,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogLocationCommand do
 
   def help_section(), do: :configuration
 
-  def description(), do: "Shows log file location(s) on the target node"
+  def description(), do: "Shows log file location(s) on target node"
 
   def usage, do: "log_location [--all|-a]"
 

--- a/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
@@ -21,8 +21,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogLocationCommand do
 
   alias RabbitMQ.CLI.Core.LogFiles
 
-  def switches, do: [all: :boolean]
-  def aliases, do: [a: :all]
+  def switches, do: [all: :boolean, timeout: :integer]
+  def aliases, do: [a: :all, t: :timeout]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{all: false}, opts)}

--- a/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/log_location_command.ex
@@ -1,0 +1,84 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.LogLocationCommand do
+  @moduledoc """
+  Displays standard log file location on the target node
+  """
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def switches, do: [all: :boolean]
+  def aliases, do: [a: :all]
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{all: false}, opts)}
+  end
+
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+
+  def run([], %{node: node_name, timeout: timeout, all: all}) do
+    case :rabbit_misc.rpc_call(node_name,
+                               :rabbit_lager, :log_locations, [],
+                               timeout) do
+      {:badrpc, _} = error ->
+        error;
+      ## No log files?
+      [] -> {:error, "No log files configured on the node"};
+      [first_log | _] = log_locations ->
+        case all do
+          true  -> log_locations;
+          false ->
+            ## Select the "main" file
+            case get_log_config_file_location(node_name, timeout) do
+              {:badrpc, _} = error -> error;
+              nil      -> to_string(first_log);
+              location ->
+                case Enum.member?(log_locations, location) do
+                  true  -> to_string(location);
+                  ## Configured location was not propagated to lager?
+                  false -> to_string(first_log)
+                end
+            end
+        end
+    end
+  end
+
+  def get_log_config_file_location(node_name, timeout) do
+    case :rabbit_misc.rpc_call(node_name,
+                               :application, :get_env, [:rabbit, :log, :none],
+                               timeout) do
+      {:badrpc, _} = error -> error;
+      :none      -> nil;
+      log_config ->
+        case log_config[:file] do
+          nil -> nil;
+          file_config ->
+            file_config[:file]
+        end
+    end
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def help_section(), do: :configuration
+
+  def description(), do: "Shows the log file location(s) on the target node"
+
+  def usage, do: "log_location"
+
+  def banner([], %{node: node_name}) do
+    "Log file location on node #{node_name} ..."
+  end
+end

--- a/lib/rabbitmq/cli/diagnostics/commands/log_tail_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/log_tail_command.ex
@@ -25,7 +25,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogTailCommand do
   def aliases, do: ['N': :number, t: :timeout]
 
   def merge_defaults(args, opts) do
-    {args, Map.merge(%{number: 10}, opts)}
+    {args, Map.merge(%{number: 50}, opts)}
   end
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
 
@@ -49,11 +49,11 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogTailCommand do
 
   def usage_additional do
     [
-      ["<number>", "number of lines to print. 10 by default"]
+      ["<number>", "number of lines to print. Defaults to 50"]
     ]
   end
 
   def banner([], %{node: node_name, number: n}) do
-    "Last #{n} lines of the log on node #{node_name} ..."
+    "Last #{n} log lines on node #{node_name} ..."
   end
 end

--- a/lib/rabbitmq/cli/diagnostics/commands/log_tail_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/log_tail_command.ex
@@ -21,8 +21,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogTailCommand do
 
   alias RabbitMQ.CLI.Core.LogFiles
 
-  def switches, do: [number: :integer]
-  def aliases, do: ['N': :number]
+  def switches, do: [number: :integer, timeout: :integer]
+  def aliases, do: ['N': :number, t: :timeout]
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{number: 10}, opts)}
@@ -41,7 +41,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogTailCommand do
 
   use RabbitMQ.CLI.DefaultOutput
 
-  def help_section(), do: :configuration
+  def help_section(), do: :observability_and_health_checks
 
   def description(), do: "Prints the last N lines of the log on the node"
 

--- a/lib/rabbitmq/cli/diagnostics/commands/log_tail_stream.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/log_tail_stream.ex
@@ -1,0 +1,66 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.LogTailStreamCommand do
+  @moduledoc """
+  Displays standard log file location on the target node
+  """
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  alias RabbitMQ.CLI.Core.LogFiles
+
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+
+  def printer(), do: RabbitMQ.CLI.Printers.StdIORaw
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    case LogFiles.get_default_log_location(node_name, timeout) do
+      {:ok, file} ->
+        pid = self()
+        ref = make_ref()
+        subscribed = :rabbit_misc.rpc_call(
+                          node_name,
+                          :rabbit_log_tail, :init_tail_stream, [file, pid, ref],
+                          timeout)
+        case subscribed do
+          {:ok, ^ref} ->
+            Stream.unfold(:started,
+              fn(_) ->
+                receive do
+                  {^ref, data, :finished} -> {data, nil};
+                  {^ref, data, :confinue} -> {data, :confinue}
+                end
+              end)
+          error -> error
+        end
+      error -> error
+    end
+  end
+
+  use RabbitMQ.CLI.DefaultOutput
+
+  def help_section(), do: :configuration
+
+  def description(), do: "Streams logs from the node"
+
+  def usage, do: "log_tail_stream"
+
+  def banner([], %{node: node_name}) do
+    "Streaming logs from node #{node_name} ..."
+  end
+end

--- a/lib/rabbitmq/cli/diagnostics/commands/log_tail_stream.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/log_tail_stream.ex
@@ -63,13 +63,13 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogTailStreamCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Streams logs from a running node"
+  def description(), do: "Streams logs from a running node for a period of time"
 
-  def usage, do: "log_tail_stream [--duration|-d <duration_in_seconds>]"
+  def usage, do: "log_tail_stream [--duration|-d <seconds>]"
 
   def usage_additional() do
     [
-      ["<duration_in_seconds>", "duration in seconds to stream log. Default is infinity"]
+      ["<duration_in_seconds>", "duration in seconds to stream log. Defaults to infinity"]
     ]
   end
 

--- a/lib/rabbitmq/cli/diagnostics/commands/log_tail_stream.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/log_tail_stream.ex
@@ -63,13 +63,13 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.LogTailStreamCommand do
 
   def help_section(), do: :observability_and_health_checks
 
-  def description(), do: "Streams logs from the node"
+  def description(), do: "Streams logs from a running node"
 
   def usage, do: "log_tail_stream [--duration|-d <duration_in_seconds>]"
 
   def usage_additional() do
     [
-      ["<duration_in_seconds>", "duration in seconds to stream log. Default is indinity"]
+      ["<duration_in_seconds>", "duration in seconds to stream log. Default is infinity"]
     ]
   end
 

--- a/lib/rabbitmq/cli/printers/std_io_raw.ex
+++ b/lib/rabbitmq/cli/printers/std_io_raw.ex
@@ -1,0 +1,37 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Printers.StdIORaw do
+  @behaviour RabbitMQ.CLI.PrinterBehaviour
+
+  def init(_), do: {:ok, :ok}
+  def finish(_), do: :ok
+
+  def print_output(nil, _), do: :ok
+
+  def print_output(output, _) when is_list(output) do
+    for line <- output do
+      IO.write(line)
+    end
+  end
+
+  def print_output(output, _) do
+    IO.write(output)
+  end
+
+  def print_ok(_) do
+    :ok
+  end
+end

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -510,7 +510,7 @@ defmodule RabbitMQCtl do
   defp format_error({:error, :check_failed, err}, %{formatter: "json"}, _) do
     {:error, ExitCodes.exit_unavailable(), err}
   end
-  defp format_error({:error, :check_failed}, _, _) do
+  defp format_error({:error, :check_failed, _}, _, _) do
     {:error, ExitCodes.exit_unavailable(), nil}
   end
 

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -196,7 +196,7 @@ defmodule RabbitMQCtl do
 
   defp process_output(output, command, options) do
     formatter = Config.get_formatter(command, options)
-    printer = Config.get_printer(options)
+    printer = Config.get_printer(command, options)
 
     output
     |> Output.format_output(formatter, options)
@@ -378,6 +378,10 @@ defmodule RabbitMQCtl do
     exit({:shutdown, code})
   end
 
+  defp format_error(:undef, _opts, _module) do
+    {:error, ExitCodes.exit_software(),
+      "Function clause.\nStacktrace:\n" <> Exception.format_stacktrace(System.stacktrace())}
+  end
   defp format_error(:function_clause, _opts, _module) do
     {:error, ExitCodes.exit_software(),
       "Function clause.\nStacktrace:\n" <> Exception.format_stacktrace(System.stacktrace())}

--- a/test/diagnostics/log_location_command_test.exs
+++ b/test/diagnostics/log_location_command_test.exs
@@ -58,9 +58,9 @@ defmodule LogLocationCommandTest do
     assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
   end
 
-  test "run: shows a default log location", context do
+  test "run: prints default log location", context do
     {:ok, logfile} = @command.run([], context[:opts])
-    log_message = "checking the default log file"
+    log_message = "default log file"
     :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [log_message])
     {:ok, log_file_data} = File.read(logfile)
     assert String.match?(log_file_data, Regex.compile!(log_message))

--- a/test/diagnostics/log_location_command_test.exs
+++ b/test/diagnostics/log_location_command_test.exs
@@ -1,0 +1,100 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule LogLocationCommandTest do
+  use ExUnit.Case
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.LogLocationCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    ExUnit.configure([max_cases: 1])
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000,
+        all: false
+      }}
+  end
+
+  test "merge_defaults: all is false" do
+    assert @command.merge_defaults([], %{}) == {[], %{all: :false}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{all: :false}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
+  end
+
+  test "run: shows a default log location", context do
+    {:ok, logfile} = @command.run([], context[:opts])
+    log_message = "checking the default log file"
+    :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [log_message])
+    {:ok, log_file_data} = File.read(logfile)
+    assert String.match?(log_file_data, Regex.compile!(log_message))
+  end
+
+  test "run: shows all log locations", context do
+    ## Assuming default configuration
+    [logfile, upgrade_log_file] =
+      @command.run([], Map.merge(context[:opts], %{all: true}))
+
+    log_message = "checking the default log file when checking all"
+    :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [log_message])
+    wait_for_log_message(log_message, logfile)
+
+    log_message_upgrade = "checking the upgrade log file when checking all"
+    :rpc.call(get_rabbit_hostname(),
+              :rabbit_log, :log, [:upgrade, :error, log_message_upgrade, []])
+    wait_for_log_message(log_message_upgrade, upgrade_log_file)
+  end
+
+  test "run: fails if there is no log file configured", context do
+    {:ok, upgrade_file} = :rpc.call(get_rabbit_hostname(), :application, :get_env, [:rabbit, :lager_upgrade_file])
+    {:ok, default_file} = :rpc.call(get_rabbit_hostname(), :application, :get_env, [:rabbit, :lager_default_file])
+    on_exit([], fn ->
+      :rpc.call(get_rabbit_hostname(), :application, :set_env, [:rabbit, :lager_upgrade_file, upgrade_file])
+      :rpc.call(get_rabbit_hostname(), :application, :set_env, [:rabbit, :lager_default_file, default_file])
+      :rpc.call(get_rabbit_hostname(), :rabbit_lager, :configure_lager, [])
+      start_rabbitmq_app()
+    end)
+    stop_rabbitmq_app()
+    :rpc.call(get_rabbit_hostname(), :application, :unset_env, [:rabbit, :lager_upgrade_file])
+    :rpc.call(get_rabbit_hostname(), :application, :unset_env, [:rabbit, :lager_default_file])
+    :rpc.call(get_rabbit_hostname(), :application, :unset_env, [:rabbit, :log])
+    :rpc.call(get_rabbit_hostname(), :rabbit_lager, :configure_lager, [])
+    {:error, "No log files configured on the node"} = @command.run([], context[:opts])
+  end
+end

--- a/test/diagnostics/log_location_command_test.exs
+++ b/test/diagnostics/log_location_command_test.exs
@@ -62,12 +62,13 @@ defmodule LogLocationCommandTest do
     {:ok, logfile} = @command.run([], context[:opts])
     log_message = "file location"
     :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [log_message])
+    wait_for_log_message(log_message, logfile)
     {:ok, log_file_data} = File.read(logfile)
     assert String.match?(log_file_data, Regex.compile!(log_message))
   end
 
   test "run: shows all log locations", context do
-    ## Assuming default configuration
+    # This assumes default configuration
     [logfile, upgrade_log_file] =
       @command.run([], Map.merge(context[:opts], %{all: true}))
 

--- a/test/diagnostics/log_location_command_test.exs
+++ b/test/diagnostics/log_location_command_test.exs
@@ -60,7 +60,7 @@ defmodule LogLocationCommandTest do
 
   test "run: prints default log location", context do
     {:ok, logfile} = @command.run([], context[:opts])
-    log_message = "default log file"
+    log_message = "file location"
     :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [log_message])
     {:ok, log_file_data} = File.read(logfile)
     assert String.match?(log_file_data, Regex.compile!(log_message))

--- a/test/diagnostics/log_tail_command_test.exs
+++ b/test/diagnostics/log_tail_command_test.exs
@@ -1,0 +1,114 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule LogTailCommandTest do
+  use ExUnit.Case
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.LogTailCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    ExUnit.configure([max_cases: 1])
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000,
+        number: 10
+      }}
+  end
+
+  test "merge_defaults: number is 10" do
+    assert @command.merge_defaults([], %{}) == {[], %{number: 10}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success", context do
+    assert @command.validate([], context[:opts]) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
+  end
+
+  test "run: shows last 10 lines from the log", context do
+    cleanup_log_files()
+    log_messages =
+      Enum.map(:lists.seq(1, 10),
+               fn(n) ->
+                 message = "Getting log tail #{n}"
+                 :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [message])
+                 message
+               end)
+    wait_for_log_message("Getting log tail 10")
+    lines = @command.run([], context[:opts])
+    assert Enum.count(lines) == 10
+
+    Enum.map(Enum.zip(log_messages, lines),
+             fn({message, line}) ->
+               assert String.match?(line, Regex.compile!(message))
+             end)
+  end
+
+  test "run: returns N lines", context do
+    ## Log a bunch of lines
+    Enum.map(:lists.seq(1, 300),
+             fn(n) ->
+               message = "More lines #{n}"
+               :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [message])
+               message
+             end)
+    wait_for_log_message("More lines 300")
+    assert Enum.count(@command.run([], Map.merge(context[:opts], %{number: 100}))) == 100
+    assert Enum.count(@command.run([], Map.merge(context[:opts], %{number: 200}))) == 200
+    assert Enum.count(@command.run([], Map.merge(context[:opts], %{number: 245}))) == 245
+  end
+
+  test "run: may return less than N lines if N is high", context do
+    cleanup_log_files()
+    ## Log a bunch of lines
+    Enum.map(:lists.seq(1, 100),
+             fn(n) ->
+               message = "More lines #{n}"
+               :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [message])
+               message
+             end)
+    wait_for_log_message("More lines 50")
+    assert Enum.count(@command.run([], Map.merge(context[:opts], %{number: 50}))) == 50
+    assert Enum.count(@command.run([], Map.merge(context[:opts], %{number: 200}))) < 200
+  end
+
+  def cleanup_log_files() do
+    [_|_] = logs = :rpc.call(get_rabbit_hostname(), :rabbit_lager, :log_locations, [])
+    Enum.map(logs, fn(log) ->
+      File.write(log, "")
+    end)
+  end
+end

--- a/test/diagnostics/log_tail_command_test.exs
+++ b/test/diagnostics/log_tail_command_test.exs
@@ -37,12 +37,12 @@ defmodule LogTailCommandTest do
     {:ok, opts: %{
         node: get_rabbit_hostname(),
         timeout: context[:test_timeout] || 30000,
-        number: 10
+        number: 50
       }}
   end
 
-  test "merge_defaults: number is 10" do
-    assert @command.merge_defaults([], %{}) == {[], %{number: 10}}
+  test "merge_defaults: number is 50" do
+    assert @command.merge_defaults([], %{}) == {[], %{number: 50}}
   end
 
   test "validate: treats positional arguments as a failure" do
@@ -58,18 +58,18 @@ defmodule LogTailCommandTest do
     assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
   end
 
-  test "run: shows last 10 lines from the log", context do
-    cleanup_log_files()
+  test "run: shows last 50 lines from the log by default", context do
+    clear_log_files()
     log_messages =
-      Enum.map(:lists.seq(1, 10),
+      Enum.map(:lists.seq(1, 50),
                fn(n) ->
                  message = "Getting log tail #{n}"
                  :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, [message])
                  message
                end)
-    wait_for_log_message("Getting log tail 10")
+    wait_for_log_message("Getting log tail 50")
     lines = @command.run([], context[:opts])
-    assert Enum.count(lines) == 10
+    assert Enum.count(lines) == 50
 
     Enum.map(Enum.zip(log_messages, lines),
              fn({message, line}) ->
@@ -92,7 +92,7 @@ defmodule LogTailCommandTest do
   end
 
   test "run: may return less than N lines if N is high", context do
-    cleanup_log_files()
+    clear_log_files()
     ## Log a bunch of lines
     Enum.map(:lists.seq(1, 100),
              fn(n) ->
@@ -105,7 +105,7 @@ defmodule LogTailCommandTest do
     assert Enum.count(@command.run([], Map.merge(context[:opts], %{number: 200}))) < 200
   end
 
-  def cleanup_log_files() do
+  def clear_log_files() do
     [_|_] = logs = :rpc.call(get_rabbit_hostname(), :rabbit_lager, :log_locations, [])
     Enum.map(logs, fn(log) ->
       File.write(log, "")

--- a/test/diagnostics/log_tail_stream_command_test.exs
+++ b/test/diagnostics/log_tail_stream_command_test.exs
@@ -109,7 +109,7 @@ defmodule LogTailStreamCommandTest do
 
     time_spent = time_after - time_before
     assert time_spent > 5
-    ## This my take longer then duration, but should not take too long
+    # This my take longer then duration, but should not take too long
     assert time_spent < 30
   end
 

--- a/test/diagnostics/log_tail_stream_command_test.exs
+++ b/test/diagnostics/log_tail_stream_command_test.exs
@@ -97,7 +97,7 @@ defmodule LogTailStreamCommandTest do
     :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, ["Message2"])
     :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, ["Message3"])
 
-    ## This may take a long time and fail with an exunit timeout
+    # This may take a long time and fail with an ExUnit timeout
     data = Enum.join(stream)
 
     time_after = System.system_time(:second)
@@ -113,7 +113,7 @@ defmodule LogTailStreamCommandTest do
     assert time_spent < 30
   end
 
-  test "run: may return error if there is no log", context do
+  test "run: may return an error if there is no log", context do
     delete_log_files()
     {:error, :enoent} = @command.run([], Map.merge(context[:opts], %{duration: 5}))
   end
@@ -124,7 +124,7 @@ defmodule LogTailStreamCommandTest do
   end
 
   def ensure_file(log, 0) do
-    flunk("timeout trying to ensure the log file #{log}")
+    flunk("timed out trying to ensure the log file #{log}")
   end
   def ensure_file(log, attempts) do
     case File.exists?(log) do

--- a/test/diagnostics/log_tail_stream_command_test.exs
+++ b/test/diagnostics/log_tail_stream_command_test.exs
@@ -1,0 +1,145 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule LogTailStreamCommandTest do
+  use ExUnit.Case
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.LogTailStreamCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    ExUnit.configure([max_cases: 1])
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000,
+        duration: :infinity
+      }}
+  end
+
+  test "merge_defaults: duration is infinity" do
+    assert @command.merge_defaults([], %{}) == {[], %{duration: :infinity}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success", context do
+    assert @command.validate([], context[:opts]) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
+  end
+
+  test "run: streams messages from the log", context do
+    ensure_log_file()
+
+    stream = @command.run([], context[:opts])
+    :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, ["Message"])
+    pid = self()
+    ref = make_ref()
+    Stream.transform(stream,
+                     "",
+                     fn(line, acc) ->
+                       acc1 = acc <> line
+                       case String.ends_with?(line, "\n") do
+                         true ->
+                           ## A hacky way to get the last value of the stream transform
+                           send pid, {:data, ref, acc1}
+                           {:halt, acc1}
+                         false ->
+                           {[], acc1}
+                       end
+                     end)
+    |> Stream.run
+    receive do
+      {:data, ^ref, data} ->
+        assert String.match?(data, ~r/Message/)
+    after 10000 ->
+      flunk("timeout waiting for streamed log message")
+    end
+  end
+
+  test "run: streams messages for N seconds", context do
+    ensure_log_file()
+    time_before = System.system_time(:second)
+
+    stream = @command.run([], Map.merge(context[:opts], %{duration: 5}))
+    :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, ["Message"])
+    :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, ["Message1"])
+    :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, ["Message2"])
+    :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, ["Message3"])
+
+    ## This may take a long time and fail with an exunit timeout
+    data = Enum.join(stream)
+
+    time_after = System.system_time(:second)
+
+    assert String.match?(data, ~r/Message/)
+    assert String.match?(data, ~r/Message1/)
+    assert String.match?(data, ~r/Message2/)
+    assert String.match?(data, ~r/Message3/)
+
+    time_spent = time_after - time_before
+    assert time_spent > 5
+    ## This my take longer then duration, but should not take too long
+    assert time_spent < 30
+  end
+
+  test "run: may return error if there is no log", context do
+    delete_log_files()
+    {:error, :enoent} = @command.run([], Map.merge(context[:opts], %{duration: 5}))
+  end
+
+  def ensure_log_file() do
+    [log|_] = :rpc.call(get_rabbit_hostname(), :rabbit_lager, :log_locations, [])
+    ensure_file(log, 100)
+  end
+
+  def ensure_file(log, 0) do
+    flunk("timeout trying to ensure the log file #{log}")
+  end
+  def ensure_file(log, attempts) do
+    case File.exists?(log) do
+      true -> :ok
+      false ->
+        :rpc.call(get_rabbit_hostname(), :rabbit_log, :error, ["Ping"])
+        :timer.sleep(100)
+        ensure_file(log, attempts - 1)
+    end
+  end
+
+  def delete_log_files() do
+    [_|_] = logs = :rpc.call(get_rabbit_hostname(), :rabbit_lager, :log_locations, [])
+    Enum.map(logs, fn(log) ->
+      File.rm(log)
+    end)
+  end
+end

--- a/test/diagnostics/log_tail_stream_command_test.exs
+++ b/test/diagnostics/log_tail_stream_command_test.exs
@@ -109,7 +109,7 @@ defmodule LogTailStreamCommandTest do
 
     time_spent = time_after - time_before
     assert time_spent > 5
-    # This my take longer then duration, but should not take too long
+    # This my take longer then duration but not too long
     assert time_spent < 30
   end
 

--- a/test/diagnostics/log_tail_stream_command_test.exs
+++ b/test/diagnostics/log_tail_stream_command_test.exs
@@ -41,7 +41,7 @@ defmodule LogTailStreamCommandTest do
       }}
   end
 
-  test "merge_defaults: duration is infinity" do
+  test "merge_defaults: duration defaults to infinity" do
     assert @command.merge_defaults([], %{}) == {[], %{duration: :infinity}}
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -509,4 +509,26 @@ defmodule TestHelper do
                                ({:error, _, _}) -> false;
                                (_) -> true end)
   end
+
+  def wait_for_log_message(message, file \\ nil, attempts \\ 100) do
+    ## Assume default log is the first one
+    log_file = case file do
+      nil ->
+        [default_log | _] = logs = :rpc.call(get_rabbit_hostname(), :rabbit_lager, :log_locations, [])
+        default_log
+      _ -> file
+    end
+    case File.read(log_file) do
+      {:ok, data} ->
+        case String.match?(data, Regex.compile!(message)) do
+          true -> :ok
+          false ->
+            :timer.sleep(100)
+            wait_for_log_message(message, log_file, attempts - 1)
+        end
+      _ ->
+        :timer.sleep(100)
+            wait_for_log_message(message, log_file, attempts - 1)
+    end
+  end
 end


### PR DESCRIPTION
Added new commands:

- `log_location` - get default log location
- `log_location --all` - get all logs locations
- `log_tail [-N <number>]` - get last N lines from the default log
- `log_tail_stream [-d <duration>]` - stream log messages from the deafault log

Default N is 10, default duration is `:infinity`.

Log streaming does not detect the log file to be deleted (because it's a hard thig to do), but that's similar to `tail -f`.
Added a new printer, which prints to the std_io, but does not split lines. This is because log data may contain partial lines.

Reading last N lines reads a buffer of data from the end of the file and counts lines. If there are not enough lines - the buffer is increased. This works well enough for reasonable number of lines.

Open questions:

- Should duration be some number of seconds by default instead of `:infinity`?
- Should there be a default number of lines? Is 10 a good number?

Additional features:

- Should there be an argument to ask for entire file?
- Should there be a command to get the tail AND stream the file from the last line returned (like `tail -n 100 -f`)?
- Should it be possible to select non-default log files?