### PR TITLE
Do not require rabbit app for rabbitmq-diagnostics observer

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/observer_command.ex
@@ -26,7 +26,6 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ObserverCommand do
 
 
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
-  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
 
   def run([], %{node: node_name, interval: interval}) do
     case :observer_cli.start(node_name, [{:interval, interval * 1000}]) do


### PR DESCRIPTION
It works perfectly fine without it. We are more likely to want to look into the Erlang VM if the rabbit app is not running.

Didn't think it was worth writing a test for this, but I am submitting it as a PR in case you think differently @michaelklishin.