### PR TITLE
Fix set_parameter command output

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/set_parameter_command.ex
@@ -70,7 +70,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.SetParameterCommand do
   def description(), do: "Sets a runtime parameter."
 
   def banner([component_name, name, value], %{vhost: vhost}) do
-    "Setting runtime parameter \"#{component_name}\" for component \"#{name}\" to \"#{value}\" in vhost \"#{
+    "Setting runtime parameter \"#{name}\" for component \"#{component_name}\" to \"#{value}\" in vhost \"#{
       vhost
     }\" ..."
   end

--- a/test/ctl/set_parameter_command_test.exs
+++ b/test/ctl/set_parameter_command_test.exs
@@ -128,7 +128,7 @@ defmodule SetParameterCommandTest do
     vhost_opts = Map.merge(context[:opts], %{vhost: context[:vhost]})
 
     assert @command.banner([context[:component_name], context[:key], context[:value]], vhost_opts)
-      =~ ~r/Setting runtime parameter \"#{context[:component_name]}\" for component \"#{context[:key]}\" to \"#{context[:value]}\" in vhost \"#{context[:vhost]}\" \.\.\./
+      =~ ~r/Setting runtime parameter \"#{context[:key]}\" for component \"#{context[:component_name]}\" to \"#{context[:value]}\" in vhost \"#{context[:vhost]}\" \.\.\./
   end
 
   # Checks each element of the first parameter against the expected context values


### PR DESCRIPTION
## Proposed Changes

There was an inversion between parameter name and component in the `set_parameter` command output. Fixed it.

## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #376)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories
