### PR TITLE
Handle empty output in JSON stream

### DIFF
--- a/lib/rabbitmq/cli/formatters/json_stream.ex
+++ b/lib/rabbitmq/cli/formatters/json_stream.ex
@@ -32,6 +32,12 @@ defmodule RabbitMQ.CLI.Formatters.JsonStream do
   alias RabbitMQ.CLI.Formatters.FormatterHelpers
   alias RabbitMQ.CLI.Core.Platform
 
+  def format_output("", _opts) do
+    # the empty string can be emitted along with a finishing marker that ends the stream
+    # (e.g. with commands that have a duration argument)
+    # we just emit the empty string as the last value for the stream in this case
+    ""
+  end
   def format_output(output, _opts) do
     {:ok, json} = JSON.encode(keys_to_atoms(output))
     json

--- a/test/core/json_stream_test.ex
+++ b/test/core/json_stream_test.ex
@@ -1,0 +1,33 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule JsonStreamTest do
+  use ExUnit.Case, async: false
+
+  @formatter RabbitMQ.CLI.Formatters.JsonStream
+
+  test "format_output map with atom keys is converted to JSON object" do
+    assert @formatter.format_output(%{a: :apple, b: :beer}, %{}) == "{\"a\":\"apple\",\"b\":\"beer\"}"
+  end
+
+  test "format_output map with binary keys is converted to JSON object" do
+    assert @formatter.format_output(%{"a" => :apple, "b" => :beer}, %{}) == "{\"a\":\"apple\",\"b\":\"beer\"}"
+  end
+
+  test "format_output empty binary is converted to empty JSON array" do
+    assert @formatter.format_output("", %{}) == ""
+  end
+
+end


### PR DESCRIPTION
Some streaming commands with a duration argument can send the empty
string as the output (along with a finishing marker). This case was not
handled properly and would result in a stack trace when the command
returned once the duration has elapsed.

To reproduce:

```
./rabbitmq-diagnostics consume_event_stream --duration 5
Function clause.
Stacktrace:
    (rabbitmqctl) lib/rabbitmqctl.ex:45: RabbitMQCtl.main/1
    (elixir) lib/kernel/cli.ex:105: anonymous fn/3 in Kernel.CLI.exec_fun/2
```