### PR TITLE
Use new `rabbit_env` module to get node settings

### DIFF
--- a/lib/rabbitmq/cli/core/code_path.ex
+++ b/lib/rabbitmq/cli/core/code_path.ex
@@ -100,9 +100,6 @@ defmodule RabbitMQ.CLI.Core.CodePath do
         {:error, {:unable_to_load_rabbit, :rabbitmq_home_is_undefined}}
 
       _ ->
-        path = Path.join(home, "ebin")
-        Code.append_path(path)
-
         case Application.load(:rabbit) do
           :ok ->
             Code.ensure_loaded(:rabbit_plugins)

--- a/lib/rabbitmq/cli/core/config.ex
+++ b/lib/rabbitmq/cli/core/config.ex
@@ -20,6 +20,7 @@ defmodule RabbitMQ.CLI.Core.Config do
     FormatterBehaviour,
     PrinterBehaviour
   }
+  alias RabbitMQ.CLI.Core.Helpers
 
   #
   # Environment
@@ -28,7 +29,7 @@ defmodule RabbitMQ.CLI.Core.Config do
   def get_option(name, opts \\ %{}) do
     raw_option =
       opts[name] ||
-        get_system_option(name) ||
+        get_system_option(name, opts) ||
         default(name)
 
     normalise(name, raw_option)
@@ -57,30 +58,84 @@ defmodule RabbitMQ.CLI.Core.Config do
   def normalise(:longnames, _val), do: :shortnames
   def normalise(_, value), do: value
 
-  def system_env_variable(name) do
-    case name do
-      :longnames -> "RABBITMQ_USE_LONGNAME"
-      :rabbitmq_home -> "RABBITMQ_HOME"
-      :mnesia_dir -> "RABBITMQ_MNESIA_DIR"
-      :plugins_dir -> "RABBITMQ_PLUGINS_DIR"
-      :plugins_expand_dir -> "RABBITMQ_PLUGINS_EXPAND_DIR"
-      :feature_flags_file -> "RABBITMQ_FEATURE_FLAGS_FILE"
-      :enabled_plugins_file -> "RABBITMQ_ENABLED_PLUGINS_FILE"
-      :node -> "RABBITMQ_NODENAME"
-      :aliases_file -> "RABBITMQ_CLI_ALIASES_FILE"
-      :erlang_cookie -> "RABBITMQ_ERLANG_COOKIE"
-      _ -> ""
-    end
-  end
-
-  def get_system_option(:script_name) do
+  def get_system_option(:script_name, _) do
     Path.basename(:escript.script_name())
     |> Path.rootname()
     |> String.to_atom()
   end
 
-  def get_system_option(name) do
-    System.get_env(system_env_variable(name))
+  def get_system_option(:node, _) do
+      System.get_env("RABBITMQ_NODENAME")
+  end
+
+  def get_system_option(:aliases_file, _) do
+      System.get_env("RABBITMQ_CLI_ALIASES_FILE")
+  end
+
+  def get_system_option(:erlang_cookie, _) do
+      System.get_env("RABBITMQ_ERLANG_COOKIE")
+  end
+
+  def get_system_option(name, opts) do
+    work_offline = opts[:offline] == true
+    remote_node = case name do
+      :longnames ->
+        nil
+      :rabbitmq_home ->
+        nil
+      _ ->
+        case opts[:node] do
+          nil ->
+            # Just in case `opts` was not normalized yet (to get the
+            # default node), we do it here as well.
+            case Helpers.normalise_node_option(opts) do
+              {:error, _}            -> nil
+              {:ok, normalized_opts} -> normalized_opts[:node]
+            end
+          node ->
+            node
+        end
+    end
+    context = get_env_context(remote_node, work_offline)
+    val0 = get_val_from_env_context(context, name)
+    val = cond do
+      remote_node != nil and
+      val0 == :undefined and
+      (name == :plugins_dir or name == :enabled_plugins_file) ->
+        context1 = get_env_context(nil, true)
+        get_val_from_env_context(context1, name)
+      true ->
+        val0
+    end
+    case val do
+      :undefined -> nil
+      _          -> val
+    end
+  end
+
+  def get_env_context(remote_node, work_offline) do
+    query_remote = remote_node != nil
+    case query_remote do
+      true ->
+        case work_offline do
+          true  -> :rabbit_env.get_context(:offline)
+          false -> :rabbit_env.get_context(remote_node)
+        end
+      false ->
+        :rabbit_env.get_context()
+    end
+  end
+
+  def get_val_from_env_context(context, name) do
+    case name do
+      :longnames -> context[:nodename_type] == :longnames
+      :rabbitmq_home -> context[:rabbitmq_home]
+      :mnesia_dir -> context[:mnesia_dir]
+      :plugins_dir -> context[:plugins_path]
+      :plugins_expand_dir -> context[:plugins_expand_dir]
+      :feature_flags_file -> context[:feature_flags_file]
+      :enabled_plugins_file -> context[:enabled_plugins_file]
+    end
   end
 
   def default(:script_name), do: :rabbitmqctl

--- a/test/ctl/delete_queue_command_test.exs
+++ b/test/ctl/delete_queue_command_test.exs
@@ -15,7 +15,7 @@
 
 
 defmodule DeleteQueueCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Ctl.Commands.DeleteQueueCommand

--- a/test/ctl/export_definitions_command_test.exs
+++ b/test/ctl/export_definitions_command_test.exs
@@ -15,7 +15,7 @@
 
 
 defmodule ExportDefinitionsCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand

--- a/test/ctl/hipe_compile_command_test.exs
+++ b/test/ctl/hipe_compile_command_test.exs
@@ -68,9 +68,4 @@ defmodule HipeCompileCommandTest do
   test "validate: providing one non-blank directory path and required options succeeds", context do
     assert @command.validate([context[:target_dir]], context[:opts]) == :ok
   end
-
-  test "validate: failure to load the rabbit application is reported as an error", context do
-    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
-      @command.validate([context[:target_dir]], Map.delete(context[:opts], :rabbitmq_home))
-  end
 end

--- a/test/ctl/import_definitions_command_test.exs
+++ b/test/ctl/import_definitions_command_test.exs
@@ -15,7 +15,7 @@
 
 
 defmodule ImportDefinitionsCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand

--- a/test/ctl/purge_queue_command_test.exs
+++ b/test/ctl/purge_queue_command_test.exs
@@ -15,7 +15,7 @@
 
 
 defmodule PurgeQueueCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Ctl.Commands.PurgeQueueCommand

--- a/test/ctl/wait_command_test.exs
+++ b/test/ctl/wait_command_test.exs
@@ -50,12 +50,6 @@ defmodule WaitCommandTest do
     assert @command.validate(["pid_file", "extra"], context[:opts]) == {:validation_failure, :too_many_args}
   end
 
-  test "validate_execution_environment: failure to load rabbit application is reported as an error", context do
-    options = Map.merge(Map.delete(context[:opts], :rabbitmq_home), %{pid: 123})
-    {:validation_failure, {:unable_to_load_rabbit, _}} =
-      @command.validate_execution_environment([], options)
-  end
-
   test "run: times out waiting for non-existent pid file", context do
     {:error, {:timeout, _}} = @command.run(["pid_file"], context[:opts]) |> Enum.to_list |> List.last
   end

--- a/test/diagnostics/alarms_command_test.exs
+++ b/test/diagnostics/alarms_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule AlarmsCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
   import RabbitMQ.CLI.Core.Alarms, only: [alarm_types: 1]
 

--- a/test/diagnostics/check_alarms_command_test.exs
+++ b/test/diagnostics/check_alarms_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule CheckAlarmsCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
   import RabbitMQ.CLI.Core.Alarms, only: [alarm_types: 1]
 

--- a/test/diagnostics/check_local_alarms_command_test.exs
+++ b/test/diagnostics/check_local_alarms_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule CheckLocalAlarmsCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
   import RabbitMQ.CLI.Core.Alarms, only: [alarm_types: 1]
 

--- a/test/diagnostics/check_port_connectivity_command_test.exs
+++ b/test/diagnostics/check_port_connectivity_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule CheckPortConnectivityCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.CheckPortConnectivityCommand

--- a/test/diagnostics/check_port_listener_command_test.exs
+++ b/test/diagnostics/check_port_listener_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule CheckPortListenerCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.CheckPortListenerCommand

--- a/test/diagnostics/check_protocol_listener_command_test.exs
+++ b/test/diagnostics/check_protocol_listener_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule CheckProtocolListenerCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.CheckProtocolListenerCommand

--- a/test/diagnostics/check_running_command_test.exs
+++ b/test/diagnostics/check_running_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule CheckRunningCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.CheckRunningCommand

--- a/test/diagnostics/check_virtual_hosts_command_test.exs
+++ b/test/diagnostics/check_virtual_hosts_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule CheckVirtualHostsCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.CheckVirtualHostsCommand

--- a/test/diagnostics/consume_event_stream_command_test.exs
+++ b/test/diagnostics/consume_event_stream_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule ConsumeEventStreamCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.ConsumeEventStreamCommand

--- a/test/diagnostics/discover_peers_command_test.exs
+++ b/test/diagnostics/discover_peers_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule DiscoverPeersCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.DiscoverPeersCommand
@@ -35,7 +35,7 @@ defmodule DiscoverPeersCommandTest do
     assert @command.validate(["a"], context[:opts]) ==
       {:validation_failure, :too_many_args}
   end
-  
+
   @tag test_timeout: 15000
   test "run: returns a list of nodes when the backend isn't configured", context do
     assert match?({:ok, {[], _}}, @command.run([], context[:opts]))

--- a/test/diagnostics/is_booting_command_test.exs
+++ b/test/diagnostics/is_booting_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule IsBootingCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.IsBootingCommand

--- a/test/diagnostics/is_running_command_test.exs
+++ b/test/diagnostics/is_running_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule IsRunningCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.IsRunningCommand

--- a/test/diagnostics/listeners_command_test.exs
+++ b/test/diagnostics/listeners_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule ListenersCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
   import RabbitMQ.CLI.Core.Listeners, only: [listener_maps: 1]
 

--- a/test/diagnostics/log_location_command_test.exs
+++ b/test/diagnostics/log_location_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule LogLocationCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.LogLocationCommand

--- a/test/diagnostics/log_tail_command_test.exs
+++ b/test/diagnostics/log_tail_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule LogTailCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.LogTailCommand

--- a/test/diagnostics/log_tail_stream_command_test.exs
+++ b/test/diagnostics/log_tail_stream_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule LogTailStreamCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.LogTailStreamCommand

--- a/test/diagnostics/memory_breakdown_command_test.exs
+++ b/test/diagnostics/memory_breakdown_command_test.exs
@@ -14,14 +14,13 @@
 ## Copyright (c) 2016-2017 Pivotal Software, Inc.  All rights reserved.
 
 defmodule MemoryBreakdownCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.MemoryBreakdownCommand
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
-
 
     start_rabbitmq_app()
 

--- a/test/diagnostics/observer_command_test.exs
+++ b/test/diagnostics/observer_command_test.exs
@@ -15,7 +15,7 @@
 
 
 defmodule ObserverCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Diagnostics.Commands.ObserverCommand

--- a/test/plugins/directories_command_test.exs
+++ b/test/plugins/directories_command_test.exs
@@ -80,16 +80,6 @@ defmodule DirectoriesCommandTest do
       {:validation_failure, {:bad_argument, "Cannot set both online and offline"}}
   end
 
-  test "validate_execution_environment: when --offline is used, not specifying an enabled_plugins_file fails validation", context do
-    opts = context[:opts] |> Map.merge(%{offline: true}) |> Map.delete(:enabled_plugins_file)
-    assert @command.validate_execution_environment([], opts) == {:validation_failure, :no_plugins_file}
-  end
-
-  test "validate_execution_environment: when --offline is used, not specifying a plugins_dir fails validation", context do
-    opts = context[:opts] |> Map.merge(%{offline: true}) |> Map.delete(:plugins_dir)
-    assert @command.validate_execution_environment([], opts) == {:validation_failure, :no_plugins_dir}
-  end
-
   test "validate_execution_environment: when --offline is used, specifying a non-existent enabled_plugins_file passes validation", context do
     opts = context[:opts] |> Map.merge(%{offline: true, enabled_plugins_file: "none"})
     assert @command.validate_execution_environment([], opts) == :ok
@@ -98,16 +88,6 @@ defmodule DirectoriesCommandTest do
   test "validate_execution_environment: when --offline is used, specifying a non-existent plugins_dir fails validation", context do
     opts = context[:opts] |> Map.merge(%{offline: true, plugins_dir: "none"})
     assert @command.validate_execution_environment([], opts) == {:validation_failure, :plugins_dir_does_not_exist}
-  end
-
-  test "validate_execution_environment: when --online is used, not specifying an enabled_plugins_file passes validation", context do
-    opts = context[:opts] |> Map.merge(%{online: true}) |> Map.delete(:enabled_plugins_file)
-    assert @command.validate_execution_environment([], opts) == :ok
-  end
-
-  test "validate_execution_environment: when --online is used, not specifying a plugins_dir passes validation", context do
-    opts = context[:opts] |> Map.merge(%{online: true}) |> Map.delete(:plugins_dir)
-    assert @command.validate_execution_environment([], opts) == :ok
   end
 
   test "validate_execution_environment: when --online is used, specifying a non-existent enabled_plugins_file passes validation", context do

--- a/test/plugins/disable_plugins_command_test.exs
+++ b/test/plugins/disable_plugins_command_test.exs
@@ -33,7 +33,10 @@ defmodule DisablePluginsCommandTest do
                                                [:rabbit, :plugins_dir])
     rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
 
+    IO.puts("plugins disable tests default env: enabled plugins = #{plugins_file}, plugins dir = #{plugins_dir}, RabbitMQ home directory = #{rabbitmq_home}")
+
     {:ok, [enabled_plugins]} = :file.consult(plugins_file)
+    IO.puts("plugins disable tests will assume tnat #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to")
 
     opts = %{enabled_plugins_file: plugins_file,
              plugins_dir: plugins_dir,

--- a/test/plugins/disable_plugins_command_test.exs
+++ b/test/plugins/disable_plugins_command_test.exs
@@ -81,16 +81,6 @@ defmodule DisablePluginsCommandTest do
     )
   end
 
-  test "validate_execution_environment: not specifying an enabled_plugins_file is reported as an error", context do
-    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:validation_failure, :no_plugins_file}
-  end
-
-  test "validate_execution_environment: not specifying a plugins_dir is reported as an error", context do
-    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
-      {:validation_failure, :no_plugins_dir}
-  end
-
   test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
   end
@@ -98,11 +88,6 @@ defmodule DisablePluginsCommandTest do
   test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
       {:validation_failure, :plugins_dir_does_not_exist}
-  end
-
-  test "validate_execution_environment: failure to load the rabbit application is reported as an error", context do
-    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
-      @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 
   test "node is inaccessible, writes out enabled plugins file and returns implicitly enabled plugin list", context do

--- a/test/plugins/enable_plugins_command_test.exs
+++ b/test/plugins/enable_plugins_command_test.exs
@@ -81,17 +81,6 @@ defmodule EnablePluginsCommandTest do
     )
   end
 
-  test "validate_execution_environment: not specifying an enabled_plugins_file is reported as an error", context do
-    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:validation_failure, :no_plugins_file}
-  end
-
-  test "validate_execution_environment: not specifying a plugins_dir is reported as an error", context do
-    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
-      {:validation_failure, :no_plugins_dir}
-  end
-
-
   test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
   end
@@ -99,11 +88,6 @@ defmodule EnablePluginsCommandTest do
   test "validate_execution_environment: specifying a non-existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
       {:validation_failure, :plugins_dir_does_not_exist}
-  end
-
-  test "validate: failure to load the rabbit application is reported as an error", context do
-    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
-      @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 
   test "if node is inaccessible, writes enabled plugins file and reports implicitly enabled plugin list", context do

--- a/test/plugins/enable_plugins_command_test.exs
+++ b/test/plugins/enable_plugins_command_test.exs
@@ -33,7 +33,10 @@ defmodule EnablePluginsCommandTest do
                                                [:rabbit, :plugins_dir])
     rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
 
+    IO.puts("plugins enable tests default env: enabled plugins = #{plugins_file}, plugins dir = #{plugins_dir}, RabbitMQ home directory = #{rabbitmq_home}")
+
     {:ok, [enabled_plugins]} = :file.consult(plugins_file)
+    IO.puts("plugins enable tests will assume tnat #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to")
 
     opts = %{enabled_plugins_file: plugins_file,
              plugins_dir: plugins_dir,

--- a/test/plugins/is_enabled_command_test.exs
+++ b/test/plugins/is_enabled_command_test.exs
@@ -70,21 +70,6 @@ defmodule PluginIsEnabledCommandTest do
     assert match?({:validation_failure, :not_enough_args}, @command.validate([], opts))
   end
 
-  test "validate_execution_environment: not specifying an enabled_plugins_file is reported as an error", context do
-    opts = context[:opts] |> Map.merge(%{online: false,
-                                         offline: true}) |> Map.delete(:enabled_plugins_file)
-    assert @command.validate_execution_environment(["rabbitmq_stomp"], opts) ==
-      {:validation_failure, :no_plugins_file}
-  end
-
-  test "validate_execution_environment: not specifying a plugins_dir is reported as an error", context do
-    opts = context[:opts] |> Map.merge(%{online: false,
-                                         offline: true}) |> Map.delete(:plugins_dir)
-    assert @command.validate_execution_environment(["rabbitmq_stomp"], opts) ==
-      {:validation_failure, :no_plugins_dir}
-  end
-
-
   test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
     assert @command.validate_execution_environment(["rabbitmq_stomp"],
       Map.merge(context[:opts], %{online: false,
@@ -100,14 +85,6 @@ defmodule PluginIsEnabledCommandTest do
     assert @command.validate_execution_environment(["rabbitmq_stomp"], opts) ==
       {:validation_failure, :plugins_dir_does_not_exist}
   end
-
-  test "validate: failure to load the rabbit application is reported as an error", context do
-    opts = context[:opts] |> Map.merge(%{online: false,
-                                         offline: true}) |> Map.delete(:rabbitmq_home)
-    assert {:validation_failure, {:unable_to_load_rabbit, :rabbitmq_home_is_undefined}} ==
-      @command.validate_execution_environment(["rabbitmq_stomp"], opts)
-  end
-
 
   test "run: when given a single enabled plugin, reports it as such", context do
     opts = context[:opts] |> Map.merge(%{online: true, offline: false})

--- a/test/plugins/list_plugins_command_test.exs
+++ b/test/plugins/list_plugins_command_test.exs
@@ -79,17 +79,6 @@ defmodule ListPluginsCommandTest do
       {:validation_failure, :too_many_args}
   end
 
-  test "validate_execution_environment: not specifying enabled_plugins_file is reported as an error", context do
-    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:validation_failure, :no_plugins_file}
-  end
-
-  test "validate_execution_environment: not specifying plugins_dir is reported as an error", context do
-    assert @command.validate_execution_environment(["a"], Map.delete(context[:opts], :plugins_dir)) ==
-      {:validation_failure, :no_plugins_dir}
-  end
-
-
   test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) == :ok
   end
@@ -97,11 +86,6 @@ defmodule ListPluginsCommandTest do
   test "validate_execution_environment: specifying non existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment(["a"], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
       {:validation_failure, :plugins_dir_does_not_exist}
-  end
-
-  test "validate_execution_environment: failure to load rabbit application is reported as an error", context do
-    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
-      @command.validate_execution_environment(["a"], Map.delete(context[:opts], :rabbitmq_home))
   end
 
   test "will report list of plugins from file for stopped node", context do

--- a/test/plugins/list_plugins_command_test.exs
+++ b/test/plugins/list_plugins_command_test.exs
@@ -36,8 +36,10 @@ defmodule ListPluginsCommandTest do
                                                :application, :get_env,
                                                [:rabbit, :plugins_dir])
     rabbitmq_home = :rabbit_misc.rpc_call(node, :code, :lib_dir, [:rabbit])
+    IO.puts("plugins list tests default env: enabled plugins = #{plugins_file}, plugins dir = #{plugins_dir}, RabbitMQ home directory = #{rabbitmq_home}")
 
     {:ok, [enabled_plugins]} = :file.consult(plugins_file)
+    IO.puts("plugins list tests will assume tnat #{Enum.join(enabled_plugins, ",")} is the list of enabled plugins to revert to")
 
     opts = %{enabled_plugins_file: plugins_file,
              plugins_dir: plugins_dir,

--- a/test/plugins/set_plugins_command_test.exs
+++ b/test/plugins/set_plugins_command_test.exs
@@ -69,16 +69,6 @@ defmodule SetPluginsCommandTest do
     )
   end
 
-  test "validate_execution_environment: not specifying enabled_plugins_file is reported as an error", context do
-    assert @command.validate_execution_environment([], Map.delete(context[:opts], :enabled_plugins_file)) ==
-      {:validation_failure, :no_plugins_file}
-  end
-
-  test "validate_execution_environment: not specifying plugins_dir is reported as an error", context do
-    assert @command.validate_execution_environment([], Map.delete(context[:opts], :plugins_dir)) ==
-      {:validation_failure, :no_plugins_dir}
-  end
-
   test "validate_execution_environment: specifying a non-existent enabled_plugins_file is fine", context do
     assert @command.validate_execution_environment([], Map.merge(context[:opts], %{enabled_plugins_file: "none"})) ==
       :ok
@@ -87,11 +77,6 @@ defmodule SetPluginsCommandTest do
   test "validate_execution_environment: specifying non existent plugins_dir is reported as an error", context do
     assert @command.validate_execution_environment([], Map.merge(context[:opts], %{plugins_dir: "none"})) ==
       {:validation_failure, :plugins_dir_does_not_exist}
-  end
-
-  test "validate_execution_environment: failure to load rabbit application is reported as an error", context do
-    assert {:validation_failure, {:unable_to_load_rabbit, _}} =
-      @command.validate_execution_environment([], Map.delete(context[:opts], :rabbitmq_home))
   end
 
   test "will write enabled plugins file if node is inaccessible and report implicitly enabled list", context do

--- a/test/queues/add_member_command_test.exs
+++ b/test/queues/add_member_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Queues.Commands.AddMemberCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Queues.Commands.AddMemberCommand

--- a/test/queues/delete_member_command_test.exs
+++ b/test/queues/delete_member_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Queues.Commands.DeleteMemberCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Queues.Commands.DeleteMemberCommand

--- a/test/queues/grow_command_test.exs
+++ b/test/queues/grow_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Queues.Commands.GrowCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Queues.Commands.GrowCommand

--- a/test/queues/quorum_status_command_test.exs
+++ b/test/queues/quorum_status_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Queues.Commands.QuorumQueuesCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Queues.Commands.QuorumStatusCommand

--- a/test/queues/shrink_command_test.exs
+++ b/test/queues/shrink_command_test.exs
@@ -14,7 +14,7 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Queues.Commands.ShrinkCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Queues.Commands.ShrinkCommand

--- a/test/upgrade/post_upgrade_command_test.exs
+++ b/test/upgrade/post_upgrade_command_test.exs
@@ -15,7 +15,7 @@
 
 
 defmodule PostUpgradeCommandTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
   import TestHelper
 
   @command RabbitMQ.CLI.Upgrade.Commands.PostUpgradeCommand


### PR DESCRIPTION
This pull request is part of the effort to move rabbitmq-server(8) scripts to Erlang code and transform the `rabbit` application in a regular Erlang/OTP application (rabbitmq/rabbitmq-server#2180).

This patch changes the CLI to use the new `rabbit_env` module introduced in rabbitmq-common. It also uses that module to query a remote node to learn more about its settings.