### PR TITLE
New commands for definition management

### DIFF
--- a/lib/rabbitmq/cli/core/doc_guide.ex
+++ b/lib/rabbitmq/cli/core/doc_guide.ex
@@ -52,6 +52,7 @@ defmodule RabbitMQ.CLI.Core.DocGuide do
   Macros.defguide("connections")
   Macros.defguide("configuration", path_segment: "configure")
   Macros.defguide("consumers")
+  Macros.defguide("definitions")
   Macros.defguide("erlang_versions", path_segment: "which-erlang")
   Macros.defguide("feature_flags", domain: "next.rabbitmq.com")
   Macros.defguide("firehose")

--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -44,6 +44,11 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     end
   end
 
+  def case_insensitive_format(%{format: format} = opts) do
+    %{opts | format: String.downcase(format)}
+  end
+  def case_insensitive_format(opts), do: opts
+
   def nodes_in_cluster(node, timeout \\ :infinity) do
     with_nodes_in_cluster(node, fn nodes -> nodes end, timeout)
   end

--- a/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/change_password_command.ex
@@ -33,7 +33,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ChangePasswordCommand do
     # Credential validators can be used to require passwords of a certain length
     # or following a certain pattern. This is a core server responsibility. MK.
     case Input.infer_password("Password: ", opts) do
-      :eof     -> {:error, :not_enough_args}
+      :eof -> {:error, :not_enough_args}
       password -> :rabbit_misc.rpc_call(
                     node_name,
                     :rabbit_auth_backend_internal,

--- a/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
@@ -83,7 +83,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand do
            {:error, :eisdir} ->
              {:error, ExitCodes.exit_dataerr(), "Path #{path} is a directory"}
            {:error, err}     ->
-             {:error, ExitCodes.exit_dataerr(), "Could not write to file: #{err}"}
+             {:error, ExitCodes.exit_dataerr(), "Could not write to file #{path}: #{err}"}
          end
     end
   end

--- a/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
@@ -72,7 +72,6 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand do
          case File.write(abs_path, body) do
            # no output
            :ok -> {:ok, nil}
-           {:badrpc, _} = err -> err
            {:error, :enoent}  ->
              {:error, ExitCodes.exit_dataerr(), "Parent directory or file #{path} does not exist"}
            {:error, :enotdir} ->

--- a/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
@@ -1,0 +1,142 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand do
+  alias RabbitMQ.CLI.Core.{DocGuide, ExitCodes, Helpers}
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def merge_defaults(["-"] = args, opts) do
+    {args, Map.merge(%{format: "json", silent: true}, Helpers.case_insensitive_format(opts))}
+  end
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{format: "json"}, Helpers.case_insensitive_format(opts))}
+  end
+
+  def switches(), do: [timeout: :integer, format: :string]
+  def aliases(), do: [t: :timeout]
+
+  def validate(_, %{format: format})
+      when format != "json" and format != "JSON" and format != "erlang" do
+    {:validation_failure, {:bad_argument, "Format should be either json or erlang"}}
+  end
+  def validate(args, _) when length(args) > 1 do
+    {:validation_failure, :too_many_args}
+  end
+  # output to stdout
+  def validate(["-"], _) do
+    :ok
+  end
+  def validate([path], _) do
+    dir = Path.dirname(path)
+    case File.exists?(dir, [raw: true]) do
+      true  -> :ok
+      false -> {:validation_failure, {:bad_argument, "Directory #{dir} does not exist"}}
+    end
+  end
+  def validate(_, _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run(["-"], %{node: node_name, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_definitions, :all_definitions, [], timeout) do
+      {:error, _} = err -> err
+      {:error, _, _} = err -> err
+      result -> {:ok, result}
+    end
+  end
+  def run([path], %{node: node_name, timeout: timeout, format: format}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_definitions, :all_definitions, [], timeout) do
+      {:badrpc, _} = err -> err
+      {:error, _} = err -> err
+      {:error, _, _} = err -> err
+      result ->
+         # write to the file in run/2 because output/2 is not meant to
+         # produce side effects
+         body = serialise(result, format)
+         abs_path = Path.absname(path)
+
+         File.rm(abs_path)
+         case File.write(abs_path, body) do
+           # no output
+           :ok -> {:ok, nil}
+           {:badrpc, _} = err -> err
+           {:error, :enoent}  ->
+             {:error, ExitCodes.exit_dataerr(), "Parent directory or file #{path} does not exist"}
+           {:error, :enotdir} ->
+             {:error, ExitCodes.exit_dataerr(), "Parent directory of file #{path} is not a directory"}
+           {:error, :enospc} ->
+             {:error, ExitCodes.exit_dataerr(), "No space left on device hosting #{path}"}
+           {:error, :eacces} ->
+             {:error, ExitCodes.exit_dataerr(), "No permissions to write to file #{path} or its parent directory"}
+           {:error, :eisdir} ->
+             {:error, ExitCodes.exit_dataerr(), "Path #{path} is a directory"}
+           {:error, err}     ->
+             {:error, ExitCodes.exit_dataerr(), "Could not write to file: #{err}"}
+         end
+    end
+  end
+
+  def output({:ok, nil}, _) do
+    {:ok, nil}
+  end
+  def output({:ok, result}, %{format: "json"}) when is_map(result) do
+    {:ok, serialise(result, "json")}
+  end
+  def output({:ok, result}, %{format: "erlang"}) when is_map(result) do
+    {:ok, serialise(result, "erlang")}
+  end
+  use RabbitMQ.CLI.DefaultOutput
+
+  def printer(), do: RabbitMQ.CLI.Printers.StdIORaw
+
+  def usage, do: "export_definitions <file_path | \"-\"> [--formatter <json | erlang>]"
+
+  def usage_additional() do
+    [
+      ["<file>", "Local file path to export to. Pass a dash (-) for stdout."],
+      ["--format", "output format to use: json or erlang"]
+    ]
+  end
+
+  def usage_doc_guides() do
+    [
+      DocGuide.definitions()
+    ]
+  end
+
+  def help_section(), do: :definitions
+
+  def description(), do: "Exports definitions in JSON or compressed Erlang Term Format."
+
+  def banner([path], %{format: fmt}), do: "Exporting definitions in #{human_fiendly_format(fmt)} to a file at \"#{path}\" ..."
+
+  #
+  # Implementation
+  #
+
+  defp serialise(map, "json") do
+    {:ok, json} = JSON.encode(map)
+    json
+  end
+
+  defp serialise(map, "erlang") do
+    :erlang.term_to_binary(map, [{:compressed, 9}])
+  end
+
+  defp human_fiendly_format("JSON"), do: "JSON"
+  defp human_fiendly_format("json"), do: "JSON"
+  defp human_fiendly_format("erlang"), do: "Erlang term format"
+end

--- a/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
@@ -101,7 +101,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand do
 
   def printer(), do: RabbitMQ.CLI.Printers.StdIORaw
 
-  def usage, do: "export_definitions <file_path | \"-\"> [--formatter <json | erlang>]"
+  def usage, do: "export_definitions <file_path | \"-\"> [--format <json | erlang>]"
 
   def usage_additional() do
     [

--- a/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
@@ -32,6 +32,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand do
       when format != "json" and format != "JSON" and format != "erlang" do
     {:validation_failure, {:bad_argument, "Format should be either json or erlang"}}
   end
+  def validate([], _) do
+    {:validation_failure, :not_enough_args}
+  end
   def validate(args, _) when length(args) > 1 do
     {:validation_failure, :too_many_args}
   end

--- a/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
@@ -120,7 +120,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand do
 
   def description(), do: "Exports definitions in JSON or compressed Erlang Term Format."
 
-  def banner([path], %{format: fmt}), do: "Exporting definitions in #{human_fiendly_format(fmt)} to a file at \"#{path}\" ..."
+  def banner([path], %{format: fmt}), do: "Exporting definitions in #{human_friendly_format(fmt)} to a file at \"#{path}\" ..."
 
   #
   # Implementation
@@ -135,7 +135,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand do
     :erlang.term_to_binary(map, [{:compressed, 9}])
   end
 
-  defp human_fiendly_format("JSON"), do: "JSON"
-  defp human_fiendly_format("json"), do: "JSON"
-  defp human_fiendly_format("erlang"), do: "Erlang term format"
+  defp human_friendly_format("JSON"), do: "JSON"
+  defp human_friendly_format("json"), do: "JSON"
+  defp human_friendly_format("erlang"), do: "Erlang term format"
 end

--- a/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
@@ -90,7 +90,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
     case Config.output_less?(opts) do
       true  -> :ok
       false -> {:ok, "Successfully started definition import. " <>
-                     "This process is asynchronous and can take some time."}
+                     "This process is asynchronous and can take some time.\n"}
     end
   end
   use RabbitMQ.CLI.DefaultOutput

--- a/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/import_definitions_command.ex
@@ -1,0 +1,138 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand do
+  alias RabbitMQ.CLI.Core.{DocGuide, ExitCodes, Helpers}
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def merge_defaults(["-"] = args, opts) do
+    {args, Map.merge(%{format: "json", silent: true}, Helpers.case_insensitive_format(opts))}
+  end
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{format: "json"}, Helpers.case_insensitive_format(opts))}
+  end
+
+  def switches(), do: [timeout: :integer, format: :string]
+  def aliases(), do: [t: :timeout]
+
+  def validate(_, %{format: format})
+      when format != "json" and format != "JSON" and format != "erlang" do
+    {:validation_failure, {:bad_argument, "Format should be either json or erlang"}}
+  end
+  def validate(args, _) when length(args) > 1 do
+    {:validation_failure, :too_many_args}
+  end
+  # output to stdout
+  def validate(["-"], _) do
+    :ok
+  end
+  def validate([path], _) do
+    dir = Path.dirname(path)
+    case File.exists?(dir, [raw: true]) do
+      true  -> :ok
+      false -> {:validation_failure, {:bad_argument, "Directory #{dir} does not exist"}}
+    end
+  end
+  def validate(_, _), do: :ok
+
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, format: format, timeout: timeout} = opts) do
+#    case Input.consume_stdio do
+#      :eof -> {:error, :not_enough_args}
+#      bin  ->
+#        {:ok, map} = deserialise(bin, format)
+#        :rabbit_misc.rpc_call(node_name, :rabbit_definition, :import_parsed, [map], timeout)
+#    end
+  end
+  def run([path], %{node: node_name, timeout: timeout, format: format}) do
+    abs_path = Path.absname(path)
+
+    case File.read(abs_path) do
+      # no output
+      {:ok, bin} ->
+        {:ok, map} = deserialise(bin, format)
+        :rabbit_misc.rpc_call(node_name, :rabbit_definitions, :import_parsed, [map], timeout)
+      {:error, :enoent}  ->
+        {:error, ExitCodes.exit_dataerr(), "Parent directory or file #{path} does not exist"}
+      {:error, :enotdir} ->
+        {:error, ExitCodes.exit_dataerr(), "Parent directory of file #{path} is not a directory"}
+      {:error, :eacces} ->
+        {:error, ExitCodes.exit_dataerr(), "No permissions to read from file #{path} or its parent directory"}
+      {:error, :eisdir} ->
+        {:error, ExitCodes.exit_dataerr(), "Path #{path} is a directory"}
+      {:error, err}     ->
+        {:error, ExitCodes.exit_dataerr(), "Could not read from file #{path}: #{err}"}
+    end
+  end
+
+  def output(:ok, %{node: node_name, formatter: "json"}) do
+    {:ok, %{"result" => "ok", "node" => node_name}}
+  end
+  def output(:ok, %{silent: silent}) when silent == false do
+    {:ok, "Successfully started definition import. " <>
+          "This process is asynchronous and can take some time."}
+  end
+  def output(:ok, %{quiet: quiet}) when quiet == false do
+    {:ok, "Successfully started definition import. " <>
+          "This process is asynchronous and can take some time."}
+  end
+  use RabbitMQ.CLI.DefaultOutput
+
+  def printer(), do: RabbitMQ.CLI.Printers.StdIORaw
+
+  def usage, do: "import_definitions <file_path | \"-\"> [--format <json | erlang>]"
+
+  def usage_additional() do
+    [
+      ["[file]", "Local file path to import from. If omitted will be read from standard input."],
+      ["--format", "input format to use: json or erlang"]
+    ]
+  end
+
+  def usage_doc_guides() do
+    [
+      DocGuide.definitions()
+    ]
+  end
+
+  def help_section(), do: :definitions
+
+  def description(), do: "Imports definitions in JSON or compressed Erlang Term Format."
+
+  def banner([], %{format: fmt}) do
+    "Importing definitions in #{human_fiendly_format(fmt)} from standard input ..."
+  end
+  def banner([path], %{format: fmt}) do
+    "Importing definitions in #{human_fiendly_format(fmt)} from a file at \"#{path}\" ..."
+  end
+
+  #
+  # Implementation
+  #
+
+  defp deserialise(bin, "json") do
+    JSON.decode(bin)
+  end
+
+  defp deserialise(bin, "erlang") do
+    {:ok, :erlang.binary_to_term(bin)}
+  end
+
+  defp human_fiendly_format("JSON"), do: "JSON"
+  defp human_fiendly_format("json"), do: "JSON"
+  defp human_fiendly_format("erlang"), do: "Erlang term format"
+end

--- a/lib/rabbitmq/cli/default_output.ex
+++ b/lib/rabbitmq/cli/default_output.ex
@@ -45,19 +45,20 @@ defmodule RabbitMQ.CLI.DefaultOutput do
   defp normalize_output({:badrpc, {:timeout, _n}} = input), do: {:error, input}
   defp normalize_output({:badrpc, {:timeout, _n, _msg}} = input), do: {:error, input}
   defp normalize_output({:badrpc, {:EXIT, reason}}), do: {:error, reason}
+  defp normalize_output({:error, exit_code, string} = input) when is_integer(exit_code) do
+    {:error, exit_code, to_string(string)}
+  end
   defp normalize_output({:error, format, args})
        when (is_list(format) or is_binary(format)) and is_list(args) do
     {:error, to_string(:rabbit_misc.format(format, args))}
   end
-
-  defp normalize_output({:error_string, string}) do
-    {:error, to_string(string)}
-  end
-
   defp normalize_output({:error, _} = input), do: input
   defp normalize_output(unknown) when is_atom(unknown), do: {:error, unknown}
   defp normalize_output({unknown, _} = input) when is_atom(unknown), do: {:error, input}
   defp normalize_output(result) when not is_atom(result), do: {:ok, result}
+  defp normalize_output({:error_string, string}) do
+    {:error, to_string(string)}
+  end
 
   defp format_output({:error, _} = result) do
     result

--- a/lib/rabbitmq/cli/default_output.ex
+++ b/lib/rabbitmq/cli/default_output.ex
@@ -53,12 +53,12 @@ defmodule RabbitMQ.CLI.DefaultOutput do
     {:error, to_string(:rabbit_misc.format(format, args))}
   end
   defp normalize_output({:error, _} = input), do: input
-  defp normalize_output(unknown) when is_atom(unknown), do: {:error, unknown}
-  defp normalize_output({unknown, _} = input) when is_atom(unknown), do: {:error, input}
-  defp normalize_output(result) when not is_atom(result), do: {:ok, result}
   defp normalize_output({:error_string, string}) do
     {:error, to_string(string)}
   end
+  defp normalize_output(unknown) when is_atom(unknown), do: {:error, unknown}
+  defp normalize_output({unknown, _} = input) when is_atom(unknown), do: {:error, input}
+  defp normalize_output(result) when not is_atom(result), do: {:ok, result}
 
   defp format_output({:error, _} = result) do
     result

--- a/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -14,17 +14,13 @@
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
+  alias RabbitMQ.CLI.Core.Helpers
+
   @behaviour RabbitMQ.CLI.CommandBehaviour
-  use RabbitMQ.CLI.DefaultOutput
 
   def merge_defaults(args, opts) do
-    {args, Map.merge(%{all: false, format: "openssl"}, case_insensitive_format(opts))}
+    {args, Map.merge(%{all: false, format: "openssl"}, Helpers.case_insensitive_format(opts))}
   end
-
-  defp case_insensitive_format(%{format: format} = opts) do
-    %{ opts | format: String.downcase(format) }
-  end
-  defp case_insensitive_format(opts), do: opts
 
   def switches(), do: [timeout: :integer,
                        format: :string,
@@ -53,6 +49,8 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
     end
     :rabbit_misc.rpc_call(node_name, mod, function, args, timeout)
   end
+
+  use RabbitMQ.CLI.DefaultOutput
 
   def banner([], %{format: "openssl"}),  do: "Listing available cipher suites in OpenSSL format"
   def banner([], %{format: "erlang"}), do: "Listing available cipher suites in Erlang term format"

--- a/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/cipher_suites_command.ex
@@ -62,7 +62,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.CipherSuitesCommand do
 
   def description(), do: "Lists cipher suites enabled by default. To list all available cipher suites, add the --all argument."
 
-  def usage, do: "cipher_suites [--format (openssl | erlang | map)] [--all]"
+  def usage, do: "cipher_suites [--format <openssl | erlang | map>] [--all]"
 
   def usage_additional() do
     [

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -163,21 +163,20 @@ defmodule RabbitMQCtl do
   defp maybe_run_command(command, arguments, options) do
     try do
       command.run(arguments, options) |> command.output(options)
-    catch
-      _error_type, error ->
-        maybe_print_stacktrace(error, System.stacktrace(), options)
+    catch error_type, error ->
+        maybe_print_stacktrace(error_type, error, __STACKTRACE__, options)
         format_error(error, options, command)
     end
   end
 
-  def maybe_print_stacktrace(error, stacktrace, %{print_stacktrace: true}) do
+  def maybe_print_stacktrace(error_type, error, stacktrace, %{print_stacktrace: true}) do
     IO.puts("Stack trace: \n")
-    IO.puts(Exception.format(:error, error, stacktrace))
+    IO.puts(Exception.format(error_type, error, stacktrace))
   end
-  def maybe_print_stacktrace(_error, _stacktrace, %{print_stacktrace: false}) do
+  def maybe_print_stacktrace(_error_type, _error, _stacktrace, %{print_stacktrace: false}) do
     nil
   end
-  def maybe_print_stacktrace(_error, _stacktrace, _opts) do
+  def maybe_print_stacktrace(_error_type, _error, _stacktrace, _opts) do
     nil
   end
 
@@ -380,11 +379,11 @@ defmodule RabbitMQCtl do
 
   defp format_error(:undef, _opts, _module) do
     {:error, ExitCodes.exit_software(),
-      "Function clause.\nStacktrace:\n" <> Exception.format_stacktrace()}
+      "\n:undef error!\nRe-run with --print-stacktrace to see stacktrace.\n"}
   end
   defp format_error(:function_clause, _opts, _module) do
     {:error, ExitCodes.exit_software(),
-      "Function clause.\nStacktrace:\n" <> Exception.format_stacktrace()}
+      "\n:function_clause error!\nRe-run with --print-stacktrace to see stacktrace.\n"}
   end
   defp format_error({:error, {:node_name, :hostname_not_allowed}}, _, _) do
     {:error, ExitCodes.exit_dataerr(),

--- a/test/core/default_output_test.exs
+++ b/test/core/default_output_test.exs
@@ -55,13 +55,12 @@ defmodule DefaultOutputTest do
   end
 
   test "error_string is error" do
-    {:error, "I am string"} =
-      ExampleCommand.output({:error_string, "I am string"}, %{})
+    assert {:error, "I am string"} == ExampleCommand.output({:error_string, "I am string"}, %{})
   end
 
   test "error_string is converted to string" do
-    {:error, "I am charlist"} =
-      ExampleCommand.output({:error_string, 'I am charlist'}, %{})
+    assert match?({:error, "I am charlist"},
+                  ExampleCommand.output({:error_string, 'I am charlist'}, %{}))
   end
 
   test "error is formatted" do
@@ -81,28 +80,25 @@ defmodule DefaultOutputTest do
   end
 
   test "custom output function can be defined" do
-    assert match?({:error, 125, "Non standard"},
-                  ExampleCommandWithCustomOutput.output(:non_standard_output, %{}))
+    assert {:error, 125, "Non standard"} == ExampleCommandWithCustomOutput.output(:non_standard_output, %{})
   end
 
   test "default output works even if custom output is defined" do
-    assert match?(:ok, ExampleCommandWithCustomOutput.output(:ok, %{}))
-    assert match?({:ok, {:complex, "message"}},
-                  ExampleCommandWithCustomOutput.output({:ok, {:complex, "message"}}, %{}))
+    assert :ok == ExampleCommandWithCustomOutput.output(:ok, %{})
+    assert {:ok, {:complex, "message"}} == ExampleCommandWithCustomOutput.output({:ok, {:complex, "message"}}, %{})
 
-    assert match?({:stream, [1,2,3]}, ExampleCommandWithCustomOutput.output({:ok, [1,2,3]}, %{}))
-    assert match?({:stream, [1,2,3]}, ExampleCommandWithCustomOutput.output([1,2,3], %{}))
+    assert {:stream, [1,2,3]} == ExampleCommandWithCustomOutput.output({:ok, [1,2,3]}, %{})
+    assert {:stream, [1,2,3]} == ExampleCommandWithCustomOutput.output([1,2,3], %{})
 
-    {:error, {:badrpc, :nodedown}} =
+    assert {:error, {:badrpc, :nodedown}} ==
       ExampleCommandWithCustomOutput.output({:badrpc, :nodedown}, %{})
-    {:error, {:badrpc, :timeout}} =
+    assert {:error, {:badrpc, :timeout}} ==
       ExampleCommandWithCustomOutput.output({:badrpc, :timeout}, %{})
 
     error = %{i: [am: "arbitrary", error: 1]}
     {:error, ^error} = ExampleCommandWithCustomOutput.output({:error, error}, %{})
 
-    {:error, "I am string"} =
-      ExampleCommandWithCustomOutput.output({:error_string, "I am string"}, %{})
+    assert {:error, "I am string"} == ExampleCommandWithCustomOutput.output({:error_string, "I am string"}, %{})
 
     val = "foo"
     assert match?({:ok, ^val}, ExampleCommandWithCustomOutput.output(val, %{}))

--- a/test/ctl/export_definitions_command_test.exs
+++ b/test/ctl/export_definitions_command_test.exs
@@ -1,0 +1,123 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+
+defmodule ExportDefinitionsCommandTest do
+  use ExUnit.Case
+  import TestHelper
+
+  @command RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000,
+        format: context[:format] || "json"
+      }}
+  end
+
+  test "merge_defaults: defaults to JSON for format" do
+    assert @command.merge_defaults([valid_file_path()], %{}) ==
+             {[valid_file_path()], %{format: "json"}}
+  end
+
+  test "merge_defaults: defaults to --silent if target is stdout" do
+    assert @command.merge_defaults(["-"], %{}) == {["-"], %{format: "json", silent: true}}
+  end
+
+  test "merge_defaults: format is case insensitive" do
+    assert @command.merge_defaults([valid_file_path()], %{format: "JSON"}) ==
+             {[valid_file_path()], %{format: "json"}}
+    assert @command.merge_defaults([valid_file_path()], %{format: "Erlang"}) ==
+             {[valid_file_path()], %{format: "erlang"}}
+  end
+
+  test "merge_defaults: format can be overridden" do
+    assert @command.merge_defaults([valid_file_path()], %{format: "erlang"}) ==
+             {[valid_file_path()], %{format: "erlang"}}
+  end
+
+  test "validate: accepts a file path argument", context do
+    assert @command.validate([valid_file_path()], context[:opts]) == :ok
+  end
+
+  test "validate: accepts a dash for stdout", context do
+    assert @command.validate(["-"], context[:opts]) == :ok
+  end
+
+  test "validate: unsupported format fails validation", context do
+    assert match?({:validation_failure, {:bad_argument, _}},
+                  @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "yolo"})))
+  end
+
+  test "validate: more than one positional argument fails validation", context do
+    assert @command.validate([valid_file_path(), "extra-arg"], context[:opts]) ==
+             {:validation_failure, :too_many_args}
+  end
+
+  test "validate: supports openssl, erlang and map formats", context do
+    assert @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "json"})) == :ok
+    assert @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "erlang"})) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    result = @command.run([valid_file_path()],
+                          %{node: :jake@thedog,
+                            timeout: context[:test_timeout],
+                            format: "json"})
+    assert match?({:badrpc, _}, result)
+  end
+
+  @tag format: "json"
+  test "run: returns a list of definitions when target is stdout and format is JSON", context do
+    {:ok, map} = @command.run(["-"], context[:opts])
+    assert Map.has_key?(map, :rabbitmq_version)
+  end
+
+  @tag format: "erlang"
+  test "run: returns a list of definitions when target is stdout and format is Erlang Terms", context do
+    {:ok, map} = @command.run(["-"], context[:opts])
+    assert Map.has_key?(map, :rabbitmq_version)
+  end
+
+  @tag format: "json"
+  test "run: writes to a file and returns nil when target is a file and format is JSON", context do
+    File.rm(valid_file_path())
+    {:ok, nil} = @command.run([valid_file_path()], context[:opts])
+
+    {:ok, bin} = File.read(valid_file_path())
+    {:ok, map} = JSON.decode(bin)
+    assert Map.has_key?(map, "rabbitmq_version")
+  end
+
+  @tag format: "erlang"
+  test "run: writes to a file and returns nil when target is a file and format is Erlang Terms", context do
+    File.rm(valid_file_path())
+    {:ok, nil} = @command.run([valid_file_path()], context[:opts])
+
+    {:ok, bin} = File.read(valid_file_path())
+    map = :erlang.binary_to_term(bin)
+    assert Map.has_key?(map, :rabbitmq_version)
+  end
+
+  defp valid_file_path(), do: "#{System.tmp_dir()}/definitions"
+end

--- a/test/ctl/export_definitions_command_test.exs
+++ b/test/ctl/export_definitions_command_test.exs
@@ -68,6 +68,11 @@ defmodule ExportDefinitionsCommandTest do
                   @command.validate([valid_file_path()], Map.merge(context[:opts], %{format: "yolo"})))
   end
 
+    test "validate: no positional arguments fails validation", context do
+    assert @command.validate([], context[:opts]) ==
+             {:validation_failure, :not_enough_args}
+  end
+
   test "validate: more than one positional argument fails validation", context do
     assert @command.validate([valid_file_path(), "extra-arg"], context[:opts]) ==
              {:validation_failure, :too_many_args}

--- a/test/fixtures/files/definitions.json
+++ b/test/fixtures/files/definitions.json
@@ -1,0 +1,27 @@
+{
+  "rabbit_version": "3.7.21",
+  "vhosts": [
+    {
+      "name": "\/"
+    }
+  ],
+  "queues": [
+    
+  ],
+  "exchanges": [
+    {
+      "name": "project.topic.default",
+      "vhost": "\/",
+      "type": "topic",
+      "durable": true,
+      "auto_delete": false,
+      "internal": false,
+      "arguments": {
+        
+      }
+    }
+  ],
+  "bindings": [
+    
+  ]
+}


### PR DESCRIPTION
## Proposed Changes

This introduces new commands for definition export and import that does not depend on any plugins:

``` bash
rabbitmqctl export_definitions /tmp/definitions.et --format=erlang --silent
rabbitmqctl import_definitions /tmp/definitions.et --format=erlang --silent
```

``` bash
# output as JSON to standard output
rabbitmqctl export_definitions - --format=json --silent | jq
```

``` bash
./escript/rabbitmqctl export_definitions - --format=json | ./escript/rabbitmqctl import_definitions --format=json
```

``` bash
./escript/rabbitmqctl import_definitions --format=json ./escript/rabbitmqctl import_definitions --format=json ./test/fixtures/files/definitions.json
```

Part of rabbitmq/rabbitmq-management#749 and depends on other PRs mentioned in that issue.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories

## Further Comments

Part of rabbitmq/rabbitmq-management#749.