### PR TITLE
Introduce `rabbitmq-queues check_if_node_is_quorum_critical`

### DIFF
--- a/lib/rabbit_common/records.ex
+++ b/lib/rabbit_common/records.ex
@@ -17,6 +17,9 @@ defmodule RabbitCommon.Records do
   require Record
   import Record, only: [defrecord: 2, extract: 2]
 
+  # Important: amqqueue records must not be used directly since they are versioned
+  #            for mixed version cluster compatibility. Convert records
+  #            to maps on the server end to access the fields of those records. MK.
   defrecord :listener, extract(:listener, from_lib: "rabbit_common/include/rabbit.hrl")
   defrecord :plugin, extract(:plugin, from_lib: "rabbit_common/include/rabbit.hrl")
   defrecord :resource, extract(:resource, from_lib: "rabbit_common/include/rabbit.hrl")

--- a/lib/rabbitmq/cli/queues/commands/check_if_node_is_quorum_critical_command.ex
+++ b/lib/rabbitmq/cli/queues/commands/check_if_node_is_quorum_critical_command.ex
@@ -1,0 +1,93 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsQuorumCriticalCommand do
+  @moduledoc """
+  Exits with a non-zero code if there are quorum queues that would lose their quorum
+  if the target node is shut down.
+
+  This command is meant to be used as a pre-upgrade (pre-shutdown) check.
+  """
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  import RabbitMQ.CLI.Core.Platform, only: [line_separator: 0]
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_quorum_queue, :list_with_minimum_quorum_for_cli, [], timeout) do
+      [] -> []
+      qs when is_list(qs) -> qs
+      other -> other
+    end
+  end
+
+  def output([], %{formatter: "json"}) do
+    {:ok, %{"result" => "ok"}}
+  end
+
+  def output([], %{silent: true}) do
+    {:ok, :check_passed}
+  end
+
+  def output([], %{node: node_name}) do
+    {:ok, "Node #{node_name} reported no quorum queues with minimum quorum"}
+  end
+
+  def output(qs, %{node: node_name, formatter: "json"}) when is_list(qs) do
+    {:error, :check_failed,
+     %{
+       "result" => "error",
+       "queues" => qs,
+       "message" => "Node #{node_name} reported local queues with minimum online quorum"
+     }}
+  end
+
+  def output(_qs, %{silent: true}) do
+    {:error, :check_failed}
+  end
+
+  def output(qs, %{node: node_name}) when is_list(qs) do
+    lines = queue_lines(qs, node_name)
+
+    {:error, :check_failed, Enum.join(lines, line_separator())}
+  end
+  use RabbitMQ.CLI.DefaultOutput
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description() do
+    "Health check that exits with a non-zero code if there are queues " <>
+    "with minimum online quorum (queues that would lose their quorum if the target node is shut down)"
+  end
+
+  def usage, do: "check_if_node_is_quorum_critical"
+
+  def banner([], %{node: node_name}) do
+    "Checking if node #{node_name} is critical for quorum of any quorum queues ..."
+  end
+
+  #
+  # Implementation
+  #
+
+  def queue_lines(qs, node_name) do
+    for q <- qs, do: "#{q["readable_name"]} would lose quorum if node #{node_name} is stopped"
+  end
+end

--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -522,8 +522,8 @@ defmodule RabbitMQCtl do
   defp format_error({:error, :check_failed, err}, %{formatter: "json"}, _) do
     {:error, ExitCodes.exit_unavailable(), err}
   end
-  defp format_error({:error, :check_failed, _}, _, _) do
-    {:error, ExitCodes.exit_unavailable(), nil}
+  defp format_error({:error, :check_failed, err}, _, _) do
+    {:error, ExitCodes.exit_unavailable(), err}
   end
 
   defp format_error({:error, nil}, _, _) do

--- a/test/queues/check_if_node_is_quorum_critical_command_test.exs
+++ b/test/queues/check_if_node_is_quorum_critical_command_test.exs
@@ -1,0 +1,49 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsQuorumCriticalCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsQuorumCriticalCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000
+      }}
+  end
+
+  test "validate: accepts no positional arguments" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  test "validate: any positional arguments fail validation" do
+    assert @command.validate(["quorum-queue-a"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["quorum-queue-a", "two"], %{}) == {:validation_failure, :too_many_args}
+    assert @command.validate(["quorum-queue-a", "two", "three"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc" do
+    assert match?({:badrpc, _}, @command.run([], %{node: :jake@thedog, vhost: "/", timeout: 200}))
+  end
+end

--- a/test/queues/quorum_status_command_test.exs
+++ b/test/queues/quorum_status_command_test.exs
@@ -13,7 +13,7 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 
-defmodule RabbitMQ.CLI.Queues.Commands.QuorumQueuesCommandTest do
+defmodule RabbitMQ.CLI.Queues.Commands.QuorumStatusCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 


### PR DESCRIPTION
Introduce `rabbitmq-queues check_if_node_is_quorum_critical` that returns a non-zero status if shutdown or removal of target node would make one or more quorum queues from sustaining a quorum.

Part one of rabbitmq/rabbitmq-cli#389.
