### PR TITLE
wait_command.ex: Change `wait` internal sleep to one second

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/wait_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/wait_command.ex
@@ -118,7 +118,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.WaitCommand do
   #
 
   def wait_for(timeout, fun) do
-    sleep = round(timeout / 10)
+    sleep = 1000
 
     case wait_for_loop(timeout, sleep, fun) do
       {:error, :timeout} -> {:error, {:timeout, timeout}}


### PR DESCRIPTION
... down from 10% of the configured timeout.

This has a significant impact on the time it takes to start RabbitMQ in all our testsuites. rabbitmq-ct-helpers sets a wait timeout of 180 seconds. Thus before this patch, the wait loop would sleep for 18
seconds between each check. Given it takes about 1.5 seconds to start RabbitMQ, a lot of time is wasted here.

Here are some numbers after running testsuites with and without this patch:

* `make ct-fast` in rabbitmq-server: 8m15s down to 4m58s
* `make ct` in rabbitmq-mqtt: 9m23s down to 6m43s
* `make ct` in rabbitmq-stomp: 4m31s down to 2m04s