### PR TITLE
Handle the move of the enabled_plugins file

### DIFF
--- a/lib/rabbitmq/cli/plugins/commands/directories_command.ex
+++ b/lib/rabbitmq/cli/plugins/commands/directories_command.ex
@@ -71,8 +71,14 @@ defmodule RabbitMQ.CLI.Plugins.Commands.DirectoriesCommand do
   end
 
   def run([], %{offline: true} = opts) do
-    do_run(fn key ->
-      Config.get_option(key, opts)
+    do_run(fn
+      :enabled_plugins_file ->
+        case PluginHelpers.enabled_plugins_file(opts) do
+          {:ok, plugins_file} -> plugins_file
+          _ -> nil
+        end
+      key ->
+        Config.get_option(key, opts)
     end)
   end
 


### PR DESCRIPTION
We look for the enabled_plugins file at the deprecated location, and at the new location. If it exists only at the deprecated location, we attempt to use that file. If the deprecated location is read-only, we allow the cli command to fail (or not) as it always used to.

Part of the changes intended to address https://github.com/rabbitmq/rabbitmq-server/issues/2234