### PR TITLE
Introduce 'rabbitmq-diagnostics os_env'

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/os_env_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/os_env_command.ex
@@ -1,0 +1,76 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.OsEnvCommand do
+  @moduledoc """
+  Lists RabbitMQ-specific environment variables defined on target node
+  """
+
+  import RabbitMQ.CLI.Core.Platform, only: [line_separator: 0]
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def scopes(), do: [:diagnostics]
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+  use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_env, :get_used_env_vars, [], timeout) do
+      {:error, _} = err -> err
+      {:error, _, _} = err -> err
+      xs when is_list(xs) ->
+        # convert keys and values to binaries (Elixir strings)
+        xs
+        |> Enum.map(fn {k, v} -> {:rabbit_data_coercion.to_binary(k), :rabbit_data_coercion.to_binary(v)} end)
+        |> :maps.from_list
+      other -> other
+    end
+  end
+
+  def output([], %{formatter: fmt}) when fmt == "csv" or fmt == "erlang" do
+    {:ok, []}
+  end
+  def output([], %{node: node_name, formatter: "json"}) do
+    {:ok, %{"result" => "ok", "node" => node_name, "variables" => []}}
+  end
+  def output([], %{node: node_name}) do
+    {:ok, "Node #{node_name} reported no relevant environment variables."}
+  end
+  def output(vars, %{node: node_name, formatter: "json"}) do
+    {:ok, %{"result" => "ok", "node" => node_name, "variables" => vars}}
+  end
+  def output(vars, %{formatter: "csv"}) do
+    {:stream, [Enum.map(vars, fn({k, v}) -> [variable: k, value: v] end)]}
+  end
+  def output(vars, _opts) do
+    lines = Enum.map(vars, fn({k, v}) -> "#{k}=#{v}" end) |> Enum.join(line_separator())
+    {:ok, lines}
+  end
+
+  def usage() do
+    "os_env"
+  end
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists RabbitMQ-specific environment variables set on target node"
+
+  def banner(_, %{node: node_name}) do
+    "Asking node #{node_name} to report its defined RabbitMQ-specific environment variables..."
+  end
+end

--- a/test/diagnostics/os_env_command_test.exs
+++ b/test/diagnostics/os_env_command_test.exs
@@ -1,0 +1,66 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule OsEnvCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.OsEnvCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+
+    start_rabbitmq_app()
+
+    ExUnit.configure([max_cases: 1])
+
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000,
+        all: false
+      }}
+  end
+
+  test "merge_defaults: merges no defaults" do
+    assert @command.merge_defaults([], %{}) == {[], %{}}
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: treats empty positional arguments and default switches as a success" do
+    assert @command.validate([], %{}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
+  end
+
+  test "run: returns defines RabbitMQ-specific environment variable", context do
+    vars = @command.run([], context[:opts])
+
+    assert vars["RABBITMQ_CONFIG_FILE"] != nil
+  end
+end


### PR DESCRIPTION
## Proposed Changes

This introduces a new diagnostics command, `rabbitmq-diagnostics os_env`.

It prints RabbitMQ-specific environment variables that
are set on the target node. Can be used to inspect env variable-based
configuration without access to the target host.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in related repositories
