### PR TITLE
Add GitHub Actions workflows

### DIFF
--- a/.github/workflows/test-erlang-otp-21.3.yaml
+++ b/.github/workflows/test-erlang-otp-21.3.yaml
@@ -49,6 +49,9 @@ jobs:
             DEPS_DIR=$PWD/.. \
             current_rmq_ref=$branch_or_tag_name > /dev/null 2>&1
 
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.8.0
           make tests \
             HONEYCOMB_FORMATTER=true \
             DEPS_DIR=$PWD/.. \

--- a/.github/workflows/test-erlang-otp-21.3.yaml
+++ b/.github/workflows/test-erlang-otp-21.3.yaml
@@ -1,0 +1,88 @@
+# vim:sw=2:et:
+# https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow
+name: "Test - Erlang 21.3"
+on:
+  push:
+  repository_dispatch:
+    types:
+      - new-commit-to-dep-release-branch
+jobs:
+  # vim:sw=2:et:
+  tests:
+    name: tests
+    runs-on: ubuntu-18.04
+    steps:
+      - name: CHECKOUT REPOSITORY
+        uses: actions/checkout@v2
+      # https://github.com/marketplace/actions/setup-elixir
+      - name: CONFIGURE OTP & ELIXIR
+        uses: actions/setup-elixir@v1
+        with:
+          otp-version: 21.3
+          # https://github.com/elixir-lang/elixir/releases
+          elixir-version: 1.8.0
+      - name: RUN TESTS
+        run: |
+          base_rmq_ref=master
+          branch_or_tag_name=${GITHUB_REF#refs/*/}
+
+          make \
+            DEPS_DIR=$PWD/.. \
+            current_rmq_ref=$branch_or_tag_name
+
+          git clone \
+            --branch "$base_rmq_ref" \
+            --depth 1 \
+            https://github.com/rabbitmq/rabbitmq-server-release.git \
+            ../rabbitmq_server_release
+          make start-background-broker -C ../rabbitmq_server_release \
+            DEPS_DIR=$PWD/.. \
+            PLUGINS='rabbitmq_federation rabbitmq_stomp' \
+            PROJECT_VERSION=3.9.0 \
+            current_rmq_ref=$branch_or_tag_name
+
+          make tests \
+            HONEYCOMB_FORMATTER=true \
+            DEPS_DIR=$PWD/.. \
+            current_rmq_ref=$branch_or_tag_name
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls /tmp/honeycomb | wc -l) events recorded"
+          for f in /tmp/honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done
+      - name: ON FAILURE ARCHIVE BROKER LOGS
+        if: failure()
+        run: |
+          ls /tmp/rabbitmq-test-instances/
+
+          make stop-node -C ../rabbitmq_server_release \
+            DEPS_DIR=$PWD/.. \
+            PLUGINS='rabbitmq_federation rabbitmq_stomp' \
+            PROJECT_VERSION=3.9.0 \
+            current_rmq_ref=$branch_or_tag_name
+
+          tar -c -f - /tmp/rabbitmq-test-instances/*/log | \
+            xz > broker-logs.tar.xz
+#      - name: ON FAILURE ARCHIVE TESTS LOGS
+#        if: failure()
+#        run: |
+#          make ct-logs-archive
+      - name: ON FAILURE UPLOAD TESTS LOGS ARTIFACT
+        # https://github.com/marketplace/actions/upload-artifact
+        uses: actions/upload-artifact@v2-preview
+        if: failure()
+        with:
+          name: broker-logs
+          path: "broker-logs.tar.xz"

--- a/.github/workflows/test-erlang-otp-21.3.yaml
+++ b/.github/workflows/test-erlang-otp-21.3.yaml
@@ -41,6 +41,14 @@ jobs:
             PROJECT_VERSION=3.9.0 \
             current_rmq_ref=$branch_or_tag_name
 
+          # due to https://github.com/elixir-lang/elixir/issues/7699 we
+          # "run" the tests, but skip them all, in order to trigger
+          # compilation of all *_test.exs files before we actually run them
+          make tests \
+            MIX_TEST_OPTS="--exclude test" \
+            DEPS_DIR=$PWD/.. \
+            current_rmq_ref=$branch_or_tag_name > /dev/null 2>&1
+
           make tests \
             HONEYCOMB_FORMATTER=true \
             DEPS_DIR=$PWD/.. \

--- a/.github/workflows/test-erlang-otp-22.3.yaml
+++ b/.github/workflows/test-erlang-otp-22.3.yaml
@@ -49,6 +49,9 @@ jobs:
             DEPS_DIR=$PWD/.. \
             current_rmq_ref=$branch_or_tag_name > /dev/null 2>&1
 
+          export BASE_RMQ_REF=master
+          export ERLANG_VERSION=21.3
+          export ELIXIR_VERSION=1.8.0
           make tests \
             HONEYCOMB_FORMATTER=true \
             DEPS_DIR=$PWD/.. \

--- a/.github/workflows/test-erlang-otp-22.3.yaml
+++ b/.github/workflows/test-erlang-otp-22.3.yaml
@@ -1,0 +1,88 @@
+# vim:sw=2:et:
+# https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow
+name: "Test - Erlang 22.3"
+on:
+  push:
+  repository_dispatch:
+    types:
+      - new-commit-to-dep-release-branch
+jobs:
+  # vim:sw=2:et:
+  tests:
+    name: tests
+    runs-on: ubuntu-18.04
+    steps:
+      - name: CHECKOUT REPOSITORY
+        uses: actions/checkout@v2
+      # https://github.com/marketplace/actions/setup-elixir
+      - name: CONFIGURE OTP & ELIXIR
+        uses: actions/setup-elixir@v1
+        with:
+          otp-version: 22.3
+          # https://github.com/elixir-lang/elixir/releases
+          elixir-version: 1.8.0
+      - name: RUN TESTS
+        run: |
+          base_rmq_ref=master
+          branch_or_tag_name=${GITHUB_REF#refs/*/}
+
+          make \
+            DEPS_DIR=$PWD/.. \
+            current_rmq_ref=$branch_or_tag_name
+
+          git clone \
+            --branch "$base_rmq_ref" \
+            --depth 1 \
+            https://github.com/rabbitmq/rabbitmq-server-release.git \
+            ../rabbitmq_server_release
+          make start-background-broker -C ../rabbitmq_server_release \
+            DEPS_DIR=$PWD/.. \
+            PLUGINS='rabbitmq_federation rabbitmq_stomp' \
+            PROJECT_VERSION=3.9.0 \
+            current_rmq_ref=$branch_or_tag_name
+
+          make tests \
+            HONEYCOMB_FORMATTER=true \
+            DEPS_DIR=$PWD/.. \
+            current_rmq_ref=$branch_or_tag_name
+      - name: HONEYCOMB
+        if: success() || failure()
+        run: |
+          echo "$(ls /tmp/honeycomb | wc -l) events recorded"
+          for f in /tmp/honeycomb/*; do
+            RC=$(curl --silent \
+                -H 'X-Honeycomb-Team: ${{ secrets.HONEYCOMB_TEAM }}' \
+                -d @${f} \
+                -o /dev/null \
+                -w "%{http_code}" \
+                "https://api.honeycomb.io/1/events/rabbitmq-ci")
+            if [ "$RC" != "200" ]; then
+              echo "Honeycomb returned ${RC}"
+              cat ${f}
+              printf "\n\n"
+            fi
+          done
+      - name: ON FAILURE ARCHIVE BROKER LOGS
+        if: failure()
+        run: |
+          ls /tmp/rabbitmq-test-instances/
+
+          make stop-node -C ../rabbitmq_server_release \
+            DEPS_DIR=$PWD/.. \
+            PLUGINS='rabbitmq_federation rabbitmq_stomp' \
+            PROJECT_VERSION=3.9.0 \
+            current_rmq_ref=$branch_or_tag_name
+
+          tar -c -f - /tmp/rabbitmq-test-instances/*/log | \
+            xz > broker-logs.tar.xz
+      #      - name: ON FAILURE ARCHIVE TESTS LOGS
+      #        if: failure()
+      #        run: |
+      #          make ct-logs-archive
+      - name: ON FAILURE UPLOAD TESTS LOGS ARTIFACT
+        # https://github.com/marketplace/actions/upload-artifact
+        uses: actions/upload-artifact@v2-preview
+        if: failure()
+        with:
+          name: broker-logs
+          path: "broker-logs.tar.xz"

--- a/.github/workflows/test-erlang-otp-22.3.yaml
+++ b/.github/workflows/test-erlang-otp-22.3.yaml
@@ -41,6 +41,14 @@ jobs:
             PROJECT_VERSION=3.9.0 \
             current_rmq_ref=$branch_or_tag_name
 
+          # due to https://github.com/elixir-lang/elixir/issues/7699 we
+          # "run" the tests, but skip them all, in order to trigger
+          # compilation of all *_test.exs files before we actually run them
+          make tests \
+            MIX_TEST_OPTS="--exclude test" \
+            DEPS_DIR=$PWD/.. \
+            current_rmq_ref=$branch_or_tag_name > /dev/null 2>&1
+
           make tests \
             HONEYCOMB_FORMATTER=true \
             DEPS_DIR=$PWD/.. \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,12 @@ DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk
 VERBOSE_TEST ?= true
 MAX_CASES ?= 1
 
+MIX_TEST_OPTS ?= ""
 MIX_TEST = mix test --max-cases=$(MAX_CASES)
+
+ifneq ("",$(MIX_TEST_OPTS))
+MIX_TEST := $(MIX_TEST) $(MIX_TEST_OPTS)
+endif
 
 ifeq ($(VERBOSE_TEST),true)
 MIX_TEST := $(MIX_TEST) --trace

--- a/lib/honeycomb_formatter.ex
+++ b/lib/honeycomb_formatter.ex
@@ -1,0 +1,102 @@
+defmodule HoneycombFormatter do
+  use GenServer
+
+  def init(opts) do
+    env = System.get_env()
+
+    config = %{
+      directory: "/tmp/honeycomb",
+      github_workflow: env["GITHUB_WORKLOW"] || "unknown",
+      github_run_id: env["GITHUB_RUN_ID"] || "unknown",
+      github_repository: env["GITHUB_REPOSITORY"] || "unknown",
+      github_sha: env["GITHUB_SHA"] || "unknown",
+      github_ref: env["GITHUB_REF"] || "unknown",
+      base_rmq_ref: env["BASE_RMQ_REF"] || "unknown",
+      erlang_version: env["ERLANG_VERSION"] || "unknown",
+      elixir_version: env["ELIXIR_VERSION"] || "unknown",
+      otp_release: "unknown", # = erlang:system_info(otp_release),
+      cpu_topology_json: "\"unknown\"", # = cpu_topology_json(erlang:system_info(cpu_topology)),
+      schedulers: -1, # = erlang:system_info(schedulers),
+      system_architecture: "unknown", # = erlang:system_info(system_architecture),
+      system_memory_data_json: "\"unknown\"", # = json_string_memory(memsup:get_system_memory_data())
+      exunit_seed: opts[:seed]
+    }
+
+    :ok = File.mkdir_p(config[:directory])
+
+    {:ok, config}
+  end
+
+  def handle_cast(
+        {
+          :test_finished,
+          %ExUnit.Test{
+            module: suite,
+            name: testcase,
+            time: duration_microseconds,
+            state: result
+          }
+        },
+        %{directory: directory} = config
+      ) do
+
+    duration_seconds = :io_lib.format("~.6f", [duration_microseconds / 1000000]) |> IO.iodata_to_binary
+
+    result_string = case result do
+      nil -> "ok"
+      r -> inspect(r)
+    end
+
+    json = "{
+    \"ci\":\"GitHub Actions\",
+    \"github_workflow\":\"#{config[:github_workflow]}\",
+    \"github_run_id\":\"#{config[:github_run_id]}\",
+    \"github_repository\":\"#{config[:github_repository]}\",
+    \"github_sha\":\"#{config[:github_sha]}\",
+    \"github_ref\":\"#{config[:github_ref]}\",
+    \"base_rmq_ref\":\"#{config[:base_rmq_ref]}\",
+    \"erlang_version\":\"#{config[:erlang_version]}\",
+    \"elixir_version\":\"#{config[:elixir_version]}\",
+    \"otp_release\":\"#{config[:otp_release]}\",
+    \"cpu_topology\":#{config[:cpu_topology_json]},
+    \"schedulers\":#{config[:schedulers]},
+    \"system_architecture\":\"#{config[:system_architecture]}\",
+    \"system_memory_data\":#{config[:system_memory_data_json]},
+    \"suite\":\"#{suite}\",
+    \"testcase\":\"#{quote_json(testcase)}\",
+    \"duration_seconds\":" <> duration_seconds <> ",
+    \"result\":\"#{quote_json(result_string)}\",
+    \"exunit_seed\":\"#{config[:exunit_seed]}\"
+    }"
+
+    file = filename(suite, testcase, directory)
+    {:ok, f} = File.open(file, [:write])
+    :ok = IO.binwrite(f, json)
+    :ok = File.close(f)
+
+    {:noreply, config}
+  end
+
+  def handle_cast(_event, config) do
+    {:noreply, config}
+  end
+
+  defp filename(suite, testcase, directory) do
+    Path.join(directory,
+      "#{System.system_time(:microsecond)}_#{escape(suite)}_#{escape(testcase)}.json")
+  end
+
+  defp escape(s) do
+    s
+    |> to_string()
+    |> String.downcase
+    |> (&(Regex.replace(~r/[^[:alnum:]]/, &1, "-"))).()
+  end
+
+  defp quote_json(s) do
+    s
+    |> to_string()
+    |> (&(Regex.replace(~r/"/, &1, "\\\""))).()
+    |> (&(Regex.replace(~r/\\e/, &1, "\\u001b"))).()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -8,7 +8,11 @@ four_hours = 240 * 60 * 1000
 ExUnit.configure(
   exclude: [disabled: true],
   module_load_timeout: four_hours,
-  timeout: four_hours)
+  timeout: four_hours,
+  formatters: case System.get_env("HONEYCOMB_FORMATTER") do
+    "true" -> [HoneycombFormatter, ExUnit.CLIFormatter]
+    _ -> [ExUnit.CLIFormatter]
+  end)
 
 ExUnit.start()
 


### PR DESCRIPTION
Since these are ExUnit rather than ct based, they aren't generated with 'make github-cations'.

Also includes honeycomb.io integration.

Originally the honeycomb formatter was enabled with "mix test --formatter HoneycombFormatter --formatter ExUnit.CLIFormatter", but that doesn't work on Elixir 1.8's version of mix.