### PR TITLE
#409 followup

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/await_startup_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/await_startup_command.ex
@@ -26,7 +26,7 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AwaitStartupCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  @default_timeout 300
+  @default_timeout 300_000
 
   def merge_defaults(args, opts) do
     {args, Map.merge(%{timeout: @default_timeout}, opts)}

--- a/lib/rabbitmq/cli/upgrade/commands/await_online_quorum_plus_one_command.ex
+++ b/lib/rabbitmq/cli/upgrade/commands/await_online_quorum_plus_one_command.ex
@@ -18,7 +18,7 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.AwaitOnlineQuorumPlusOneCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  @default_timeout 120
+  @default_timeout 120_000
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments

--- a/lib/rabbitmq/cli/upgrade/commands/await_online_synchronized_mirror_command.ex
+++ b/lib/rabbitmq/cli/upgrade/commands/await_online_synchronized_mirror_command.ex
@@ -18,7 +18,7 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.AwaitOnlineSynchronizedMirrorCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  @default_timeout 120
+  @default_timeout 120_000
 
   use RabbitMQ.CLI.Core.RequiresRabbitAppRunning
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments

--- a/lib/rabbitmq/cli/upgrade/commands/await_online_synchronized_mirror_command.ex
+++ b/lib/rabbitmq/cli/upgrade/commands/await_online_synchronized_mirror_command.ex
@@ -37,7 +37,7 @@ defmodule RabbitMQ.CLI.Upgrade.Commands.AwaitOnlineSynchronizedMirrorCommand do
 
   def run([], %{node: node_name, timeout: timeout}) do
     rpc_timeout = timeout + 500
-    case :rabbit_misc.rpc_call(node_name, :rabbit_upgrade_preparation, :await_online_synchronised_mirror, [timeout], rpc_timeout) do
+    case :rabbit_misc.rpc_call(node_name, :rabbit_upgrade_preparation, :await_online_synchronised_mirrors, [timeout], rpc_timeout) do
       {:error, _} = err -> err
       {:error, _, _} = err -> err
       {:badrpc, _} = err -> err

--- a/test/ctl/await_startup_command_test.exs
+++ b/test/ctl/await_startup_command_test.exs
@@ -31,7 +31,7 @@ defmodule AwaitStartupCommandTest do
   end
 
   test "merge_defaults: default timeout is 5 minutes" do
-    assert @command.merge_defaults([], %{}) == {[], %{timeout: 300}}
+    assert @command.merge_defaults([], %{}) == {[], %{timeout: 300_000}}
   end
 
   test "validate: accepts no arguments", context do

--- a/test/upgrade/await_online_quorum_plus_one_command_test.exs
+++ b/test/upgrade/await_online_quorum_plus_one_command_test.exs
@@ -34,7 +34,7 @@ defmodule AwaitOnlineQuorumPlusOneCommandTest do
   end
 
   test "merge_defaults: overrides a timeout" do
-    assert @command.merge_defaults([], %{}) == {[], %{timeout: 120}}
+    assert @command.merge_defaults([], %{}) == {[], %{timeout: 120_000}}
   end
 
   test "validate: accepts no positional arguments" do

--- a/test/upgrade/await_online_synchronized_mirror_command_test.exs
+++ b/test/upgrade/await_online_synchronized_mirror_command_test.exs
@@ -34,7 +34,7 @@ defmodule AwaitOnlineSynchronizedMirrorsCommandTest do
   end
 
   test "merge_defaults: overrides a timeout" do
-    assert @command.merge_defaults([], %{}) == {[], %{timeout: 120}}
+    assert @command.merge_defaults([], %{}) == {[], %{timeout: 120_000}}
   end
 
   test "validate: accepts no positional arguments" do


### PR DESCRIPTION
This addresses a typo in #409 as well as a couple of default timeouts that were specified incorrectly (assumed the values was in seconds instead of milliseconds).

Spotted by @gerhard in #409.