### PR TITLE
Rely on rabbit_env to infer node name

### DIFF
--- a/lib/rabbitmq/cli/core/helpers.ex
+++ b/lib/rabbitmq/cli/core/helpers.ex
@@ -39,8 +39,20 @@ defmodule RabbitMQ.CLI.Core.Helpers do
     case NodeName.create(node_opt, longnames_opt) do
       {:error, _} = err ->
         err
-      {:ok, normalised_node_opt} ->
-        {:ok, Map.put(options, :node, normalised_node_opt)}
+      {:ok, val} ->
+        {:ok, Map.put(options, :node, val)}
+    end
+  end
+
+  def normalise_node_option(nil, _, _) do
+    nil
+  end
+  def normalise_node_option(node_opt, longnames_opt, options) do
+    case NodeName.create(node_opt, longnames_opt) do
+      {:error, _} = err ->
+        err
+      {:ok, val} ->
+        {:ok, Map.put(options, :node, val)}
     end
   end
 

--- a/lib/rabbitmq/cli/core/node_name.ex
+++ b/lib/rabbitmq/cli/core/node_name.ex
@@ -56,7 +56,7 @@ defmodule RabbitMQ.CLI.Core.NodeName do
   def split_node(name) do
     case String.split(name, "@", parts: 2) do
       ["", host] ->
-        default_name = to_string(Config.get_option(:node))
+        default_name = to_string(Config.default(:node))
         [default_name, host]
 
       [_head, _host] = rslt ->

--- a/test/core/helpers_test.exs
+++ b/test/core/helpers_test.exs
@@ -53,7 +53,7 @@ defmodule HelpersTest do
   ## ------------------- Helpers.normalise_node_option tests --------------------
 
   test "longnames: 'rabbit' as node name, correct domain is used" do
-    default_name = Config.get_option(:node)
+    default_name = Config.default(:node)
     options = %{node: default_name, longnames: true}
     {:ok, options} = Helpers.normalise_node_option(options)
     assert options[:node] == :"rabbit@#{hostname()}.#{domain()}"
@@ -90,7 +90,7 @@ defmodule HelpersTest do
   end
 
   test "shortnames: if input is a hostname without a node name, default node name is added" do
-    default_name = Config.get_option(:node)
+    default_name = Config.default(:node)
     want = String.to_atom("#{default_name}@#{hostname()}")
     got = Helpers.normalise_node("@#{hostname()}", :shortnames)
     assert want == got


### PR DESCRIPTION
During the 3.8.4 cycle we have backported `rabbit_env` to v3.8.x.
Instead of messing with env variable prefixing, it tries both
RABBITMQ_{VAR} and {VAR} environment variables. However,
in CLI tools node name currently only picks up RABBITMQ_NODENAME,
so environments where node name has to be explicitly configured
via rabbitmq-env.conf:

``` shell
NODENAME=rabbit@our.custom.hostname
```

would not pick this node name up. RABBITMQ_NODENAME had to be added
as a workaround.

With this change the behavior of CLI tools and the server is closer.

Note that this updates a few places which used `Config.get_option/2`
to get a "default node name" which more often than not ended up
being a node prefix ("rabbit"). Those tests had to be updated
to use `Config.default/1`.

Closes #421.
References 29ecca24e5345f532e27945b0c94018e2665dfec, 4243d9a0b3487eaba1f54bf459363420b501e9f0, #278.
