### PR TITLE
Introduce 'rabbitmq-diagnostics list_network_interfaces'

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/list_network_interfaces_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/list_network_interfaces_command.ex
@@ -28,7 +28,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ListNetworkInterfacesCommand do
   use RabbitMQ.CLI.Core.MergesNoDefaults
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
 
-  def run([], %{node: node_name, offline: true}) do
+  def run([], %{offline: true}) do
     :rabbit_net.getifaddrs()
   end
   def run([], %{node: node_name, timeout: timeout}) do

--- a/lib/rabbitmq/cli/diagnostics/commands/list_network_interfaces_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/list_network_interfaces_command.ex
@@ -22,22 +22,16 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ListNetworkInterfacesCommand do
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
-  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  def switches(), do: [timeout: :integer, offline: :boolean]
+  def aliases(), do: [t: :timeout]
+
   use RabbitMQ.CLI.Core.MergesNoDefaults
   use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
 
+  def run([], %{node: node_name, offline: true}) do
+    :rabbit_net.getifaddrs()
+  end
   def run([], %{node: node_name, timeout: timeout}) do
-    # Example response when there are alarms:
-    #
-    # [
-    #  file_descriptor_limit,
-    #  {{resource_limit,disk,hare@warp10},[]},
-    #  {{resource_limit,memory,hare@warp10},[]},
-    #  {{resource_limit,disk,rabbit@warp10},[]},
-    #  {{resource_limit,memory,rabbit@warp10},[]}
-    # ]
-    #
-    # The topmost file_descriptor_limit alarm is node-local.
     :rabbit_misc.rpc_call(node_name, :rabbit_net, :getifaddrs, [], timeout)
   end
 

--- a/lib/rabbitmq/cli/diagnostics/commands/list_network_interfaces_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/list_network_interfaces_command.ex
@@ -1,0 +1,92 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.ListNetworkInterfacesCommand do
+  @moduledoc """
+  Displays all network interfaces (NICs) reported by the target node.
+  """
+  import RabbitMQ.CLI.Core.Platform, only: [line_separator: 0]
+  import RabbitMQ.CLI.Core.ANSI
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+
+  def run([], %{node: node_name, timeout: timeout}) do
+    # Example response when there are alarms:
+    #
+    # [
+    #  file_descriptor_limit,
+    #  {{resource_limit,disk,hare@warp10},[]},
+    #  {{resource_limit,memory,hare@warp10},[]},
+    #  {{resource_limit,disk,rabbit@warp10},[]},
+    #  {{resource_limit,memory,rabbit@warp10},[]}
+    # ]
+    #
+    # The topmost file_descriptor_limit alarm is node-local.
+    :rabbit_misc.rpc_call(node_name, :rabbit_net, :getifaddrs, [], timeout)
+  end
+
+  def output(nic_map, %{node: node_name, formatter: "json"}) when map_size(nic_map) == 0 do
+    {:ok, %{"result" => "ok", "node" => node_name, "interfaces" => %{}}}
+  end
+  def output(nic_map, %{node: node_name}) when map_size(nic_map) == 0 do
+    {:ok, "Node #{node_name} reported no network interfaces"}
+  end
+  def output(nic_map0, %{node: node_name, formatter: "json"}) do
+    nic_map = Enum.map(nic_map0, fn ({k, v}) -> {to_string(k), v} end)
+    {:ok,
+     %{
+       "result" => "ok",
+       "interfaces" => Enum.into(nic_map, %{}),
+       "message" => "Node #{node_name} reported network interfaces"
+     }}
+  end
+  def output(nic_map, _) when is_map(nic_map) do
+    lines = nic_lines(nic_map)
+
+    {:ok, Enum.join(lines, line_separator())}
+  end
+  use RabbitMQ.CLI.DefaultOutput
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Lists network interfaces (NICs) on the target node"
+
+  def usage, do: "list_network_interfaces"
+
+  def banner([], %{node: node_name}) do
+    "Asking node #{node_name} to report its network interfaces ..."
+  end
+
+  #
+  # Implementation
+  #
+
+  defp nic_lines(nic_map) do
+    Enum.reduce(nic_map, [],
+      fn({iface, props}, acc) ->
+        iface_lines = Enum.reduce(props, [],
+          fn({prop, val}, inner_acc) ->
+            ["#{prop}: #{val}" | inner_acc]
+          end)
+
+        header = "#{bright("Interface #{iface}")}\n"
+        acc ++ [header | iface_lines] ++ ["\n"]
+      end)
+  end
+end

--- a/test/diagnostics/list_network_interfaces_command_test.exs
+++ b/test/diagnostics/list_network_interfaces_command_test.exs
@@ -13,11 +13,11 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-defmodule DiscoverPeersCommandTest do
+defmodule ListNetworkInterfacesCommandTest do
   use ExUnit.Case, async: false
   import TestHelper
 
-  @command RabbitMQ.CLI.Diagnostics.Commands.DiscoverPeersCommand
+  @command RabbitMQ.CLI.Diagnostics.Commands.ListNetworkInterfacesCommand
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
     :ok
@@ -36,13 +36,13 @@ defmodule DiscoverPeersCommandTest do
       {:validation_failure, :too_many_args}
   end
 
-  @tag test_timeout: 3000
+    @tag test_timeout: 3000
   test "run: targeting an unreachable node throws a badrpc", context do
     assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog})))
   end
 
   @tag test_timeout: 15000
-  test "run: returns a list of nodes when the backend isn't configured", context do
-    assert match?({:ok, {[], _}}, @command.run([], context[:opts]))
+  test "run: returns a map of interfaces", context do
+    assert match?(%{}, @command.run([], context[:opts]))
   end
 end


### PR DESCRIPTION
To make it easier to discover them without using `rabbitmqctl eval` and obscure functions.

Closes rabbitmq/rabbitmq-cli#424
