### PR TITLE
Introduce 'rabbitmq-diagnostics resolve_hostname'

### DIFF
--- a/lib/rabbit_common/records.ex
+++ b/lib/rabbit_common/records.ex
@@ -23,4 +23,6 @@ defmodule RabbitCommon.Records do
   defrecord :listener, extract(:listener, from_lib: "rabbit_common/include/rabbit.hrl")
   defrecord :plugin, extract(:plugin, from_lib: "rabbit_common/include/rabbit.hrl")
   defrecord :resource, extract(:resource, from_lib: "rabbit_common/include/rabbit.hrl")
+
+  defrecord :hostent, extract(:hostent, from_lib: "kernel/include/inet.hrl")
 end

--- a/lib/rabbitmq/cli/core/networking.ex
+++ b/lib/rabbitmq/cli/core/networking.ex
@@ -1,0 +1,55 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Core.Networking do
+  @type address_family() :: :inet | :inet6
+
+  @spec address_family(String.t() | atom() | charlist() | binary()) :: address_family()
+  def address_family(value) do
+    val = Rabbitmq.Atom.Coerce.to_atom(value)
+    case val do
+      :inet  -> :inet
+      :inet4 -> :inet
+      :inet6 -> :inet6
+      :ipv4  -> :inet
+      :ipv6  -> :inet6
+      :IPv4  -> :inet
+      :IPv6  -> :inet6
+    end
+  end
+
+  @spec address_family(String.t() | atom()) :: boolean()
+  def valid_address_family?(value) when is_atom(value) do
+    valid_address_family?(to_string(value))
+  end
+  def valid_address_family?("inet"),  do: true
+  def valid_address_family?("inet4"), do: true
+  def valid_address_family?("inet6"), do: true
+  def valid_address_family?("ipv4"),  do: true
+  def valid_address_family?("ipv6"),  do: true
+  def valid_address_family?("IPv4"),  do: true
+  def valid_address_family?("IPv6"),  do: true
+  def valid_address_family?(_other),  do: false
+
+  @spec format_address(:inet.ip_address()) :: String.t()
+  def format_address(addr) do
+    to_string(:inet.ntoa(addr))
+  end
+
+  @spec format_addresses([:inet.ip_address()]) :: [String.t()]
+  def format_addresses(addrs) do
+    Enum.map(addrs, &format_address/1)
+  end
+end

--- a/lib/rabbitmq/cli/diagnostics/commands/resolve_hostname_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/resolve_hostname_command.ex
@@ -21,7 +21,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ResolveHostnameCommand do
   """
 
   import RabbitCommon.Records
-  alias RabbitMQ.CLI.Core.Networking, as: Networking
+  alias RabbitMQ.CLI.Core.Networking
   alias RabbitMQ.CLI.Core.ExitCodes
 
   @behaviour RabbitMQ.CLI.CommandBehaviour

--- a/lib/rabbitmq/cli/diagnostics/commands/resolve_hostname_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/resolve_hostname_command.ex
@@ -1,0 +1,103 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.ResolveHostnameCommand do
+  @moduledoc """
+  Resolves a hostname to one or more addresses of a given IP address family (IPv4 ot IPv6).
+  This command is not meant to compete with `dig` but rather provide a way
+  to perform basic resolution tests that take Erlang's inetrc file into account.
+  """
+
+  import RabbitCommon.Records
+  alias RabbitMQ.CLI.Core.Networking, as: Networking
+  alias RabbitMQ.CLI.Core.ExitCodes
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def scopes(), do: [:diagnostics]
+
+  def switches(), do: [address_family: :string, offline: :boolean]
+  def aliases(), do: [a: :address_family]
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{address_family: "IPv4", offline: false}, opts)}
+  end
+
+  def validate(args, _) when length(args) < 1, do: {:validation_failure, :not_enough_args}
+  def validate(args, _) when length(args) > 1, do: {:validation_failure, :too_many_args}
+  def validate([_], %{address_family: family}) do
+    case Networking.valid_address_family?(family) do
+      true  -> :ok
+      false -> {:validation_failure, {:bad_argument, "unsupported IP address family #{family}. Valid values are: ipv4, ipv6"}}
+    end
+  end
+  def validate([_], _), do: :ok
+
+  def run([hostname], %{address_family: family, offline: true}) do
+    :inet.gethostbyname(to_charlist(hostname), Networking.address_family(family))
+  end
+  def run([hostname], %{node: node_name, address_family: family, offline: false, timeout: timeout}) do
+    case :rabbit_misc.rpc_call(node_name, :inet, :gethostbyname,
+           [to_charlist(hostname), Networking.address_family(family)], timeout) do
+      {:error, _} = err -> err
+      {:error, _, _} = err -> err
+      {:ok, result} -> {:ok, result}
+      other -> other
+    end
+  end
+
+  def output({:error, :nxdomain}, %{node: node_name, formatter: "json"}) do
+    m = %{
+      "result"  => "error",
+      "node"    => node_name,
+      "message" => "Hostname does not resolve (resolution failed with an nxdomain)"
+    }
+    {:error, ExitCodes.exit_dataerr(), m}
+  end
+  def output({:error, :nxdomain}, _opts) do
+    {:error, ExitCodes.exit_dataerr(), "Hostname does not resolve (resolution failed with an nxdomain)"}
+  end
+  def output({:ok, result}, %{node: node_name, address_family: family, formatter: "json"}) do
+    hostname  = hostent(result, :h_name)
+    addresses = hostent(result, :h_addr_list)
+    {:ok, %{
+      "result"         => "ok",
+      "node"           => node_name,
+      "hostname"       => to_string(hostname),
+      "address_family" => family,
+      "addresses"      => Networking.format_addresses(addresses)
+    }}
+  end
+  def output({:ok, result}, _opts) do
+    addresses = hostent(result, :h_addr_list)
+    {:ok, Enum.join(Networking.format_addresses(addresses), "\n")}
+  end
+  use RabbitMQ.CLI.DefaultOutput
+
+  def usage() do
+    "resolve_hostname <hostname> [--address-family <ipv4 | ipv6>]"
+  end
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Resolves a hostname to a set of addresses. Takes Erlang's inetrc file into account."
+
+  def banner([hostname], %{offline: false, node: node_name, address_family: family}) do
+    "Asking node #{node_name} to resolve hostname #{hostname} to #{family} addresses..."
+  end
+  def banner([hostname], %{offline: true, address_family: family}) do
+    "Resolving hostname #{hostname} to #{family} addresses..."
+  end
+end

--- a/lib/rabbitmq/cli/diagnostics/commands/resolver_info_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/resolver_info_command.ex
@@ -1,0 +1,123 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.ResolverInfoCommand do
+  @moduledoc """
+  Lists RabbitMQ-specific environment variables defined on target node
+  """
+
+  import RabbitMQ.CLI.Core.Platform, only: [line_separator: 0]
+  import RabbitMQ.CLI.Core.ANSI, only: [bright: 1]
+
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  def scopes(), do: [:diagnostics]
+
+  def switches(), do: [offline: :boolean]
+  def aliases(), do: []
+
+  def merge_defaults(args, opts) do
+    {args, Map.merge(%{offline: false}, opts)}
+  end
+
+  def validate(args, _) when length(args) > 0, do: {:validation_failure, :too_many_args}
+  def validate([], _), do: :ok
+
+  def run([], %{offline: true}) do
+    inetrc_map(:inet.get_rc())
+  end
+  def run([], %{node: node_name, timeout: timeout, offline: false}) do
+    case :rabbit_misc.rpc_call(node_name, :inet, :get_rc, [], timeout) do
+      {:error, _} = err -> err
+      {:error, _, _} = err -> err
+      xs when is_list(xs) -> inetrc_map(xs)
+      other -> other
+    end
+  end
+
+  def output(info, %{node: node_name, formatter: "json"}) do
+    {:ok, %{
+      "result"   => "ok",
+      "node"     => node_name,
+      "resolver" => info
+    }}
+  end
+  def output(info, _opts) do
+    main_section = [
+      "#{bright("Runtime Hostname Resolver (inetrc) Settings")}\n",
+      "Lookup order: #{info["lookup"]}",
+      "Hosts file: #{info["hosts_file"]}",
+      "Resolver conf file: #{info["resolv_conf"]}",
+      "Cache size: #{info["cache_size"]}"
+    ]
+    hosts_section = [
+      "\n#{bright("inetrc File Host Entries")}\n"
+    ] ++ case info["hosts"] do
+      []  -> ["(none)"]
+      nil -> ["(none)"]
+      hs  -> Enum.reduce(hs, [], fn {k, v}, acc -> ["#{k} #{Enum.join(v, ", ")}" | acc] end)
+    end
+
+    lines = main_section ++ hosts_section
+
+    {:ok, Enum.join(lines, line_separator())}
+  end
+
+  def usage() do
+    "resolver_info"
+  end
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description(), do: "Displays effective hostname resolver (inetrc) configuration on target node"
+
+  def banner(_, %{node: node_name, offline: false}) do
+    "Asking node #{node_name} for its effective hostname resolver (inetrc) configuration..."
+  end
+  def banner(_, %{offline: true}) do
+    "Displaying effective hostname resolver (inetrc) configuration used by CLI tools..."
+  end
+
+  ##
+  ## Implementation
+  ##
+
+  @spec inetrc_map(nonempty_list()) :: map()
+  def inetrc_map(list) do
+    Enum.reduce(list, %{},
+      fn hosts, acc when is_list(hosts) ->
+           Map.put(acc, "hosts", host_resolution_map(hosts))
+         {k, v}, acc when k == :domain or k == :resolv_conf or k == :hosts_file ->
+           Map.put(acc, to_string(k), to_string(v))
+         {k, v}, acc when is_list(v) when k == :search or k == :lookup ->
+           Map.put(acc, to_string(k), Enum.join(Enum.map(v, &to_string/1), ", "))
+         {k, v}, acc when is_integer(v) ->
+           Map.put(acc, to_string(k), v)
+         {k, v, v2}, acc when is_tuple(v) when k == :nameserver or k == :nameservers or k == :alt_nameserver ->
+           Map.put(acc, to_string(k), "#{:inet.aton(v)}:#{v2}")
+         {k, v}, acc when is_tuple(v) when k == :nameserver or k == :nameservers or k == :alt_nameserver ->
+           Map.put(acc, to_string(k), to_string(:inet.ntoa(v)))
+         {k, v}, acc ->
+           Map.put(acc, to_string(k), to_string(v))
+      end)
+  end
+
+  def host_resolution_map(hosts) do
+    Enum.reduce(hosts, %{},
+        fn {:host, address, hosts}, acc ->
+          Map.put(acc, to_string(:inet.ntoa(address)), Enum.map(hosts, &to_string/1))
+        end)
+  end
+end

--- a/test/diagnostics/resolve_hostname_command_test.exs
+++ b/test/diagnostics/resolve_hostname_command_test.exs
@@ -1,0 +1,94 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule ResolveHostnameCommandTest do
+  use ExUnit.Case, async: false
+  import TestHelper
+
+  @command RabbitMQ.CLI.Diagnostics.Commands.ResolveHostnameCommand
+
+  setup_all do
+    RabbitMQ.CLI.Core.Distribution.start()
+    start_rabbitmq_app()
+
+    ExUnit.configure([max_cases: 1])
+    on_exit([], fn ->
+      start_rabbitmq_app()
+    end)
+
+    :ok
+  end
+
+  setup context do
+    {:ok, opts: %{
+        node: get_rabbit_hostname(),
+        timeout: context[:test_timeout] || 30000,
+        address_family: "ipv4",
+        offline: false
+      }}
+  end
+
+  test "merge_defaults: defaults to IPv4 address family" do
+    assert @command.merge_defaults([], %{}) == {[], %{address_family: "IPv4", offline: false}}
+  end
+
+  test "validate: a single positional argument passes validation" do
+    assert @command.validate(["rabbitmq.com"], %{}) == :ok
+  end
+
+  test "validate: treats positional arguments as a failure" do
+    assert @command.validate(["elixir-lang.org", "extra-arg"], %{}) == {:validation_failure, :too_many_args}
+  end
+
+  test "validate: address family other than IPv4 or IPv6 fails validation" do
+    assert match?({:validation_failure, {:bad_argument, _}},
+                  @command.validate(["elixir-lang.org"], %{address_family: "ipv5"}))
+
+    assert match?({:validation_failure, {:bad_argument, _}},
+                  @command.validate(["elixir-lang.org"], %{address_family: "IPv5"}))
+  end
+
+  test "validate: IPv4 for address family passes validation" do
+    assert @command.validate(["elixir-lang.org"], %{address_family: "ipv4"}) == :ok
+    assert @command.validate(["elixir-lang.org"], %{address_family: "IPv4"}) == :ok
+  end
+
+  test "validate: IPv6 for address family passes validation" do
+    assert @command.validate(["elixir-lang.org"], %{address_family: "ipv6"}) == :ok
+    assert @command.validate(["elixir-lang.org"], %{address_family: "IPv6"}) == :ok
+  end
+
+  @tag test_timeout: 3000
+  test "run: targeting an unreachable node throws a badrpc", context do
+    opts = Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})
+    assert match?({:badrpc, _}, @command.run(["elixir-lang.org"], opts))
+  end
+
+  test "run: returns a resolution result", context do
+    case @command.run(["github.com"], context[:opts]) do
+      {:ok, _hostent}     -> :ok
+      {:error, :nxdomain} -> :ok
+      other -> flunk("hostname resolution returned #{other}")
+    end
+  end
+
+  test "run with --offline: returns a resolution result", context do
+    case @command.run(["github.com"], Map.merge(context[:opts], %{offline: true})) do
+      {:ok, _hostent}     -> :ok
+      {:error, :nxdomain} -> :ok
+      other -> flunk("hostname resolution returned #{other}")
+    end
+  end
+end


### PR DESCRIPTION
Helps with troubleshooting host name resolution behavior
on nodes and locally for CLI tools.

This is obviously not meant to be a replacement for existing tools such as dig,
only a way to quickly spot obvious irregularities, e.g. those
in environments that use custom [Erlang inetrc files](https://erlang.org/doc/apps/erts/inet_cfg.html).

Per discussion @harshac.