### PR TITLE
rabbitmqctl export_definitions: ensure that parameter values are maps

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/export_definitions_command.ex
@@ -129,7 +129,15 @@ defmodule RabbitMQ.CLI.Ctl.Commands.ExportDefinitionsCommand do
   # Implementation
   #
 
-  defp serialise(map, "json") do
+  defp serialise(raw_map, "json") do
+    # make sure all runtime parameter values are maps, otherwise
+    # they will end up being a list of pairs (a keyword list/proplist)
+    # in the resulting JSON document
+    map = Map.update!(raw_map, :parameters, fn(params) ->
+      Enum.map(params, fn(param) ->
+        Map.update!(param, "value", &:rabbit_data_coercion.to_map/1)
+      end)
+    end)
     {:ok, json} = JSON.encode(map)
     json
   end

--- a/test/ctl/clear_parameter_command_test.exs
+++ b/test/ctl/clear_parameter_command_test.exs
@@ -23,7 +23,7 @@ defmodule ClearParameterCommandTest do
   @root   "/"
   @component_name "federation-upstream"
   @key "reconnect-delay"
-  @value "{\"uri\":\"amqp://\"}"
+  @value "{\"uri\":\"amqp://127.0.0.1:5672\"}"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()

--- a/test/ctl/export_definitions_command_test.exs
+++ b/test/ctl/export_definitions_command_test.exs
@@ -114,6 +114,25 @@ defmodule ExportDefinitionsCommandTest do
     assert Map.has_key?(map, "rabbitmq_version")
   end
 
+  @tag format: "json"
+  test "run: correctly formats runtime parameter values", context do
+    File.rm(valid_file_path())
+    imported_file_path = Path.join([File.cwd!(), "test", "fixtures", "files", "definitions.json"])
+    # prepopulate some runtime parameters
+    RabbitMQ.CLI.Ctl.Commands.ImportDefinitionsCommand.run([imported_file_path], context[:opts])
+
+    {:ok, nil} = @command.run([valid_file_path()], context[:opts])
+
+    # clean up the state we've modified
+    clear_parameter("/", "federation-upstream", "up-1")
+
+    {:ok, bin} = File.read(valid_file_path())
+    {:ok, map} = JSON.decode(bin)
+    assert Map.has_key?(map, "rabbitmq_version")
+    params = map["parameters"]
+    assert is_map(hd(params)["value"])
+  end
+
   @tag format: "erlang"
   test "run: writes to a file and returns nil when target is a file and format is Erlang Terms", context do
     File.rm(valid_file_path())

--- a/test/ctl/import_definitions_command_test.exs
+++ b/test/ctl/import_definitions_command_test.exs
@@ -86,6 +86,9 @@ defmodule ImportDefinitionsCommandTest do
   @tag format: "json"
   test "run: imports definitions from a file", context do
     assert :ok == @command.run([valid_file_path()], context[:opts])
+
+    # clean up the state we've modified
+    clear_parameter("/", "federation-upstream", "up-1")
   end
 
   defp valid_file_path() do

--- a/test/ctl/set_parameter_command_test.exs
+++ b/test/ctl/set_parameter_command_test.exs
@@ -24,7 +24,7 @@ defmodule SetParameterCommandTest do
   @root   "/"
   @component_name "federation-upstream"
   @key "reconnect-delay"
-  @value "{\"uri\":\"amqp://\"}"
+  @value "{\"uri\":\"amqp://127.0.0.1:5672\"}"
 
   setup_all do
     RabbitMQ.CLI.Core.Distribution.start()
@@ -36,6 +36,9 @@ defmodule SetParameterCommandTest do
     on_exit([], fn ->
       delete_vhost @vhost
     end)
+
+    # featured in a definitions file imported by other tests
+    clear_parameter("/", "federation-upstream", "up-1")
 
     :ok
   end

--- a/test/fixtures/files/definitions.json
+++ b/test/fixtures/files/definitions.json
@@ -23,5 +23,18 @@
   ],
   "bindings": [
     
+  ],
+
+  "parameters": [
+      {
+          "component": "federation-upstream",
+          "name": "up-1",
+          "value": {
+              "ack-mode": "on-confirm",
+              "trust-user-id": false,
+              "uri": "amqp://127.0.0.1:5672"
+          },
+          "vhost": "/"
+      }
   ]
 }


### PR DESCRIPTION
otherwise, it would be serialized as a list of pairs, which is
not the format the import path (or an operator) expects.

Closes #435.
