### PR TITLE
Make --help, help usage help messages consistent

### DIFF
--- a/lib/rabbitmqctl.ex
+++ b/lib/rabbitmqctl.ex
@@ -59,7 +59,7 @@ defmodule RabbitMQCtl do
 
     # the user asked for --help and we are displaying it to her,
     # reporting a success
-    {:ok, ExitCodes.exit_ok(), HelpCommand.all_usage(parsed_options)};
+    {:ok, ExitCodes.exit_ok(), Enum.join(HelpCommand.all_usage(parsed_options), "")};
   end
 
   def exec_command(["--version"] = _unparsed_command, opts) do
@@ -80,7 +80,7 @@ defmodule RabbitMQCtl do
 
         usage_string =
           command_not_found_string <>
-            HelpCommand.all_usage(parsed_options)
+            Enum.join(HelpCommand.all_usage(parsed_options), "")
 
         {:error, ExitCodes.exit_usage(), usage_string}
 
@@ -249,7 +249,7 @@ defmodule RabbitMQCtl do
   end
 
   def auto_complete(script_name, args) do
-    Rabbitmq.CLI.AutoComplete.complete(script_name, args)
+    RabbitMQ.CLI.AutoComplete.complete(script_name, args)
     |> Stream.map(&IO.puts/1)
     |> Stream.run()
 

--- a/test/core/auto_complete_test.exs
+++ b/test/core/auto_complete_test.exs
@@ -17,7 +17,7 @@
 defmodule AutoCompleteTest do
   use ExUnit.Case, async: false
 
-  @subject Rabbitmq.CLI.AutoComplete
+  @subject RabbitMQ.CLI.AutoComplete
 
 
   test "Auto-completes a command" do


### PR DESCRIPTION
 * `help` printed an "Error:" at the top for no reason
 * `help [command]` with a non-existent command did not offer a suggestion
   like an attempt to invoke a non-existent command would
 * Exit codes were not consistent
 * `help --list-commands` had line break issues

With this change,

  * `help` is consistent with --help
  * `help [command]` is consistent with `[command] --help`
  * If a command is not found, either during the execution flow
    or `help [commnad]`, we consistently attempt a Jaro distance suggestion
  * Successful or effectively successful exits from the `help` command do not produce any error messages at the top
