### PR TITLE
if a node is the only cluster member, pass on the mirror sync critical check

### DIFF
--- a/lib/rabbitmq/cli/queues/commands/check_if_node_is_mirror_sync_critical_command.ex
+++ b/lib/rabbitmq/cli/queues/commands/check_if_node_is_mirror_sync_critical_command.ex
@@ -35,26 +35,43 @@ defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsMirrorSyncCriticalCommand do
 
   def run([], %{node: node_name, timeout: timeout}) do
     case :rabbit_misc.rpc_call(node_name,
-           :rabbit_amqqueue, :list_local_mirrored_classic_without_synchronised_mirrors_for_cli, [], timeout) do
-      [] -> []
-      qs when is_list(qs) -> qs
+           :rabbit_nodes, :is_single_node_cluster, [], timeout) do
+      # if target node is the only one in the cluster, the check makes little sense
+      # and false positives can be misleading
+      true  -> {:ok, :single_node_cluster}
+      false ->
+        case :rabbit_misc.rpc_call(node_name,
+                                    :rabbit_amqqueue, :list_local_mirrored_classic_without_synchronised_mirrors_for_cli, [], timeout) do
+          [] -> {:ok, []}
+          qs when is_list(qs) -> {:ok, qs}
+          other -> other
+        end
       other -> other
     end
   end
 
-  def output([], %{formatter: "json"}) do
+  def output({:ok, :single_node_cluster}, %{formatter: "json"}) do
+    {:ok, %{
+      "result"  => "ok",
+      "message" => "Target node seems to be the only one in a single node cluster, the check does not apply"
+    }}
+  end
+  def output({:ok, []}, %{formatter: "json"}) do
     {:ok, %{"result" => "ok"}}
   end
-
-  def output([], %{silent: true}) do
+  def output({:ok, :single_node_cluster}, %{silent: true}) do
     {:ok, :check_passed}
   end
-
-  def output([], %{node: node_name}) do
+  def output({:ok, []}, %{silent: true}) do
+    {:ok, :check_passed}
+  end
+  def output({:ok, :single_node_cluster}, %{node: node_name}) do
+    {:ok, "Node #{node_name} seems to be the only one in a single node cluster, the check does not apply"}
+  end
+  def output({:ok, []}, %{node: node_name}) do
     {:ok, "Node #{node_name} reported no classic mirrored queues without online synchronised mirrors"}
   end
-
-  def output(qs, %{node: node_name, formatter: "json"}) when is_list(qs) do
+  def output({:ok, qs}, %{node: node_name, formatter: "json"}) when is_list(qs) do
     {:error, :check_failed,
      %{
        "result" => "error",
@@ -62,12 +79,10 @@ defmodule RabbitMQ.CLI.Queues.Commands.CheckIfNodeIsMirrorSyncCriticalCommand do
        "message" => "Node #{node_name} reported local classic mirrored queues without online synchronised mirrors"
      }}
   end
-
-  def output(_qs, %{silent: true}) do
+  def output({:ok, qs}, %{silent: true}) when is_list(qs) do
     {:error, :check_failed}
   end
-
-  def output(qs, %{node: node_name}) when is_list(qs) do
+  def output({:ok, qs}, %{node: node_name}) when is_list(qs) do
     lines = queue_lines(qs, node_name)
 
     {:error, :check_failed, Enum.join(lines, line_separator())}


### PR DESCRIPTION
as it would produce a confusing false positive.

Per discussion with @harshac, @ansd.

Closes rabbitmq/rabbitmq-cli#432
