### PR TITLE
Deprecate RABBITMQ_ERLANG_COOKIE env variable support

### DIFF
--- a/lib/rabbitmq/cli/core/ansi.ex
+++ b/lib/rabbitmq/cli/core/ansi.ex
@@ -17,4 +17,20 @@ defmodule RabbitMQ.CLI.Core.ANSI do
   def bright(string) do
     "#{IO.ANSI.bright()}#{string}#{IO.ANSI.reset()}"
   end
+
+  def red(string) do
+    "#{IO.ANSI.red()}#{string}#{IO.ANSI.reset()}"
+  end
+
+  def yellow(string) do
+    "#{IO.ANSI.yellow()}#{string}#{IO.ANSI.reset()}"
+  end
+
+  def bright_red(string) do
+    "#{IO.ANSI.bright()}#{IO.ANSI.red()}#{string}#{IO.ANSI.reset()}"
+  end
+
+  def bright_yellow(string) do
+    "#{IO.ANSI.bright()}#{IO.ANSI.yellow()}#{string}#{IO.ANSI.reset()}"
+  end
 end

--- a/lib/rabbitmq/cli/core/distribution.ex
+++ b/lib/rabbitmq/cli/core/distribution.ex
@@ -14,7 +14,7 @@
 ## Copyright (c) 2016-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
 defmodule RabbitMQ.CLI.Core.Distribution do
-  alias RabbitMQ.CLI.Core.{Config, Helpers}
+  alias RabbitMQ.CLI.Core.{ANSI, Config, Helpers}
 
   #
   # API
@@ -118,8 +118,10 @@ defmodule RabbitMQ.CLI.Core.Distribution do
           case Config.output_less?(options) do
             true  -> :ok
             false ->
-              IO.puts("RABBITMQ_ERLANG_COOKIE env variable support is deprecated and will be REMOVED in a future version. " <>
-              "Use the $HOME/.erlang.cookie file or the --erlang-cookie switch instead.")
+              warning = ANSI.bright_red("RABBITMQ_ERLANG_COOKIE env variable support is deprecated and will be REMOVED in a future version. ") <>
+                        ANSI.yellow("Use the $HOME/.erlang.cookie file or the --erlang-cookie switch instead.")
+
+              IO.puts(warning)
           end
       end
   end

--- a/lib/rabbitmq/cli/core/distribution.ex
+++ b/lib/rabbitmq/cli/core/distribution.ex
@@ -77,6 +77,7 @@ defmodule RabbitMQ.CLI.Core.Distribution do
 
       cookie ->
         Node.set_cookie(cookie)
+        maybe_warn_about_deprecated_rabbitmq_erlang_cookie_env_variable(options)
         :ok
     end
   end
@@ -108,5 +109,18 @@ defmodule RabbitMQ.CLI.Core.Distribution do
       {:error, _} = err -> throw(err)
       rmq_hostname      -> String.to_atom("rabbitmqcli-#{:os.getpid()}-#{rmq_hostname}")
     end
+  end
+
+  defp maybe_warn_about_deprecated_rabbitmq_erlang_cookie_env_variable(options) do
+      case System.get_env("RABBITMQ_ERLANG_COOKIE") do
+        nil -> :ok
+        _   ->
+          case Config.output_less?(options) do
+            true  -> :ok
+            false ->
+              IO.puts("RABBITMQ_ERLANG_COOKIE env variable support is deprecated and will be REMOVED in a future version. " <>
+              "Use the $HOME/.erlang.cookie file or the --erlang-cookie switch instead.")
+          end
+      end
   end
 end


### PR DESCRIPTION
It's not worth the confusion it causes in practice since the server does not support it.

To test:

``` shell
RABBITMQ_ERLANG_COOKIE=$(cat $HOME/.erlang.cookie) ERL_LIBS=../rabbit/plugins ./escript/rabbitmqctl status

RABBITMQ_ERLANG_COOKIE="mismatching-value" ERL_LIBS=../rabbit/plugins ./escript/rabbitmqctl status

ERL_LIBS=../rabbit/plugins ./escript/rabbitmqctl status --erlang-cookie $(cat $HOME/.erlang.cookie)

ERL_LIBS=../rabbit/plugins ./escript/rabbitmqctl status --erlang-cookie mismatching-value
```

Per discussion with @gerhard @dumbbell.

Closes #443.
