### PR TITLE
Introduce 'rabbitmq-diagnostics erlang_cookie_sources'

### DIFF
--- a/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_sources_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_sources_command.ex
@@ -70,7 +70,7 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand do
     cookie_file_lines = [
       "#{bright("Cookie File")}\n",
       "Effective user: #{result[:effective_user] || "(none)"}",
-      "$HOME directory: #{result[:home_dir] || "(none)"}",
+      "Effective home directory: #{result[:home_dir] || "(none)"}",
       "Cookie file path: #{result[:cookie_file_path]}",
       "Cookie file exists? #{result[:cookie_file_exists]}",
       "Cookie file type: #{result[:cookie_file_type] || "(n/a)"}",

--- a/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_sources_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_sources_command.ex
@@ -1,0 +1,107 @@
+## The contents of this file are subject to the Mozilla Public License
+## Version 1.1 (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License
+## at https://www.mozilla.org/MPL/
+##
+## Software distributed under the License is distributed on an "AS IS"
+## basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See
+## the License for the specific language governing rights and
+## limitations under the License.
+##
+## The Original Code is RabbitMQ.
+##
+## The Initial Developer of the Original Code is GoPivotal, Inc.
+## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
+
+defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand do
+  @behaviour RabbitMQ.CLI.CommandBehaviour
+
+  import RabbitMQ.CLI.Core.ANSI
+
+  use RabbitMQ.CLI.Core.AcceptsDefaultSwitchesAndTimeout
+  use RabbitMQ.CLI.Core.MergesNoDefaults
+  use RabbitMQ.CLI.Core.AcceptsNoPositionalArguments
+
+  def distribution(_), do: :none
+
+  def run([], opts) do
+    switch_cookie = opts[:erlang_cookie]
+    home_dir = System.get_env("HOME")
+    cookie_file_path = Path.join(home_dir, ".erlang.cookie")
+    cookie_file_stat = case File.stat(Path.join(System.get_env("HOME"), ".erlang.cookie")) do
+      {:error, :enoent} -> nil
+      {:ok, value}     -> value
+    end
+    cookie_file_type = case cookie_file_stat do
+      nil   -> nil
+      value -> value.type
+    end
+    cookie_file_access = case cookie_file_stat do
+      nil   -> nil
+      value -> value.access
+    end
+    cookie_file_size = case cookie_file_stat do
+      nil   -> nil
+      value -> value.size
+    end
+
+    %{
+      os_env_cookie_set: System.get_env("RABBITMQ_ERLANG_COOKIE") != nil,
+      os_env_cookie_value_length: String.length(System.get_env("RABBITMQ_ERLANG_COOKIE") || ""),
+      switch_cookie_set: switch_cookie != nil,
+      switch_cookie_value_length: String.length(to_string(switch_cookie) || ""),
+      effective_user: System.get_env("USER"),
+      home_dir: home_dir,
+      cookie_file_path: cookie_file_path,
+      cookie_file_exists: File.exists?(cookie_file_path),
+      cookie_file_type: cookie_file_type,
+      cookie_file_access: cookie_file_access,
+      cookie_file_size: cookie_file_size
+    }
+  end
+
+  def banner([], %{}), do: "Listing Erlang cookie sources used by CLI tools..."
+
+  def output(result, %{formatter: "json"}) do
+    {:ok, result}
+  end
+
+  def output(result, _opts) do
+    cookie_file_lines = [
+      "#{bright("Cookie File")}\n",
+      "Effective user: #{result[:effective_user] || "(none)"}",
+      "$HOME directory: #{result[:home_dir] || "(none)"}",
+      "Cookie file path: #{result[:cookie_file_path]}",
+      "Cookie file exists? #{result[:cookie_file_exists]}",
+      "Cookie file type: #{result[:cookie_file_type] || "(n/a)"}",
+      "Cookie file access: #{result[:cookie_file_access] || "(n/a)"}",
+      "Cookie file size: #{result[:cookie_file_size] || "(n/a)"}",
+    ]
+
+    switch_lines = [
+      "\n#{bright("Cookie CLI Switch")}\n",
+      "--erlang-cookie value set? #{result[:switch_cookie_set]}",
+      "--erlang-cookie value length: #{result[:switch_cookie_value_length] || 0}"
+    ]
+
+    os_env_lines = [
+      "\n#{bright("Env variable ")} #{bright_red("(Deprecated)")}\n",
+      "RABBITMQ_ERLANG_COOKIE value set? #{result[:os_env_cookie_set]}",
+      "RABBITMQ_ERLANG_COOKIE value length: #{result[:os_env_cookie_value_length] || 0}"
+    ]
+
+    lines = cookie_file_lines ++ switch_lines ++ os_env_lines
+
+    {:ok, lines}
+  end
+
+  def help_section(), do: :observability_and_health_checks
+
+  def description() do
+    "Display Erlang cookie source (e.g. $HOME/.erlang.cookie file) information useful for troubleshooting"
+  end
+
+  def usage, do: "erlang_cookie_sources"
+
+  def formatter(), do: RabbitMQ.CLI.Formatters.StringPerLine
+end

--- a/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_sources_command.ex
+++ b/lib/rabbitmq/cli/diagnostics/commands/erlang_cookie_sources_command.ex
@@ -26,9 +26,9 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand do
 
   def run([], opts) do
     switch_cookie = opts[:erlang_cookie]
-    home_dir = System.get_env("HOME")
+    home_dir = get_home_dir()
     cookie_file_path = Path.join(home_dir, ".erlang.cookie")
-    cookie_file_stat = case File.stat(Path.join(System.get_env("HOME"), ".erlang.cookie")) do
+    cookie_file_stat = case File.stat(Path.join(home_dir, ".erlang.cookie")) do
       {:error, :enoent} -> nil
       {:ok, value}     -> value
     end
@@ -104,4 +104,22 @@ defmodule RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand do
   def usage, do: "erlang_cookie_sources"
 
   def formatter(), do: RabbitMQ.CLI.Formatters.StringPerLine
+
+  #
+  # Implementation
+  #
+
+  @doc """
+  Computes HOME directory path the same way Erlang VM/ei does,
+  including taking Windows-specific env variables into account.
+  """
+  def get_home_dir() do
+    homedrive = System.get_env("HOMEDRIVE")
+    homepath  = System.get_env("HOMEPATH")
+
+    case {homedrive != nil, homepath != nil} do
+      {true, true} -> "#{homedrive}#{homepath}"
+      _            -> System.get_env("HOME")
+    end
+  end
 end

--- a/test/diagnostics/erlang_cookie_sources_command_test.exs
+++ b/test/diagnostics/erlang_cookie_sources_command_test.exs
@@ -13,32 +13,13 @@
 ## The Initial Developer of the Original Code is GoPivotal, Inc.
 ## Copyright (c) 2007-2020 VMware, Inc. or its affiliates.  All rights reserved.
 
-defmodule OsEnvCommandTest do
-  use ExUnit.Case, async: false
-  import TestHelper
+defmodule ErlangCookieSourcesCommandTest do
+  use ExUnit.Case, async: true
 
-  @command RabbitMQ.CLI.Diagnostics.Commands.OsEnvCommand
-
-  setup_all do
-    RabbitMQ.CLI.Core.Distribution.start()
-
-    start_rabbitmq_app()
-
-    ExUnit.configure([max_cases: 1])
-
-    on_exit([], fn ->
-      start_rabbitmq_app()
-    end)
-
-    :ok
-  end
+  @command RabbitMQ.CLI.Diagnostics.Commands.ErlangCookieSourcesCommand
 
   setup context do
-    {:ok, opts: %{
-        node: get_rabbit_hostname(),
-        timeout: context[:test_timeout] || 30000,
-        all: false
-      }}
+    {:ok, opts: %{}}
   end
 
   test "merge_defaults: merges no defaults" do
@@ -53,19 +34,13 @@ defmodule OsEnvCommandTest do
     assert @command.validate([], %{}) == :ok
   end
 
-  @tag test_timeout: 3000
-  test "run: targeting an unreachable node throws a badrpc", context do
-    assert match?({:badrpc, _}, @command.run([], Map.merge(context[:opts], %{node: :jake@thedog, timeout: 100})))
-  end
+  test "run: returns Erlang cookie sources info", context do
+    result = @command.run([], context[:opts])
 
-  test "run: returns defined RabbitMQ-specific environment variables", context do
-    vars = @command.run([], context[:opts])
-
-    # Only variables that are used by RABBITMQ are returned.
-    # They can be prefixed with RABBITMQ_ or not, rabbit_env tries both
-    # when filtering env variables down.
-    assert Enum.any?(vars, fn({k, _v}) ->
-      String.starts_with?(k, "RABBITMQ_") or String.starts_with?(k, "rabbitmq_")
-    end)
+    assert result[:effective_user] != nil
+    assert result[:home_dir] != nil
+    assert result[:cookie_file_path] != nil
+    assert result[:cookie_file_exists] != nil
+    assert result[:cookie_file_access] != nil
   end
 end


### PR DESCRIPTION
to help troubleshoot authentication issues.

I could not quickly locate an Erlang function that would return the expected path in OTP so
we reinvent what [this BIF does](https://github.com/erlang/otp/blob/master/lib/erl_interface/src/connect/ei_connect.c#L2942) in C to cover the Windows-specific special handling of the `HOMEDRIVE` and `HOMEPATH` env variables.

Example output:

```
Cookie File

Effective user: user
Effective home directory: /Users/user
Cookie file path: /Users/user/.erlang.cookie
Cookie file exists? true
Cookie file type: regular
Cookie file access: read
Cookie file size: 20

Cookie CLI Switch

--erlang-cookie value set? false
--erlang-cookie value length: 0

Env variable  (Deprecated)

RABBITMQ_ERLANG_COOKIE value set? false
RABBITMQ_ERLANG_COOKIE value length: 0
```

Inspired by an idea from @gerhard.
