### PR TITLE
Include total amount of memory used into 'rabbitmq-diagnostics status' output

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/status_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/status_command.ex
@@ -7,7 +7,7 @@
 defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
   alias RabbitMQ.CLI.Core.DocGuide
   alias RabbitMQ.CLI.InformationUnit, as: IU
-  import RabbitMQ.CLI.Core.{Alarms, ANSI, Listeners, Memory, Platform}
+  import RabbitMQ.CLI.Core.{Alarms, ANSI, DataCoercion, Listeners, Memory, Platform}
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -127,6 +127,8 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
          end
 
     breakdown = compute_relative_values(m[:memory])
+    memory_calculation_strategy = to_atom(m[:vm_memory_calculation_strategy])
+    total_memory = get_in(m[:memory], [:total, memory_calculation_strategy])
 
     readable_watermark_setting = case m[:vm_memory_high_watermark_setting] do
       %{:relative => val} -> "#{val} of available memory"
@@ -135,8 +137,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.StatusCommand do
     end
     memory_section = [
       "\n#{bright("Memory")}\n",
-      "Calculation strategy: #{m[:vm_memory_calculation_strategy]}",
-      "Memory high watermark setting: #{readable_watermark_setting}, computed to: #{IU.convert(m[:vm_memory_high_watermark_limit], unit)} #{unit}"
+      "Total memory used: #{IU.convert(total_memory, unit)} #{unit}",
+      "Calculation strategy: #{memory_calculation_strategy}",
+      "Memory high watermark setting: #{readable_watermark_setting}, computed to: #{IU.convert(m[:vm_memory_high_watermark_limit], unit)} #{unit}\n"
     ] ++ Enum.map(breakdown, fn({category, val}) -> "#{category}: #{IU.convert(val[:bytes], unit)} #{unit} (#{val[:percentage]} %)" end)
 
     file_descriptors = [


### PR DESCRIPTION
Note that with `--formatter=json`, the command already reports that value.

Spotted by Jon P on rabbitmq-users and @lukebakken.
