### PR TITLE
Update minimum required Elixir version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -11,7 +11,7 @@ defmodule RabbitMQCtl.MixfileBase do
     [
       app: :rabbitmqctl,
       version: "3.8.0-dev",
-      elixir: ">= 1.8.0 and < 1.11.0",
+      elixir: ">= 1.9.0 and < 1.11.0",
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       escript: [main_module: RabbitMQCtl,


### PR DESCRIPTION
See https://github.com/rabbitmq/rabbitmq-ci/pull/33

Part of an effort to use Elixir 1.9 as the minimum.

cc @dumbbell