### PR TITLE
Provide an extra hint in 'rabbitmqctl add_user' output

### DIFF
--- a/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
+++ b/lib/rabbitmq/cli/ctl/commands/add_user_command.ex
@@ -6,6 +6,7 @@
 
 defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
   alias RabbitMQ.CLI.Core.{DocGuide, ExitCodes, Helpers, Input}
+  import RabbitMQ.CLI.Core.Config, only: [output_less?: 1]
 
   @behaviour RabbitMQ.CLI.CommandBehaviour
 
@@ -54,6 +55,22 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
   def output({:error, {:user_already_exists, username}}, _) do
     {:error, ExitCodes.exit_software(), "User \"#{username}\" already exists"}
   end
+  def output(:ok, %{formatter: "json", node: node_name}) do
+    m = %{
+      "status"  => "ok",
+      "node"    => node_name,
+      "message" => "Done. Don't forget to grant the user permissions to some virtual hosts! See 'rabbitmqctl help set_permissions' to learn more."
+    }
+    {:ok, m}
+  end
+  def output(:ok, opts) do
+    case output_less?(opts) do
+      true ->
+        :ok
+      false ->
+        {:ok, "Done. Don't forget to grant the user permissions to some virtual hosts! See 'rabbitmqctl help set_permissions' to learn more."}
+    end
+  end
   use RabbitMQ.CLI.DefaultOutput
 
   def usage, do: "add_user <username> <password>"
@@ -73,7 +90,9 @@ defmodule RabbitMQ.CLI.Ctl.Commands.AddUserCommand do
 
   def help_section(), do: :user_management
 
-  def description(), do: "Creates a new user in the internal database"
+  def description() do
+    "Creates a new user in the internal database. This user will have no permissions for any virtual hosts by default."
+  end
 
   def banner([username | _], _), do: "Adding user \"#{username}\" ..."
 end


### PR DESCRIPTION
to give the user an idea that she would have to
grant permissions to the newly added user.
